### PR TITLE
Nethermind not reporting metrics

### DIFF
--- a/nethermind.yml
+++ b/nethermind.yml
@@ -73,8 +73,6 @@ services:
       - "true"
       - --Metrics.ExposePort
       - "6060"
-      - --Metrics.IntervalSeconds
-      - "999999"
       - --config
       - ${NETWORK}
       - --Sync.AncientBodiesBarrier


### PR DESCRIPTION
The delay has been set really long making nethermind not send any metrics. 
If this is not a requirement I suggest leaving the default