### PR TITLE
Using grep to limit default NM_SRC_BUILD_TARGET 

### DIFF
--- a/default.env
+++ b/default.env
@@ -207,7 +207,7 @@ ERIGON_DOCKERFILE=Dockerfile.binary
 
 # Nethermind
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
-NM_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
+NM_SRC_BUILD_TARGET='$(git tag --sort=-committerdate | grep -E "^[0-9]+[.][0-9]+[.][0-9]+$" | head -1)'
 NM_DOCKER_TAG=latest
 NM_DOCKERFILE=Dockerfile.binary
 


### PR DESCRIPTION
Using grep to limit default NM_SRC_BUILD_TARGET to tags that match
regex: "^[0-9]+[.][0-9]+[.][0-9]+$" .  This avoids building from tags like "1.20.0-rc" or "1.17.0-unstable"

This is a fix for issue  #1433