### PR TITLE
Make Grafana only accessible locally

### DIFF
--- a/grafana-localhost.yml
+++ b/grafana-localhost.yml
@@ -1,0 +1,8 @@
+version: "3.4"
+services:
+  grafana:
+    ports:
+      - 127.0.0.1:${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+#  prometheus:
+#    ports:
+#      - 9090:9090/tcp

--- a/grafana-shared.yml
+++ b/grafana-shared.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   grafana:
     ports:
-      - 127.0.0.1:${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
 #  prometheus:
 #    ports:
 #      - 9090:9090/tcp

--- a/grafana-shared.yml
+++ b/grafana-shared.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   grafana:
     ports:
-      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+      - 127.0.0.1:${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
 #  prometheus:
 #    ports:
 #      - 9090:9090/tcp


### PR DESCRIPTION
Hi, I saw that in the docs, you describe a way to use the firewall to make the Grafana port (3000) be only accessible on the 127.0.0.1 interface and not on the 0.0.0.0 interface. But I think this could be easier achieved with this change I'm proposing here. I tried it out on my staking setup and it seems to work exactly as intended: Grafana is available on 127.0.0.1:3000 but not externally, which means you must use SSH tunneling to access it.

I got the idea from here: https://earthly.dev/blog/youre-using-docker-compose-wrong/#problem-2-youre-binding-ports-on-the-hosts-0.0.0.0