### PR TITLE
fix for issue 1086: building nethermind from source fails when checking out submodules

### DIFF
--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -8,7 +8,13 @@ ARG BUILD_TARGET
 WORKDIR /
 
 RUN apt-get update -y && apt-get install -y git
-RUN bash -c "git clone https://github.com/NethermindEth/nethermind && cd nethermind && git config advice.detachedHead false && git fetch --all --tags && git checkout ${BUILD_TARGET} && git submodule update --init src/Dirichlet src/int256 src/rocksdb-sharp src/Math.Gmp.Native && \
+RUN bash -c "\
+    git clone https://github.com/NethermindEth/nethermind && \
+    cd nethermind && \
+    git config advice.detachedHead false && \
+    git fetch --all --tags && \
+    git checkout ${BUILD_TARGET} && \
+    git submodule update --init --recursive && \
     dotnet publish src/Nethermind/Nethermind.Runner -c release -o out"
 
 FROM ghcr.io/tomwright/dasel:latest as dasel


### PR DESCRIPTION
Using --recursive instead of individual submodules to checkout nethermind source.
Put bash -c arguments on multiple lines for readability.