### PR TITLE
ethereum-metrics-exporter fails to start 

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -38,7 +38,7 @@ services:
       - CLIENT=${COMPOSE_FILE}
     entrypoint:
       - docker-entrypoint.sh
-      - /exporter
+      - /ethereum-metrics-exporter
     <<: *logging
 
   node-exporter:


### PR DESCRIPTION
I had this issue where ethereum-metrics-exporter would not start and it was due to this name been different. 
I don't know much about this code but maybe it broke because an update to the container. 

