### PR TITLE
Enable Teku validator lockfiles

### DIFF
--- a/teku.yml
+++ b/teku.yml
@@ -73,7 +73,7 @@ services:
       - --validator-api-keystore-file=/var/lib/teku/teku-keyapi.keystore
       - --validator-api-keystore-password-file=/var/lib/teku/teku-keyapi.password
       - --validators-proposer-default-fee-recipient=${FEE_RECIPIENT}
-      - --validators-keystore-locking-enabled=false
+      - --validators-keystore-locking-enabled=true
 
   validator-import:
     profiles: ["tools"]


### PR DESCRIPTION
Teku has a safety feature to lock validator keys when used. This has been disabled but it's enabled by default. 
Unless there is a requirement we should enable it to prevent slashes 