### PR TITLE
Fix for Lighthouse validator exit if there is a keybackup directory

### DIFF
--- a/lighthouse/validator-exit.sh
+++ b/lighthouse/validator-exit.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # Copy keys, then restart script without root
 if [ "$(id -u)" = '0' ]; then
   mkdir /keys
-  cp /validator_keys/* /keys/
+  cp -r /validator_keys/* /keys/
   chown lhvalidator:lhvalidator /keys/*
   exec gosu lhvalidator "${BASH_SOURCE[0]}" "$@"
 fi


### PR DESCRIPTION
Issue https://github.com/eth-educators/eth-docker/issues/1336