### PR TITLE
Add command "./ethd version"

### DIFF
--- a/ethd
+++ b/ethd
@@ -1397,6 +1397,33 @@ config () {
     exec 2>&4
 }
 
+version() {
+    # ethd version
+    grep "^This is" README.md
+    echo ""
+    var="COMPOSE_FILE"
+    value=$(sed -n -e "s/^${var}=\(.*\)/\1/p" ".env" || true)
+    # EL version
+    if [[ "${value}" =~ "geth.yml" ]]; then
+        cmd exec execution geth version
+    else
+        echo "Command version is unsupported for your EL client"
+    fi
+    echo ""
+    # CL version
+    if [[ "${value}" =~ "lighthouse.yml" ]]; then
+        cmd exec consensus lighthouse --version
+    else
+        echo "Command version is unsupported for your CL client"
+    fi
+    echo ""
+    # others
+    if [[ "${value}" =~ "mev-boost.yml" ]]; then
+        cmd exec mev-boost /app/mev-boost -version
+    fi
+    echo ""
+}
+
 printhelp() {
     me=$(basename "${BASH_SOURCE}")
     echo "usage: ${me} [help|-h|--help] <subcommand>"


### PR DESCRIPTION
Hello! I've been using this command for a while now to easily retrieve the version I'm running for my EL and CL clients.

At the moment it only works with the clients I use. First I would like to know if you would accept this contribution and if so I can figure out the rest of cli arguments to make it work with all clients supported by eth-docker actually.

Example output:

```
~/src/eth-docker$ ./ethd version
This is eth-docker v2.0.2

Geth
Version: 1.10.25-stable
Git Commit: 69568c554880b3567bace64f8848ff1be27d084d
Architecture: amd64
Go Version: go1.18.6
Operating System: linux
GOPATH=
GOROOT=go

Lighthouse v3.1.0-aa022f4
BLS library: blst-modern
SHA256 hardware acceleration: true
Specs: mainnet (true), minimal (false), gnosis (true)

mev-boost v1.3.1
```