### PR TITLE
Update beacon node job name in lodestar prometheus configs

### DIFF
--- a/prometheus/ls-prom.yml
+++ b/prometheus/ls-prom.yml
@@ -1,4 +1,4 @@
-  - job_name: 'nodes'
+  - job_name: 'beacon'
     static_configs:
       - targets: ['consensus:8008']
   - job_name: 'validator'

--- a/prometheus/lscc-prom.yml
+++ b/prometheus/lscc-prom.yml
@@ -1,3 +1,3 @@
-  - job_name: 'nodes'
+  - job_name: 'beacon'
     static_configs:
       - targets: ['consensus:8008']


### PR DESCRIPTION
The lodestar dashboard uses the `job` label to differentiate between beacon and validator metrics. The job name for the beacon node needs to be set to `beacon` and for the validator job it needs to be `validator`.

See [#4952](https://github.com/ChainSafe/lodestar/pull/4952) for related PR in Lodestar repository.