### PR TITLE
Fix docker registry for prism validator and beacon-chain image. 

### DIFF
--- a/prysm/Dockerfile.binary
+++ b/prysm/Dockerfile.binary
@@ -1,6 +1,6 @@
 ARG DOCKER_TAG
 ARG DOCKER_VC_TAG
-FROM prysmaticlabs/prysm-beacon-chain:${DOCKER_TAG} as ccsource
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain:${DOCKER_TAG} as ccsource
 
 FROM debian:bullseye-slim as consensus
 
@@ -45,7 +45,7 @@ USER ${USER}
 
 ENTRYPOINT ["beacon-chain"]
 
-FROM prysmaticlabs/prysm-validator:${DOCKER_VC_TAG} as vcsource
+FROM gcr.io/prysmaticlabs/prysm/validator:${DOCKER_VC_TAG} as vcsource
 
 FROM consensus as validator
 


### PR DESCRIPTION
https://docs.prylabs.network/docs/install/install-with-docker only lists gcr.io as source, 

This https://github.com/prysmaticlabs/prysm/pull/11250/ might have stopped image updates on docker.io. Consequently e.g. stable now points to an outdated image on docker.io, no idea who updates those.