### PR TITLE
Add example value for MEV minimum bid

### DIFF
--- a/default.env
+++ b/default.env
@@ -8,7 +8,7 @@ FEE_RECIPIENT=
 MEV_BOOST=false
 # For relay information, please see https://ethstaker.cc/mev-relay-list/
 MEV_RELAYS=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli.flashbots.net,https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.max-profit.builder.goerli.blxrbdn.com,https://0x8f7b17a74569b7a57e9bdafd2e159380759f5dc3ccbd4bf600414147e8c4e1dc6ebada83c0139ac15850eb6c975e82d0@builder-relay-goerli.blocknative.com,https://0xaa1488eae4b06a1fff840a2b6db167afc520758dc2c8af0dfb57037954df3431b747e2f900fe8805f05d635e9a29717b@relay-goerli.edennetwork.io,https://0x8a72a5ec3e2909fff931c8b42c9e0e6c6e660ac48a98016777fc63a73316b3ffb5c622495106277f8dbcc17a06e92ca3@goerli-relay.securerpc.com/
-# Set a minimum MEV bid, used by mev-boost.yml. If empty, no minimum is used.
+# Set a minimum MEV bid (e.g. 0.05), used by mev-boost.yml. If empty, no minimum is used.
 MEV_MIN_BID=
 # Graffiti to use for validator
 GRAFFITI=🐼eth-docker🐼


### PR DESCRIPTION
The example value makes it easier to understand what format is expected. Without the example it is not obvious if this should be set in ETH or GWei without looking up the MEV boost documentation.

We should also advocate for setting this to 0.05 ETH to improve censorship resistance of the network as recommended by Vitalik
in this [Tweet](https://twitter.com/VitalikButerin/status/1595793106926014466).