### PR TITLE
Add promtail/loki for getting all container logs to grafana

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   execution:

--- a/blox-ssv.yml
+++ b/blox-ssv.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   ssv-node:

--- a/erigon.yml
+++ b/erigon.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   erigon:

--- a/geth.yml
+++ b/geth.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   execution:

--- a/grafana.yml
+++ b/grafana.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   prometheus:
@@ -84,6 +85,35 @@ services:
     expose:
       - 9745/tcp
     <<: *logging
+  promtail:
+    image: grafana/promtail:latest
+    user: root
+    ports:
+      - 9080:9080
+      - 9081:9081
+    volumes:
+      - /etc/machine-id:/etc/machine-id:ro
+      - ./promtail:/etc/promtail
+      - promtail-data:/tmp
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command:
+      - '--config.file=/etc/promtail/promtail.yml'
+    restart: "${RESTART}"
+    depends_on:
+      - loki
+    <<: *logging
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - 3100:3100
+      - 9096:9096
+    volumes:
+      - loki-data:/tmp
+      - ./loki:/etc/loki
+    command:
+      - '--config.file=/etc/loki/loki.yml'
+    restart: "${RESTART}"
+    <<: *logging
   grafana:
     restart: "${RESTART}"
     build:
@@ -98,6 +128,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     depends_on:
       - prometheus
+      - loki
     expose:
       - ${GRAFANA_PORT}/tcp
     entrypoint: ["provision-dashboards.sh"]
@@ -116,3 +147,5 @@ volumes:
   grafana-data:
   grafana-config:
   prom-data:
+  loki-data:
+  promtail-data:

--- a/grafana.yml
+++ b/grafana.yml
@@ -129,6 +129,7 @@ services:
     depends_on:
       - prometheus
       - loki
+      - promtail
     expose:
       - ${GRAFANA_PORT}/tcp
     entrypoint: ["provision-dashboards.sh"]

--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -27,7 +27,4 @@ datasources:
     access: proxy
     orgId: 1
     url: http://loki:3100
-    basicAuth: false
-    isDefault: false
-    version: 1
     editable: true

--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -6,6 +6,9 @@ deleteDatasources:
   - name: Prometheus
     orgId: 1
 
+  - name: Loki
+    orgId: 1
+
 # list of datasources to insert/update depending
 # whats available in the database
 datasources:
@@ -16,5 +19,15 @@ datasources:
     url: http://prometheus:9090
     basicAuth: false
     isDefault: true
+    version: 1
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
     version: 1
     editable: true

--- a/lh-base.yml
+++ b/lh-base.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/lh-consensus.yml
+++ b/lh-consensus.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/lh-validator.yml
+++ b/lh-validator.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   validator:

--- a/lodestar-base.yml
+++ b/lodestar-base.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/lodestar-consensus.yml
+++ b/lodestar-consensus.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/lodestar-validator.yml
+++ b/lodestar-validator.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   validator:

--- a/loki/loki.yml
+++ b/loki/loki.yml
@@ -1,0 +1,28 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+

--- a/loki/loki.yml
+++ b/loki/loki.yml
@@ -25,4 +25,3 @@ schema_config:
       index:
         prefix: index_
         period: 24h
-

--- a/nimbus-base.yml
+++ b/nimbus-base.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/nimbus-consensus.yml
+++ b/nimbus-consensus.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/nm.yml
+++ b/nm.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   execution:

--- a/promtail/promtail.yml
+++ b/promtail/promtail.yml
@@ -47,4 +47,3 @@ scrape_configs:
 
   - output:
       source: output
-

--- a/promtail/promtail.yml
+++ b/promtail/promtail.yml
@@ -1,0 +1,50 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 9081
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: containers
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: containerlogs
+      __path__: /var/lib/docker/containers/*/*log
+
+  pipeline_stages:
+  - json:
+      expressions:
+        output: log
+        stream: stream
+        attrs:
+
+  - json:
+      expressions:
+        tag:
+      source: attrs
+
+  - regex:
+      expression: (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|])).(?P<container_id>(?:[^|]*[^|]))
+      source: tag
+
+  - timestamp:
+      format: RFC3339Nano
+      source: time
+
+  - labels:
+      stream:
+      container_name:
+
+  - labeldrop:
+    - filename
+
+  - output:
+      source: output
+

--- a/prysm-base.yml
+++ b/prysm-base.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 x-build: &prysm-build
   context: ./prysm

--- a/prysm-consensus-rest.yml
+++ b/prysm-consensus-rest.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 x-build: &prysm-build
   context: ./prysm

--- a/prysm-consensus.yml
+++ b/prysm-consensus.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 x-build: &prysm-build
   context: ./prysm

--- a/prysm-validator.yml
+++ b/prysm-validator.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 x-build: &prysm-build
   context: ./prysm

--- a/teku-base.yml
+++ b/teku-base.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/teku-consensus.yml
+++ b/teku-consensus.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   consensus:

--- a/teku-validator.yml
+++ b/teku-validator.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   validator:

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   traefik:

--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -5,6 +5,7 @@ x-logging: &logging
     options:
       max-size: 10m
       max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 services:
   traefik:


### PR DESCRIPTION
After starting all services, one can view logs by tailing the specific containers or compose as from the documentation at 

https://eth-docker.net/docs/Usage/Deposit#:~:text=docker%2Dcompose%20logs%20%2Df%20consensus

This feature allows viewing of logs directly from grafana if enabled. You can choose which container to view logs for and even search and filter using Explore menu in grafana