### PR TITLE
Teku Mobile Monitoring

### DIFF
--- a/default.env
+++ b/default.env
@@ -54,7 +54,7 @@ EL_MAX_PEER_COUNT=
 EL_MIN_PEER_COUNT=
 
 # Beaconcha.in API key for sending client stats. Automatic for Lighthouse and Teku, or with prysm-stats.yml,
-# source build only for Prysm as of Sept 2021.
+# source build only for Prysm as of Sept 2021. Flags for mobile app client monitoring added in teku-base.yml
 # Specify as just the API key as found at https://beaconcha.in/user/settings#api, and give the machine name separately
 BEACON_STATS_API=
 BEACON_STATS_MACHINE=

--- a/teku-base.yml
+++ b/teku-base.yml
@@ -61,6 +61,7 @@ services:
       - --metrics-port=8008
       - --metrics-interface=0.0.0.0
       - --metrics-host-allowlist=*
+      - --metrics-publish-endpoint=https://beaconcha.in/api/v1/client/metrics?apikey=${BEACON_STATS_API}&machine=${BEACON_STATS_MACHINE}
       - --validator-api-enabled=true
       - --validator-api-interface=0.0.0.0
       - --validator-api-port=${KEY_API_PORT:-7500}


### PR DESCRIPTION
Flags for mobile app client monitoring (https://beaconcha.in/user/settings#app) added in `teku-base.yml`.
Teku users can use the existing `BEACON_STATS_API` and `BEACON_STATS_MACHINE` vars to get metrics published.