### PR TITLE
Add docker-compose version check

### DIFF
--- a/ethd
+++ b/ethd
@@ -35,6 +35,13 @@ determine_compose() {
   if [ $? -ne 0 ]; then
     __compose_exe="docker compose"
   else
+    __compose_version=$(docker-compose --version | grep -oP "version \K[\w.-]+")
+    __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
+    __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
+    if [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then
+      echo "Error: Outdated docker-compose version detected ($__compose_version). Please upgrade to version 1.28.0 or later." >&2
+      exit 1
+    fi
     __compose_exe="docker-compose"
   fi
 


### PR DESCRIPTION
Updating my Goerli node, I found that things stopped working, and I got unexpected errors about unsupported configuration items in `prysm-base.yml`.

I did some investigation and it appears that the `profiles` option which was introduced in 0e2447abd5031975a2e20c43b919f2aba4c36ce5 means that at least `docker-compose` version 1.28.0 is needed and mine was too old - Ubuntu version from default apt is 1.25.0.

This PR adds a simple version check to `determine_compose()`, similar to the Ubuntu version test.