### PR TITLE
opened up origins for websocket server

### DIFF
--- a/geth.yml
+++ b/geth.yml
@@ -59,6 +59,7 @@ services:
       - ${EL_WS_PORT:-8546}
       - --ws.api
       - web3,eth,net
+      - --ws.origins=*
       - --${NETWORK}
       - --metrics
       - --metrics.expensive


### PR DESCRIPTION
when opening up the geth ports to the public `--ws.origins=*` is needed.