### PR TITLE
Use `maxperf` profile when building Lighthouse from source

### DIFF
--- a/lighthouse/Dockerfile.source
+++ b/lighthouse/Dockerfile.source
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y cmake libcla
 #ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /usr/src
-RUN bash -c "git clone https://github.com/sigp/lighthouse.git && cd lighthouse && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:lh-pr; git checkout lh-pr; else git checkout ${BUILD_TARGET}; fi && make"
+RUN bash -c "git clone https://github.com/sigp/lighthouse.git && cd lighthouse && git config advice.detachedHead false && git fetch --all --tags && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:lh-pr; git checkout lh-pr; else git checkout ${BUILD_TARGET}; fi && CROSS_PROFILE=maxperf make"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:bullseye-slim


### PR DESCRIPTION
Lighthouse official binaries & images are built using the `maxperf` profile to enable further optimizations, so it _might_ be worth changing the Dockerfile for source builds to use the same, depending on what user uses the source build feature for - if using it for comparative testing with `stable` or running a validator, it probably makes sense to enable `maxperf`.

From [Lighthouse book](https://lighthouse-book.sigmaprime.io/installation-source.html#compilation-profiles):
> `maxperf`: default for binary releases, enables aggressive optimisations including full LTO. Although compiling with this profile improves some benchmarks by around 20% compared to `release`, it imposes a significant cost at compile time and is only recommended if you have a fast CPU.


