### PR TITLE
dasel multiarch support

### DIFF
--- a/nethermind/Dockerfile.binary
+++ b/nethermind/Dockerfile.binary
@@ -1,6 +1,9 @@
 ARG DOCKER_TAG
 
-FROM ghcr.io/tomwright/dasel:v2.2.0-alpine as dasel
+FROM alpine as dasel
+RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
+    wget -q https://github.com/TomWright/dasel/releases/download/v2.2.0/dasel_linux_${arch} -O /usr/local/bin/dasel && \
+    chmod +x /usr/local/bin/dasel
 
 FROM nethermind/nethermind:${DOCKER_TAG}
 

--- a/nethermind/Dockerfile.dev
+++ b/nethermind/Dockerfile.dev
@@ -1,6 +1,9 @@
 ARG DOCKER_TAG
 
-FROM ghcr.io/tomwright/dasel:v2.2.0-alpine as dasel
+FROM alpine as dasel
+RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
+    wget -q https://github.com/TomWright/dasel/releases/download/v2.2.0/dasel_linux_${arch} -O /usr/local/bin/dasel && \
+    chmod +x /usr/local/bin/dasel
 
 FROM nethermindeth/nethermind:${DOCKER_TAG}
 

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -19,7 +19,10 @@ RUN bash -c "\
     git submodule update --init --recursive && \
     dotnet publish src/Nethermind/Nethermind.Runner -c release -o out"
 
-FROM ghcr.io/tomwright/dasel:v2.2.0-alpine as dasel
+FROM alpine as dasel
+RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
+    wget -q https://github.com/TomWright/dasel/releases/download/v2.2.0/dasel_linux_${arch} -O /usr/local/bin/dasel && \
+    chmod +x /usr/local/bin/dasel
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 


### PR DESCRIPTION
# 

When attempting to start `Nethermind` on ARM, the following error is reported:

```
exec /usr/local/bin/dasel: exec format error
```

This occurs because the `dasel` docker image only supports amd64 architecture, not multiarch.

To fix this issue `dasel` binary is downloaded directly from the GitHub release page