### PR TITLE
Use v2 GetState API for Teku checkpoint sync

### DIFF
--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Check whether we should rapid sync
 if [ -n "${RAPID_SYNC_URL:+x}" ]; then
-    __rapid_sync="--initial-state=${RAPID_SYNC_URL}/eth/v1/debug/beacon/states/finalized"
+    __rapid_sync="--initial-state=${RAPID_SYNC_URL}/eth/v2/debug/beacon/states/finalized"
 else
     __rapid_sync=""
 fi


### PR DESCRIPTION
v1 phase0 endpoint is deprecated and v2 should be used post Altair.

When I started Teku, the following URL returns 404
https://goerli.checkpoint-sync.ethdevops.io/eth/v1/debug/beacon/states/finalized

Changing to v2 fixed this.