### PR TITLE
Remove the default http.api configuration to avoid overwriting configuration in geth.yml.

### DIFF
--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -51,7 +51,7 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     touch /var/lib/goethereum/setupdone
   fi
 else
-  __network="--${NETWORK} --http.api web3,eth,net"
+  __network="--${NETWORK}"
 fi
 
 # Set verbosity


### PR DESCRIPTION
https://geth.ethereum.org/docs/interacting-with-geth/rpc#http-server

The default whitelist allows access to the eth, net and web3 namespaces.