### PR TITLE
Fixed broken interpolation

### DIFF
--- a/lh-base.yml
+++ b/lh-base.yml
@@ -23,7 +23,7 @@ services:
       - lhbeacon-data:/var/lib/lighthouse
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
     ports:
       - ${CC_P2P_PORT:-9000}:${CC_P2P_PORT:-9000}/tcp
       - ${CC_P2P_PORT:-9000}:${CC_P2P_PORT:-9000}/udp

--- a/lodestar-base.yml
+++ b/lodestar-base.yml
@@ -23,7 +23,7 @@ services:
       - lsconsensus-data:/var/lib/lodestar/consensus
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
     ports:
       - ${CC_P2P_PORT:-9000}:${CC_P2P_PORT:-9000}/tcp
       - ${CC_P2P_PORT:-9000}:${CC_P2P_PORT:-9000}/udp

--- a/nimbus-base.yml
+++ b/nimbus-base.yml
@@ -23,7 +23,7 @@ services:
       - nimbus-data:/var/lib/nimbus
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
       - NETWORK=${NETWORK}
     expose:
       - 8008/tcp

--- a/prysm-base.yml
+++ b/prysm-base.yml
@@ -27,7 +27,7 @@ services:
       - prysmbeacon-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
     ports:
       - ${PRYSM_PORT}:${PRYSM_PORT}/tcp
       - ${PRYSM_UDP_PORT}:${PRYSM_UDP_PORT}/udp

--- a/teku-base.yml
+++ b/teku-base.yml
@@ -24,7 +24,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     environment:
       - JAVA_OPTS=-XX:SoftMaxHeapSize=2g -Xmx4g
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
     expose:
       - 8008/tcp
     ports:


### PR DESCRIPTION
Was getting the following error when trying to update.

`ERROR: Invalid interpolation format for "environment" option in service "consensus": "RAPID_SYNC_URL=${RAPID_SYNC_URL:-}"`