### PR TITLE
Make mainnet the default choice

### DIFF
--- a/ethd
+++ b/ethd
@@ -841,10 +841,10 @@ query_network() {
     # Mainnet or Testnet network
     NETWORK=$(whiptail --notags --title "Select Network" --menu \
     "Which network do you want to run on?" 12 60 5 \
+    "mainnet" "Ethereum Mainnet" \
     "goerli" "Görli (né Prater) Testnet" \
     "ropsten" "Ropsten Testnet (abandoned after mainnet merge)" \
     "sepolia" "Sepolia Testnet (permissioned validators)" \
-    "mainnet" "Ethereum Mainnet" \
     "gnosis" "Gnosis Chain (né xDai)" 3>&1 1>&2 2>&3)
 
     case "${NETWORK}" in


### PR DESCRIPTION
Edited on mobile. I haven't tested this. I'm on vacation.

I guess a few people may start using this project when they see the merge is coming. So it's good to have the wizard offer the most common choice as default.

Do the other questions also default to the most common use-case?

Please feel free to modify this PR, or reproduce it.