### PR TITLE
use execution as host in prometheus config

### DIFF
--- a/prometheus/erigon-prom.yml
+++ b/prometheus/erigon-prom.yml
@@ -3,4 +3,4 @@
     scheme: http
     static_configs:
     - targets:
-      - erigon:6060
+      - execution:6060


### PR DESCRIPTION
The dashboard for erigon didn't fill out any values because it was trying to connect to the wrong hostname