### PR TITLE
Remove -x flag for Besu bonsai storage to accomodate the breaking change in version 22.1.3

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -65,7 +65,7 @@ services:
       - --metrics-enabled
       - --metrics-host
       - 0.0.0.0
-      - --Xdata-storage-format=BONSAI
+      - --data-storage-format=BONSAI
   eth:
     depends_on:
       - execution


### PR DESCRIPTION
The developers have removed the -x flag for Bonsai storage as of Besu version 22.1.3.

See [https://github.com/hyperledger/besu/pull/3578](https://github.com/hyperledger/besu/pull/3578) for more details.