### PR TITLE
Add prometheus-shared.yml to expose prometheus port

### DIFF
--- a/default.env
+++ b/default.env
@@ -76,6 +76,8 @@ PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000
 # Local grafana dashboard port. Do not expose to Internet, it is insecure http
 GRAFANA_PORT=3000
+# Prometheus port used when exposing directly on host; used for federation
+PROMETHEUS_PORT=9090
 # Local key manager port. Reachable only via localhost. Also doubles as Prysm web port
 KEY_API_PORT=7500
 # Secure web proxy port, 443 and 80 are great defaults

--- a/prometheus-shared.yml
+++ b/prometheus-shared.yml
@@ -1,0 +1,6 @@
+# Prometheus federation, or other reasons to have prometheus through traefik
+version: "3.9"
+services:
+  prometheus:
+    ports:
+      - ${HOST_IP:-}${PROMETHEUS_PORT:-9090}:9090/tcp


### PR DESCRIPTION
Along the lines of all the other `*-shared.yml` configuration files. I'm using this locally for federation.