### PR TITLE
Increase torrent download speed during initial sync

### DIFF
--- a/erigon.yml
+++ b/erigon.yml
@@ -55,6 +55,8 @@ services:
       - ${EL_P2P_PORT:-30303},${ERIGON_P2P_PORT_2:-30304},${ERIGON_P2P_PORT_3:-30305}
       - --torrent.port
       - ${ERIGON_TORRENT_PORT:-42069}
+      - --torrent.download.rate
+      - 500mb
       - --nat
       - any
       - --chain


### PR DESCRIPTION
The default speed limit is 16mb/s resulting in around 4/5h of download time.
With this change it should be <1h depending on the connection speed. 