### PR TITLE
Correctly detect docker root dir on rootless docker or -g

### DIFF
--- a/auto-prune.sh
+++ b/auto-prune.sh
@@ -10,18 +10,7 @@ fi
 cd "$(dirname "$0")" || exit 1
 
 
-__docker_dir="/var/lib/docker"
-if [ -f "/etc/docker/daemon.json" ]; then
-  if [ "$(dpkg-query -W -f='${Status}' jq 2>/dev/null | grep -c "ok installed")" = "0" ]; then
-    echo "This script requires the jq package to parse /etc/docker/daemon.json, please install it via 'sudo apt install jq'"
-    exit 1
-  fi
-  __dir=$(jq --raw-output '."data-root"' /etc/docker/daemon.json)
-  if [ ! "$__dir" = "null" ]; then
-    __docker_dir="$__dir"
-  fi
-fi
-
+__docker_dir=$(docker system info --format '{{json .DockerRootDir}}' | tr -d '"')
 __dryrun=0
 __threshold_override=0
 for (( i=1; i<=$#; i++ )); do

--- a/ethd
+++ b/ethd
@@ -166,7 +166,7 @@ install() {
             echo "This script cannot install docker on Ubuntu ${__major_version}. Consider upgrading to 22.04 or 20.04"
         fi
         if [ -z "$(command -v docker)" ]; then
-            ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install -y ca-certificates curl gnupg lsb-release whiptail bc
+            ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install -y ca-certificates curl gnupg lsb-release whiptail bc chrony
             ${__auto_sudo} mkdir -p /etc/apt/keyrings
             ${__auto_sudo} curl -fsSL https://download.docker.com/linux/ubuntu/gpg | ${__auto_sudo} gpg --dearmor -o /etc/apt/keyrings/docker.gpg
             ${__auto_sudo} echo \
@@ -189,7 +189,7 @@ install() {
     elif [[ "$__distro" =~ "debian" ]]; then
         if [ -z "$(command -v docker)" ]; then
             ${__auto_sudo} apt-get update
-            ${__auto_sudo} apt-get -y install ca-certificates curl gnupg lsb-release whiptail bc jq
+            ${__auto_sudo} apt-get -y install ca-certificates curl gnupg lsb-release whiptail bc chrony
             ${__auto_sudo} mkdir -p /etc/apt/keyrings
             ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg | ${__auto_sudo} gpg --dearmor -o /etc/apt/keyrings/docker.gpg
             ${__auto_sudo} echo \
@@ -675,17 +675,7 @@ prune-geth() {
         exit 1
     fi
 
-    __docker_dir="/var/lib/docker"
-    if [ -f "/etc/docker/daemon.json" ]; then
-        if [ "$(dpkg-query -W -f='${Status}' jq 2>/dev/null | grep -c "ok installed")" = "0" ]; then
-            echo "This script requires the jq package to parse /etc/docker/daemon.json, please install it via 'sudo apt install jq'"
-            exit 1
-        fi
-        __dir=$(jq --raw-output '."data-root"' /etc/docker/daemon.json)
-        if [ ! "$__dir" = "null" ]; then
-            __docker_dir="$__dir"
-        fi
-    fi
+    __docker_dir=$(docker system info --format '{{json .DockerRootDir}}' | tr -d '"')
 
     if [ "$(df -P ${__docker_dir} | awk '/[0-9]%/{print $(NF-2)}')" -lt 41943040 ]; then
         echo "You do not have enough free disk space. Make sure this reads at least 40G free (Avail):"
@@ -792,17 +782,8 @@ prune-nethermind() {
         exit 1
     fi
 
-    __docker_dir="/var/lib/docker"
-    if [ -f "/etc/docker/daemon.json" ]; then
-        if [ "$(dpkg-query -W -f='${Status}' jq 2>/dev/null | grep -c "ok installed")" = "0" ]; then
-            echo "This script requires the jq package to parse /etc/docker/daemon.json, please install it via 'sudo apt install jq'"
-            exit 1
-        fi
-        __dir=$(jq --raw-output '."data-root"' /etc/docker/daemon.json)
-        if [ ! "$__dir" = "null" ]; then
-            __docker_dir="$__dir"
-        fi
-    fi
+
+    __docker_dir=$(docker system info --format '{{json .DockerRootDir}}' | tr -d '"')
 
     if [ "$(df -P ${__docker_dir} | awk '/[0-9]%/{print $(NF-2)}')" -lt 262144000 ]; then
         echo "You do not have enough free disk space. Make sure this reads at least 250G free (Avail):"


### PR DESCRIPTION
There's probably a clever go template way of doing this without `tr -d '"'` but I haven't managed to figure that out.

@mLewisLogic this impacts you, different way of detecting docker dir
