### PR TITLE
Hide MEV option for RPC node

### DIFF
--- a/ethd
+++ b/ethd
@@ -1652,9 +1652,9 @@ config() {
         query_rapid_sync
         if [ ! "${__deployment}" = "rpc" ]; then
           query_mev
+          query_coinbase
         fi
         query_grafana
-        query_coinbase
         if [ "${__deployment}" = "node" ]; then
           query_graffiti
         fi

--- a/ethd
+++ b/ethd
@@ -1650,7 +1650,9 @@ config() {
 
         query_execution_client
         query_rapid_sync
-        query_mev
+        if [ ! "${__deployment}" = "rpc" ]; then
+          query_mev
+        fi
         query_grafana
         query_coinbase
         if [ "${__deployment}" = "node" ]; then


### PR DESCRIPTION
@yorickdowne 
Not sure if `mev-boost` and `coinbase` do anything for an RPC node - I think these options can be hidden?