### PR TITLE
feat: add grafana-auth.yml

### DIFF
--- a/grafana-auth.yml
+++ b/grafana-auth.yml
@@ -1,0 +1,5 @@
+version: "3.9"
+services:
+  grafana:
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true


### PR DESCRIPTION
## Reason for PR
i often run multiple instances of the eth-docker (and subsequently, grafana, in a single browser window). However, grafana adds some browser storage value for auth, and personally, i like to just disable auth here. so adding the ability to view the dashboard without auth is a nice feature to have for me so I'm thinking it will be helpful for others too.