### PR TITLE
[WIP] Sudo improvements

### DIFF
--- a/ethd
+++ b/ethd
@@ -1399,12 +1399,12 @@ if ! type -P whiptail >/dev/null 2>&1; then
 fi
 
 if ! dodocker images >/dev/null 2>&1; then
-    echo "Please ensure you can access $__maybe_sudo docker before running this script."
+    echo "Please ensure you can call ${__maybe_sudo:+$__maybe_sudo }docker before running this script."
     exit 1
 fi
 
 if ! cmd --help >/dev/null 2>&1; then
-    echo "Please ensure you can call $__maybe_sudo $__compose_exe before running this script"
+    echo "Please ensure you can call ${__maybe_sudo:+$__maybe_sudo }$__compose_exe before running this script"
     exit 1
 fi
 

--- a/ethd
+++ b/ethd
@@ -5,7 +5,11 @@ set -uo pipefail
 __compose_exe="docker-compose"
 
 cmd() {
-    $__compose_exe "$@"
+    $__maybe_sudo $__compose_exe "$@"
+}
+
+dodocker() {
+    $__maybe_sudo docker "$@"
 }
 
 determine_distro() {
@@ -29,18 +33,26 @@ determine_distro() {
     __distro=$(echo $__distro | tr "[:upper:]" "[:lower:]")
 }
 
+determine_sudo() {
+    __maybe_sudo=""
+    if ! docker images >/dev/null 2>&1; then
+        echo "Will use sudo to access docker"
+        __maybe_sudo="sudo"
+    fi
+}
+
 determine_compose() {
 # This is mainly for Debian and docker-ce, where docker-compose does not exist
   type -P docker-compose >/dev/null 2>&1
   if [ $? -ne 0 ]; then
     __compose_exe="docker compose"
   else
-    __compose_version=$(docker-compose --version | sed -n -e "s/.*version [v]\?\([0-9.-]*\).*/\1/p")
+    __compose_version=$($__maybe_sudo docker-compose --version | sed -n -e "s/.*version [v]\?\([0-9.-]*\).*/\1/p")
     __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
     __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
     if ! [ "$__compose_version_major" -eq "$__compose_version_major" -a "$__compose_version_minor" -eq "$__compose_version_minor" ] 2> /dev/null; then
         echo "docker-compose version detection failed. Please report this output so it can be fixed."
-        docker-compose --version
+        $__maybe_sudo docker-compose --version
     elif [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then
       echo "Error: Outdated docker-compose version detected ($__compose_version). Please upgrade to version 1.28.0 or later." >&2
       if [[ "$__distro" = "ubuntu" ]]; then
@@ -63,17 +75,12 @@ determine_compose() {
     fi
     __compose_exe="docker-compose"
   fi
-
-  # If this user cannot access docker directly, then use sudo
-  if ! docker images >/dev/null 2>&1; then
-    __compose_exe="sudo $__compose_exe"
-  fi
 }
 
 upgrade_compose() {
   type -P docker-compose >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
+    __compose_version=$($__maybe_sudo docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
     __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
     __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
     if [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then
@@ -82,7 +89,7 @@ upgrade_compose() {
       ${__auto_sudo} curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/bin/docker-compose
       ${__auto_sudo} chmod +x /usr/bin/docker-compose
     fi
-    __compose_version=$(docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
+    __compose_version=$($__maybe_sudo docker-compose --version | sed -n -e "s/.*version \([0-9.-]*\).*/\1/p")
     __compose_version_major=$(echo $__compose_version | cut -f1 -d.)
     __compose_version_minor=$(echo $__compose_version | cut -f2 -d.)
     if [ "$__compose_version_major" -eq 1 -a "$__compose_version_minor" -lt 28 ]; then
@@ -517,7 +524,7 @@ delete_erigon() {
         return
     fi
 
-    if [ -z "$(docker volume ls -q | grep $(basename $(realpath .))_erigon-ec-data)" ]; then
+    if [ -z "$(dodocker volume ls -q | grep $(basename $(realpath .))_erigon-ec-data)" ]; then
         return
     fi
 
@@ -532,9 +539,9 @@ delete_erigon() {
     done
 
     echo "Stopping Erigon container"
-    docker stop $(basename $(realpath .))_erigon_1 && docker rm -f $(basename $(realpath .))_erigon_1
+    dodocker stop $(basename $(realpath .))_erigon_1 && dodocker rm -f $(basename $(realpath .))_erigon_1
     cmd stop execution && cmd rm -f execution
-    docker volume rm $(docker volume ls -q | grep $(basename $(realpath .))_erigon-ec-data)
+    dodocker volume rm $(dodocker volume ls -q | grep $(basename $(realpath .))_erigon-ec-data)
     echo ""
     echo "Erigon stopped and database deleted."
     echo ""
@@ -769,7 +776,7 @@ terminate() {
     done
 
     down
-    docker volume rm $(docker volume ls -q | grep $(basename $(realpath .)))
+    dodocker volume rm $(dodocker volume ls -q | grep $(basename $(realpath .)))
     echo ""
     echo "All containers stopped and all volumes deleted"
     echo ""
@@ -1378,6 +1385,7 @@ command="$1"
 shift
 
 determine_distro
+determine_sudo
 handle_root
 determine_compose
 
@@ -1390,13 +1398,13 @@ if ! type -P whiptail >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! docker images >/dev/null 2>&1 && ! sudo docker images >/dev/null 2>&1; then
-    echo "Please ensure your user can access docker before running this script"
+if ! dodocker images >/dev/null 2>&1; then
+    echo "Please ensure you can access $__maybe_sudo docker before running this script."
     exit 1
 fi
 
 if ! cmd --help >/dev/null 2>&1; then
-    echo "Please ensure your user can call $__compose_exe before running this script"
+    echo "Please ensure you can call $__maybe_sudo $__compose_exe before running this script"
     exit 1
 fi
 

--- a/ethd
+++ b/ethd
@@ -2,14 +2,15 @@
 #set -euo pipefail
 set -uo pipefail
 
+__docker_exe="docker"
 __compose_exe="docker-compose"
 
-cmd() {
-    $__maybe_sudo $__compose_exe "$@"
+dodocker() {
+    $__docker_exe "$@"
 }
 
-dodocker() {
-    $__maybe_sudo docker "$@"
+cmd() {
+    $__compose_exe "$@"
 }
 
 determine_distro() {
@@ -38,6 +39,12 @@ determine_sudo() {
     if ! docker images >/dev/null 2>&1; then
         echo "Will use sudo to access docker"
         __maybe_sudo="sudo"
+    fi
+}
+
+determine_docker() {
+    if [ -n "$__maybe_sudo" ]; then
+        __docker_exe="sudo $__docker_exe"
     fi
 }
 
@@ -74,6 +81,10 @@ determine_compose() {
       fi
     fi
     __compose_exe="docker-compose"
+  fi
+
+  if [ -n "$__maybe_sudo" ]; then
+    __compose_exe="sudo $__compose_exe"
   fi
 }
 
@@ -1387,6 +1398,7 @@ shift
 determine_distro
 determine_sudo
 handle_root
+determine_docker
 determine_compose
 
 if [ $command = "install" ]; then
@@ -1399,12 +1411,12 @@ if ! type -P whiptail >/dev/null 2>&1; then
 fi
 
 if ! dodocker images >/dev/null 2>&1; then
-    echo "Please ensure you can call ${__maybe_sudo:+$__maybe_sudo }docker before running this script."
+    echo "Please ensure you can call $__docker_exe before running this script."
     exit 1
 fi
 
 if ! cmd --help >/dev/null 2>&1; then
-    echo "Please ensure you can call ${__maybe_sudo:+$__maybe_sudo }$__compose_exe before running this script"
+    echo "Please ensure you can call $__compose_exe before running this script"
     exit 1
 fi
 


### PR DESCRIPTION
WIP because I will test this either this week or next. I am posting it now, for feedback and review.

This cleans up some leftover issues with #760:

- PR 760 handled the calls to `docker-compose` but _not_ the calls to `docker`

----

We now have these two functions:

```bash
cmd() {
    $__maybe_sudo $__compose_exe "$@"
}

dodocker() {
    $__maybe_sudo docker "$@"
}
```

Thoughts:

1. We should probably name these functions consistently.

   One option is `docompose()` and `dodocker()` but you may have another preference.

2. The functions were _supposed_ to encapsulate the use of `$__maybe_sudo`

   But in fact there are some places in the script where we still need to use `$__maybe_sudo $__compose_exe` and `$__maybe_sudo docker` which looks a bit ugly.

   I could make those a bit cleaner, if I put the `sudo` back inside `$__compose_exe` and inside `$__docker_exe` variables.

   I think I will try that arrangement later. We can always rollback if it doesn't feel better.

   **Update:** I did that. It does look a bit cleaner now. But there arestill places where we need to write `$__maybe_sudo docker-compose` (before we have determined `$__compose_exe`).