### PR TITLE
Automatically use sudo if needed

### DIFF
--- a/ethd
+++ b/ethd
@@ -37,6 +37,11 @@ determine_compose() {
   else
     __compose_exe="docker-compose"
   fi
+
+  # If this user cannot access docker directly, then use sudo
+  if ! docker images >/dev/null 2>&1; then
+    __compose_exe="sudo $__compose_exe"
+  fi
 }
 
 handle_root() {


### PR DESCRIPTION
If I'm not mistaken, this would be needed if the user does not have access to call docker.

(And I think using sudo is probably preferable to giving the user access to docker, because as the docs say, this gives root access without a password.)