### PR TITLE
Add to startup instructions

### DIFF
--- a/MERGE-READY.md
+++ b/MERGE-READY.md
@@ -28,16 +28,18 @@
   - `./ethd config`
 - Generate the keystore files. This mnemonic should be considered compromised, as it is not generated on an air-gapped
 machine.
-  - `docker-compose run --rm deposit-cli-new --eth1_withdrawal_address YOURTESTADDRESS`
+  - `sudo docker-compose build --pull`
+  - `sudo docker-compose run --rm deposit-cli-new --eth1_withdrawal_address YOURTESTADDRESS`
 - Deposit for this key at the launchpad for your testnet. The `deposit_data` JSON file will be in `.eth/validator_keys`,
  which is "hidden" directory if you use a graphical file explorer.
 - Import the keys: `./ethd keyimport`
+- Edit `.env` and set `FEE_RECIPIENT` to your staking address
 - Start the stack:
-  - `./ethd up`
+  - `sudo ./ethd up`
 - Look at logs and see consensus and execution client synchronizing, and the validator client validating:
-  - `./ethd logs -f consensus`
-  - `./ethd logs -f execution`
-  - `./ethd logs -f validator` - for those clients that have a separate validator client, like Lighthouse and Prysm
+  - `sudo ./ethd logs -f consensus`
+  - `sudo ./ethd logs -f execution`
+  - `sudo ./ethd logs -f validator` - for those clients that have a separate validator client, like Lighthouse and Prysm
 - Observe your validator at the beaconcha.in site for this testnet, by entering its public key or the ETH address you funded it from
 - If you want to try a different combo, first `./ethd terminate` so the chain data gets deleted, then just `./ethd config`, choose your clients,
   **wait 15 minutes**, `./ethd keyimport` and `./ethd up`. The 15 minute wait is there to avoid slashing.


### PR DESCRIPTION
You may drop this pull request. I'm just providing it as feedback.

[This page](https://notes.ethereum.org/@launchpad/ropsten) recommended beginners to follow `MERGE-READY.md`, so that's what I tried to do. I did not know the [docs](https://eth-docker.net/docs/Usage/ClientSetup/#build-the-client) existed. Now I'm not sure if I should have started at the docs, or started at `MERGE-READY.md`.

1. If I remember correctly, `ethd config` insisted I run it as a non-root user. But I guess it failed to complete `docker-compose build` because: my user didn't have sudo or docker access (and I'm not sure the script tries to sudo there anyway?). Perhaps the best solution there would be a more meaningful error message, and exit the script, if the build fails.

2. I added a lot of `sudo` to the docs, because basically all docker commands need to be run as sudo. (I think using sudo is preferable to giving the user docker access, right?)

3. I think this might be the most useful contribution from me:

   ```diff
   + - Edit `.env` and set `FEE_RECIPIENT` to your staking address
   ```

   Before I did that, the consensus logs were giving me an error something like "Byte20 has size 0", which didn't really explain what was wrong. I just guessed it was the `FEE_RECIPIENT`.

   But perhaps there are other things I should be configuring as well...

My current situation is "Max retries reached, cancel pivot block download." But also, I never got to select which clients and which network I wanted to use.

So I think I will stop trying `MERGE-READY.md` for now, and start over using the docs this time.