### PR TITLE
Update Lodestar CLI flag to enable doppelganger protection

### DIFF
--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -24,7 +24,7 @@ fi
 
 # Check whether we should enable doppelganger protection
 if [ "${DOPPELGANGER}" = "true" ]; then
-  __doppel="--doppelgangerProtectionEnabled"
+  __doppel="--doppelgangerProtection"
   echo "Doppelganger protection enabled, VC will pause for 2 epochs"
 else
   __doppel=""


### PR DESCRIPTION
Updates Lodestar CLI flag to enable doppelganger protection to `--doppelgangerProtection`. Previous value still works as an alias but this one it now referenced in our docs.

![image](https://github.com/eth-educators/eth-docker/assets/38436224/67d714df-f90b-4d43-b8a1-6fd4678abefa)
