### PR TITLE
Fix Ethereum Metrics exporter entrypoint

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -48,7 +48,7 @@ services:
       - CLIENT=${COMPOSE_FILE}
     entrypoint:
       - docker-entrypoint.sh
-      - /exporter
+      - /ethereum-metrics-exporter
     <<: *logging
 
   node-exporter:

--- a/grafana.yml
+++ b/grafana.yml
@@ -38,7 +38,7 @@ services:
       - CLIENT=${COMPOSE_FILE}
     entrypoint:
       - docker-entrypoint.sh
-      - /exporter
+      - /ethereum-metrics-exporter
     <<: *logging
 
   node-exporter:


### PR DESCRIPTION
same issue https://github.com/eth-educators/eth-docker/issues/1164 as before, see https://github.com/ethpandaops/ethereum-metrics-exporter/pull/74 😄 

```sh
/usr/local/bin/docker-entrypoint.sh: line 11: /exporter: No such file or directory
/usr/local/bin/docker-entrypoint.sh: line 11: /exporter: No such file or directory
/usr/local/bin/docker-entrypoint.sh: line 11: /exporter: No such file or directory
/usr/local/bin/docker-entrypoint.sh: line 11: /exporter: No such file or directory
```