### PR TITLE
Pin eth-metrics version

### DIFF
--- a/eth-metrics/Dockerfile
+++ b/eth-metrics/Dockerfile
@@ -1,3 +1,3 @@
-FROM samcm/ethereum-metrics-exporter:0.20.0-debian
+FROM samcm/ethereum-metrics-exporter:0.21.0-debian
 
 COPY ./docker-entrypoint.sh /usr/local/bin/

--- a/eth-metrics/Dockerfile
+++ b/eth-metrics/Dockerfile
@@ -1,3 +1,3 @@
-FROM samcm/ethereum-metrics-exporter:debian-latest
+FROM samcm/ethereum-metrics-exporter:0.20.0-debian
 
 COPY ./docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
Latest eth-metrics fails with the following error:

```
/usr/local/bin/docker-entrypoint.sh: line 11: /exporter: No such file or directory
```