### PR TITLE
Add option to omit graffiti to use validator default

### DIFF
--- a/default.env
+++ b/default.env
@@ -10,7 +10,7 @@ MEV_BOOST=false
 MEV_RELAYS=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli.flashbots.net,https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.max-profit.builder.goerli.blxrbdn.com,https://0x8f7b17a74569b7a57e9bdafd2e159380759f5dc3ccbd4bf600414147e8c4e1dc6ebada83c0139ac15850eb6c975e82d0@builder-relay-goerli.blocknative.com,https://0xaa1488eae4b06a1fff840a2b6db167afc520758dc2c8af0dfb57037954df3431b747e2f900fe8805f05d635e9a29717b@relay-goerli.edennetwork.io,https://0x8a72a5ec3e2909fff931c8b42c9e0e6c6e660ac48a98016777fc63a73316b3ffb5c622495106277f8dbcc17a06e92ca3@goerli-relay.securerpc.com/
 # Set a minimum MEV bid (e.g. 0.05), used by mev-boost.yml. If empty, no minimum is used.
 MEV_MIN_BID=
-# Graffiti to use for validator
+# Graffiti to use for validator, comment out line below to use default validator graffiti
 GRAFFITI=🐼eth-docker🐼
 # Merged network to use. If using main net, set to mainnet.
 NETWORK=goerli

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -36,8 +36,6 @@ services:
       - /var/lib/lighthouse
       - --beacon-nodes
       - ${CL_NODE:-http://consensus:5052}
-      - --graffiti
-      - ${GRAFFITI}
       - --network
       - ${NETWORK}
       - --debug-level=${LOG_LEVEL}

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -95,8 +95,6 @@ services:
       - /var/lib/lighthouse
       - --beacon-nodes
       - ${CL_NODE:-http://consensus:5052}
-      - --graffiti
-      - ${GRAFFITI}
       - --network
       - ${NETWORK}
       - --debug-level=${LOG_LEVEL}

--- a/lighthouse/docker-entrypoint-vc.sh
+++ b/lighthouse/docker-entrypoint-vc.sh
@@ -6,6 +6,14 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu lhvalidator docker-entrypoint.sh "$@"
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--graffiti ${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--builder-proposals"
@@ -31,4 +39,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${__beacon_stats} ${__doppel} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${__beacon_stats} ${__doppel} ${VC_EXTRAS}

--- a/lodestar-vc-only.yml
+++ b/lodestar-vc-only.yml
@@ -41,8 +41,6 @@ services:
       - "8009"
       - --metrics.address
       - 0.0.0.0
-      - --graffiti
-      - ${GRAFFITI}
       - --logLevel
       - ${LOG_LEVEL}
       - --network

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -102,8 +102,6 @@ services:
       - "8009"
       - --metrics.address
       - 0.0.0.0
-      - --graffiti
-      - ${GRAFFITI}
       - --logLevel
       - ${LOG_LEVEL}
       - --network

--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -6,6 +6,14 @@ if [ "$(id -u)" = '0' ]; then
   exec su-exec lsvalidator docker-entrypoint.sh "$@"
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--graffiti ${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--builder"
@@ -24,4 +32,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${__doppel} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${__doppel} ${VC_EXTRAS}

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -56,7 +56,6 @@ services:
       - --network=${NETWORK}
       - --web3-url=${EL_NODE}
       - --jwt-secret=/var/lib/nimbus/ee-secret/jwtsecret
-      - --graffiti=${GRAFFITI}
       - --rest
       - --rest-address=0.0.0.0
       - --rest-port=${CL_REST_PORT:-5052}

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -36,7 +36,6 @@ services:
       - --data-dir=/var/lib/nimbus
       - --non-interactive
       - --beacon-node=${CL_NODE}
-      - --graffiti=${GRAFFITI}
       - --metrics
       - --metrics-port=8009
       - --metrics-address=0.0.0.0

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -56,7 +56,6 @@ services:
       - --network=${NETWORK}
       - --web3-url=${EL_NODE}
       - --jwt-secret=/var/lib/nimbus/ee-secret/jwtsecret
-      - --graffiti=${GRAFFITI}
       - --rest
       - --rest-address=0.0.0.0
       - --rest-port=${CL_REST_PORT:-5052}

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -10,6 +10,14 @@ if [ ! -f /var/lib/nimbus/api-token.txt ]; then
     echo "$__token" > /var/lib/nimbus/api-token.txt
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--graffiti=${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should enable doppelganger protection
 if [ "${DOPPELGANGER}" = "true" ]; then
   __doppel=""
@@ -22,4 +30,4 @@ __log_level="--log-level=${LOG_LEVEL^^}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__log_level} ${__doppel} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__log_level} ${__doppel} ${VC_EXTRAS}

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -35,6 +35,14 @@ if [ -n "${RAPID_SYNC_URL:+x}" ] && [ ! -f "/var/lib/nimbus/setupdone" ]; then
     fi
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--graffiti=${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--payload-builder=true --payload-builder-url=${MEV_NODE:-http://mev-boost:18550}"
@@ -62,4 +70,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${__log_level} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${__log_level} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -40,8 +40,6 @@ services:
       - /var/lib/prysm/
       - --beacon-rpc-provider
       - ${CL_NODE:-http://consensus:4000}
-      - --graffiti
-      - ${GRAFFITI}
       - --verbosity
       - ${LOG_LEVEL}
       - --${NETWORK}

--- a/prysm.yml
+++ b/prysm.yml
@@ -99,8 +99,6 @@ services:
       - /var/lib/prysm/
       - --beacon-rpc-provider
       - consensus:4000
-      - --graffiti
-      - ${GRAFFITI}
       - --verbosity
       - ${LOG_LEVEL}
       - --${NETWORK}

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -6,6 +6,14 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu prysmvalidator docker-entrypoint.sh "$@"
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--graffiti ${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--enable-builder"
@@ -24,4 +32,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${__doppel} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${__doppel} ${VC_EXTRAS}

--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -35,7 +35,6 @@ services:
       - --log-destination=CONSOLE
       - --network=auto
       - --validator-keys=/var/lib/teku/validator-keys:/var/lib/teku/validator-passwords
-      - --validators-graffiti=${GRAFFITI}
       - --validators-early-attestations-enabled=false
       - --validator-api-enabled=true
       - --validator-api-interface=0.0.0.0

--- a/teku.yml
+++ b/teku.yml
@@ -56,7 +56,6 @@ services:
       - --p2p-peer-upper-bound=${CL_MAX_PEER_COUNT:-100}
       - --p2p-peer-lower-bound=${CL_MIN_PEER_COUNT:-64}
       - --validator-keys=/var/lib/teku/validator-keys:/var/lib/teku/validator-passwords
-      - --validators-graffiti=${GRAFFITI}
       - --logging=${LOG_LEVEL}
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true

--- a/teku/docker-entrypoint-vc.sh
+++ b/teku/docker-entrypoint-vc.sh
@@ -24,6 +24,14 @@ if [ ! -f /var/lib/teku/teku-keyapi.keystore ]; then
     openssl pkcs12 -export -in /var/lib/teku/teku-keyapi.crt -inkey /var/lib/teku/teku-keyapi.key -out /var/lib/teku/teku-keyapi.keystore -name teku-keyapi -passout pass:"$__password"
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--validators-graffiti=${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--validators-builder-registration-default-enabled"
@@ -34,4 +42,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${VC_EXTRAS}

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -50,6 +50,14 @@ else
     __rapid_sync=""
 fi
 
+# Check whether custom graffiti is set
+if [ -v GRAFFITI ]; then
+  __graffiti="--validators-graffiti=${GRAFFITI}"
+  echo "Custom graffiti was supplied in .env"
+else
+  __graffiti=""
+fi
+
 # Check whether we should use MEV Boost
 if [ "${MEV_BOOST}" = "true" ]; then
   __mev_boost="--validators-builder-registration-default-enabled --builder-endpoint=${MEV_NODE:-http://mev-boost:18550}"
@@ -75,4 +83,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${CL_EXTRAS} ${VC_EXTRAS}
+exec "$@" ${__graffiti} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${CL_EXTRAS} ${VC_EXTRAS}


### PR DESCRIPTION
**Current behavior**

At the moment it is not possible to omit the graffiti flag, even if `GRAFFITI` in the env file is removed or commented out it will add the `--graffiti` flag which results in an empty graffiti being used.

It is not possible to let the validator use the default graffiti which is a lot of times desired if you want to have the client name and version as graffiti since most validators use the `<client-name>-<version>/<short-commit-sha>` as default graffiti.

**Expected behavior**

setting different `GRAFFITI` values in `.env` should behave like this

- `GRAFFITI=🐼eth-docker🐼` should use `🐼eth-docker🐼` as graffiti
- `GRAFFITI=` or `GRAFFITI=""` should result in an empty graffiti
- `GRAFFITI` env removed or commented out should result in omitting `--graffiti` flag and use validator default graffiti

**Proposed change**

Move setting graffiti flag to docker-entrypoint scripts to add additional logic to check if `GRAFFITI` is set
