### PR TITLE
Update Nethermind executable name

### DIFF
--- a/nethermind/Dockerfile.dev
+++ b/nethermind/Dockerfile.dev
@@ -43,4 +43,4 @@ RUN chmod -R 755 /usr/local/bin/*
 
 USER ${USER}
 
-ENTRYPOINT ["dotnet","/nethermind/Nethermind.Runner.dll"]
+ENTRYPOINT ["dotnet","/nethermind/nethermind.dll"]

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -56,4 +56,4 @@ RUN chmod -R 755 /usr/local/bin/*
 
 USER ${USER}
 
-ENTRYPOINT ["./Nethermind.Runner"]
+ENTRYPOINT ["./nethermind"]


### PR DESCRIPTION
To be consistent across different distribution channels, we renamed the Nethermind executable from `Nethermind.Runner` to `nethermind`. This PR updates Docker files accordingly.

The `Dockerfile.binary` is not updated as it uses the production image that will be updated once the abovementioned change is released.
