### PR TITLE
QoL changes

### DIFF
--- a/.eth/ethdo/create-withdrawal-change.sh
+++ b/.eth/ethdo/create-withdrawal-change.sh
@@ -53,8 +53,8 @@ echo "MAKE SURE YOU CONTROL THE WITHDRAWAL ADDRESS"
 echo "This can only be changed once."
 while true; do
     read -rp "What is your validator mnemonic? : " __mnemonic
-    if ! [ "$(echo "$__mnemonic" | wc -w)" -eq 24 ]; then
-        echo "The mnemonic needs to be 24 words. You can try again or hit Ctrl-C to abort."
+    if [ ! "$(echo "$__mnemonic" | wc -w)" -eq 24 ] && [ ! "$(echo "$__mnemonic" | wc -w)" -eq 12 ]; then
+        echo "The mnemonic needs to be 24 or 12 words. You can try again or hit Ctrl-C to abort."
         continue
     fi
     read -rp "Please verify your validator mnemonic : " __mnemonic2

--- a/ethd
+++ b/ethd
@@ -1240,19 +1240,19 @@ keys() {
         echo
         echo "Downloading ethdo"
         REPO="wealdtech/ethdo"; \
-        curl -s https://api.github.com/repos/${REPO}/releases/latest | grep "browser_download_url.*linux-amd64.tar.gz" \
+        wget -q -O- https://api.github.com/repos/${REPO}/releases/latest | grep "browser_download_url.*linux-amd64.tar.gz" \
         | head -1 \
         | cut -d : -f 2,3 \
         | tr -d \" \
-        | wget -qi - -O- \
+        | wget -qi- -O- \
         | tar zxf - -C ./.eth/ethdo/ \
         || echo "-> Could not download the latest version of '${REPO}' for amd64."
         mkdir -p ./.eth/ethdo/arm64
-        curl -s https://api.github.com/repos/${REPO}/releases/latest | grep "browser_download_url.*linux-arm64.tar.gz" \
+        wget -q -O- https://api.github.com/repos/${REPO}/releases/latest | grep "browser_download_url.*linux-arm64.tar.gz" \
         | head -1 \
         | cut -d : -f 2,3 \
         | tr -d \" \
-        | wget -qi - -O- \
+        | wget -qi- -O- \
         | tar zxf - -C ./.eth/ethdo/arm64 \
         || echo "-> Could not download the latest version of '${REPO}' for arm64."
         mv ./.eth/ethdo/arm64/ethdo ./.eth/ethdo/ethdo-arm64

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -58,7 +58,7 @@ if [ "${ARCHIVE_NODE}" = "true" ]; then
   if [ "${__memtotal}" -gt 62 ]; then
     __memhint="--Init.MemoryHint=4096000000"
   else
-    __memhint=""
+    __memhint="--Init.MemoryHint=1024000000"
   fi
 else
   __parallel=$(($(nproc)/4))


### PR DESCRIPTION
- Use wget instead of curl for prepare-address-change
- create-withdrawal-change can handle 12-word mnemonics
- Lower memory hint for archive Nethermind on 32 GiB machines