### PR TITLE
Check for whiptail, and working docker, before starting

### DIFF
--- a/ethd
+++ b/ethd
@@ -1183,6 +1183,11 @@ if [ "${OWNER}" == "root" ]; then
     exit 1
 fi
 
+if ! type -P whiptail >/dev/null 2>&1; then
+    echo "Please install the package whiptail or newt before running this script"
+    exit 1
+fi
+
 ENV_FILE=.env
 
 command="$1"
@@ -1191,5 +1196,10 @@ shift
 determine_distro
 determine_compose
 handle_root
+
+if ! docker images >/dev/null 2>&1; then
+    echo "Please ensure your user can call docker before running this script"
+    exit 1
+fi
 
 "$command" $@

--- a/ethd
+++ b/ethd
@@ -1197,8 +1197,13 @@ determine_distro
 determine_compose
 handle_root
 
-if ! docker images >/dev/null 2>&1; then
-    echo "Please ensure your user can call docker before running this script"
+if ! docker images >/dev/null 2>&1 && ! sudo docker images >/dev/null 2>&1; then
+    echo "Please ensure your user can access docker before running this script"
+    exit 1
+fi
+
+if ! cmd --help >/dev/null 2>&1; then
+    echo "Please ensure your user can call $__compose_exe before running this script"
     exit 1
 fi
 


### PR DESCRIPTION
Current behaviour:

- When `whiptail` is not present, `ethd config` exits with "You selected Cancel"

I think it should exit with a clear error message instead.

First I tried adding `set -e` but that just caused the script to exit with no output at all! Which doesn't really help the user.

So instead, I added a little check for `whiptail` when the script starts up.

(On CentOS 7.9, there is no `whiptail` package, but it can be found in the `newt` package.)

I also added a check that the user can call docker.

I can refactor to use `$?` if you need it. I just use `if` directly.