### PR TITLE
Updating docs for setting withdrawal credentials

### DIFF
--- a/.eth/ethdo/README.md
+++ b/.eth/ethdo/README.md
@@ -8,66 +8,80 @@ This follows the [ethdo instructions](https://github.com/wealdtech/ethdo/blob/ma
 ## Check whether your validator has a withdrawal address set
 
 [Metrika](https://app.metrika.co/ethereum/dashboard/withdrawals-overview) will let you see whether your validator has a withdrawal address set.
-If yes, that is where consensus layer rewards will be swept automatically every 4-5 days at ~500,000 validators total.
+If yes, that is where consensus layer rewards will be swept automatically (every 4-5 days at ~500,000 validators total) and where your funds will be sent when exiting.
 
-You can use `./ethd keys list` to get a list of your validator public keys.
+You can use `./ethd keys list` to get a list of your validator public keys that are currently active on your system.
 
 ## Offline preparation
 
-On your node running under eth-docker, run `./ethd keys prepare-address-change`.
+On your machine running eth-docker, run `./ethd keys prepare-address-change`.
 
-This will, under the hood, run `./ethd cmd run --rm ethdo validator credentials set --prepare-offline --timeout 2m --allow-insecure-connections --connection http://consensus:5052`
-which creates an `offline-preparation.json` file in `./.eth/ethdo`, this directory. This file contains all validators on the network, and is used during the offline step.
+Under the hood this will run `./ethd cmd run --rm ethdo validator credentials set --prepare-offline --timeout 2m --allow-insecure-connections --connection http://consensus:5052`
+which creates an `offline-preparation.json` file in `./.eth/ethdo`. 
+This file contains a list of all validators currently on the network and is necessary for the offline machine. 
 
 This command will also download `ethdo` itself into this directory.
 
-Copy the contents of this directory, including this `README.md`, `ethdo`, `ethdo-arm64`, `jq`, the `offline-preparation.json`, and the `create-withdrawal-change.sh` script, to a USB stick.
+Copy the contents of this directory, including this `README.md`, `ethdo`, `ethdo-arm64`, `jq`, the `offline-preparation.json`, and the `create-withdrawal-change.sh` script, to a USB stick (we will call it Data USB).
 
-## Make Linux Live USB
-
-Get the [Ubuntu Desktop](https://ubuntu.com/download/desktop) ISO and burn it to a second USB stick with [Balena Etcher](https://www.balena.io/etcher)
-or [Rufus](https://rufus.ie/en/).
-
-Take note of the withdrawal address you intend to use. This has to be an address you control. Good choices are a hardware wallet, where the mnemonic was
-**never** online, or a contract such as a [multi-signature safe](https://app.safe.global).
+You should also create a new text file on the Data USB that contains the address you want your validator rewards to go to. 
+This has to be an address you control. Good choices are a hardware wallet where the mnemonic was
+**never** online or a contract such as a [multi-signature safe](https://app.safe.global).
 
 **Triple-check the withdrawal address you choose! You can only set this once**
 
-Boot from this USB stick by overriding the boot target in UEFI settings. Methods to do this vary by device: Common key interrupts are F2, F8, F12, DEL and Enter.
+If you do not provide the address through a USB stick you will have to type it manually which is prone to human error.
 
-When prompted, choose to "Try Ubuntu". Do not install Ubuntu.
+## Make Linux Live USB
 
-Also insert the USB stick that holds `ethdo` and the other files.
+Get the [Ubuntu Desktop](https://ubuntu.com/download/desktop) ISO and burn it to a second USB stick (we will call it Live USB) with [Balena Etcher](https://www.balena.io/etcher)
+or [Rufus](https://rufus.ie/en/).
+
+Plug in the Live USB to your offline computer and turn it on. You will likely need to override the boot target in the UEFI(BIOS) settings. Methods to do this vary by device: Common key interrupts are F2, F8, F12, DEL and Enter.
+While you are updating the boot target, it would be proper to additionally turn off WIFI, Bluetooth and LAN integrated devices.
+
+Upon saving those settings and exiting the UEFI(BIOS) interface, you will be prompted with a list of options.
+Choose "Try Ubuntu". Do not install Ubuntu.
+
+After Ubuntu loads, insert the Data USB that holds `ethdo` and the other files from the Offline preparation step.
 
 ## Create change credentials file
 
-Disconnect Ubuntu from Internet, if it is connected. This is in the upper right corner.
+Verify your internet has been disabled by attempting to visit a website, ping through terminal, or looking in the upper right corner of the desktop.
 
-Open a "Terminal", and cd to the second USB stick.
+Open a "Terminal", and cd to the Data USB directory.
 
-Run `./create-withdrawal-change.sh`. This will create a `change-operations.json` file on that USB stick for use with eth-docker and `ethdo`, and
-several \<validator-index\>.json files for use with [CLWP](https://clwp.xyz).
+Run `./create-withdrawal-change.sh`. 
+
+You will be prompted to specify the withdrawal address you want your funds to be sent to. You should copy that value from the text file.
 
 **Triple-check the withdrawal address you set here! You can only set this once**
 
-The withdrawal address has to be an address you control. Good choices are a hardware wallet, where the mnemonic was
-**never** online, or a contract such as a [multi-signature safe](https://app.safe.global).
+You will then be prompted to provide the mnemonic key of your withdrawal key. This is needed to sign the change withdrawal request.
 
-Shut down Ubuntu, which will make your PC "forget" anything it knew about your mnemonic during this process.
+A file `change-operations.json` will then be created and saved on the Data USB for use with eth-docker and `ethdo` on your online computer.
 
-## Send changes to the chain
+You will be given the option to create a separate file for each validator if you plan to use [CLWP](https://clwp.xyz). Doing so will create several \<validator-index\>.json files.
+
+Shut down Ubuntu which will make your PC "forget" anything it knew about your mnemonic during this process.
+
+At this point your Live USB will no longer be needed.
+
+## Broadcast changes to the chain
 
 **This is not yet implemented. It'll go live in time for Goerli withdrawals**
 
-Copy the `change-operations.json` from USB to `./eth/ethdo` on your eth-docker node.
+Insert the Data USB to your online computer where eth-docker is running.
+
+Copy the `change-operations.json` from the Data USB to `./eth/ethdo` on your eth-docker node.
 
 Run `./ethd keys send-address-change`. You will have one more chance to verify your withdrawal address.
 
 Did I mention to **triple-check the withdrawal address you have set? You can only set this once!**
 
 If a Shanghai/Capella fork has been announced on your chain, the changes will be loaded into the consensus layer client
-for broadcast. If Shanghai/Capella is live, they will be broadcast. Inclusion should take ~3 days after the hardfork date if
-everyone piles in at once, or is expected to be immediate if you are sending it later.
+for broadcast. If Shanghai/Capella is live, they will be broadcasted. Inclusion should take ~3 days after the hardfork date if
+everyone piles in at once or should be almost immediate if you have waited.
 
 ## Check whether your validator has a withdrawal address set
 

--- a/.eth/ethdo/README.md
+++ b/.eth/ethdo/README.md
@@ -17,8 +17,8 @@ You can use `./ethd keys list` to get a list of your validator public keys that 
 On your machine running eth-docker, run `./ethd keys prepare-address-change`.
 
 Under the hood this will run `./ethd cmd run --rm ethdo validator credentials set --prepare-offline --timeout 2m --allow-insecure-connections --connection http://consensus:5052`
-which creates an `offline-preparation.json` file in `./.eth/ethdo`. 
-This file contains a list of all validators currently on the network and is necessary for the offline machine. 
+which creates an `offline-preparation.json` file in `./.eth/ethdo`.
+This file contains a list of all validators currently on the network and is necessary for the offline machine.
 
 This command will also download `ethdo` itself into this directory.
 
@@ -34,8 +34,7 @@ If you do not provide the address through a USB stick you will have to type it m
 
 ## Make Linux Live USB
 
-Get the [Ubuntu Desktop](https://ubuntu.com/download/desktop) ISO and burn it to a second USB stick (we will call it Live USB) with [Balena Etcher](https://www.balena.io/etcher)
-or [Rufus](https://rufus.ie/en/).
+Get the [Ubuntu Desktop](https://ubuntu.com/download/desktop) ISO and burn it to a second USB stick (we will call it Live USB) with [Balena Etcher](https://www.balena.io/etcher) or [Rufus](https://rufus.ie/en/).
 
 Plug in the Live USB to your offline computer and turn it on. You will likely need to override the boot target in the UEFI(BIOS) settings. Methods to do this vary by device: Common key interrupts are F2, F8, F12, DEL and Enter.
 While you are updating the boot target, it would be proper to additionally turn off WIFI, Bluetooth and LAN integrated devices.
@@ -51,7 +50,7 @@ Verify your internet has been disabled by attempting to visit a website, ping th
 
 Open a "Terminal", and cd to the Data USB directory.
 
-Run `./create-withdrawal-change.sh`. 
+Run `./create-withdrawal-change.sh`.
 
 You will be prompted to specify the withdrawal address you want your funds to be sent to. You should copy that value from the text file.
 

--- a/.eth/ethdo/README.md
+++ b/.eth/ethdo/README.md
@@ -24,7 +24,7 @@ This command will also download `ethdo` itself into this directory.
 
 Copy the contents of this directory, including this `README.md`, `ethdo`, `ethdo-arm64`, `jq`, the `offline-preparation.json`, and the `create-withdrawal-change.sh` script, to a USB stick (we will call it Data USB).
 
-You should also create a new text file on the Data USB that contains the address you want your validator rewards to go to. 
+You should also create a new text file on the Data USB that contains the address you want your validator rewards to go to.
 This has to be an address you control. Good choices are a hardware wallet where the mnemonic was
 **never** online or a contract such as a [multi-signature safe](https://app.safe.global).
 
@@ -87,4 +87,4 @@ everyone piles in at once or should be almost immediate if you have waited.
 Obsessively refresh [Metrika](https://app.metrika.co/ethereum/dashboard/withdrawals-overview) to see whether your validator now has a withdrawal address set.
 If yes, that is where consensus layer rewards will be swept automatically every 4-5 days at ~500,000 validators total.
 
-You can use `./ethd keys list` to get a list of your validator public keys.
+You can use `./ethd keys list` to get a list of your validator public keys that are currently active on your system.


### PR DESCRIPTION
Updating documentation to try to differentiate more between the two USB sticks and to recommend creating an additional file that contains the address instead of having the user type manually.