### PR TITLE
Fix numeric range for docker-compose version check

### DIFF
--- a/ethd
+++ b/ethd
@@ -35,7 +35,7 @@ determine_compose() {
   if [ $? -ne 0 ]; then
     __compose_exe="docker compose"
   else
-    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([1-9.-]*\).*/\1/p")
+    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
     __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
     __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
     if [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then
@@ -70,7 +70,7 @@ determine_compose() {
 upgrade_compose() {
   type -P docker-compose >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([1-9.-]*\).*/\1/p")
+    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
     __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
     __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
     if [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then


### PR DESCRIPTION
Docker-compose versions can include 0, so we need to make sure they're included in case a `1.30` is released.

```shell
aliask@ubuntu:~/eth-docker$ cat test.sh
#!/bin/bash
__compose_version=$(echo "docker-compose version 1.30.0" | sed -n -e "s/.*version \([1-9.-]*\).*/\1/p")
__compose_version_major=$(echo $__compose_version | cut -f1 -d.)
__compose_version_minor=$(echo $__compose_version | cut -f2 -d.)

echo "$__compose_version_major.$__compose_version_minor"
aliask@ubuntu:~/eth-docker$ ./test.sh
1.3
```