### PR TITLE
Revert "Remove Teku web3signer wait loop (#1504)"

### DIFF
--- a/teku/docker-entrypoint-vc.sh
+++ b/teku/docker-entrypoint-vc.sh
@@ -66,6 +66,15 @@ fi
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
   __w3s_url="--validators-external-signer-url http://web3signer:9000 --validators-external-signer-public-keys external-signer"
+  while true; do
+    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+        echo "web3signer is up, starting Teku"
+        break
+    else
+        echo "Waiting for web3signer to be reachable..."
+        sleep 5
+    fi
+  done
 else
   __w3s_url=""
 fi

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -114,6 +114,15 @@ fi
 # Web3signer URL
 if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
   __w3s_url="--validators-external-signer-url http://web3signer:9000 --validators-external-signer-public-keys external-signer"
+  while true; do
+    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+        echo "web3signer is up, starting Teku"
+        break
+    else
+        echo "Waiting for web3signer to be reachable..."
+        sleep 5
+    fi
+  done
 else
   __w3s_url=""
 fi


### PR DESCRIPTION
This reverts commit 5535b9658256278ace46058a5ad5473c55e804c5.

According to Discord user Higgz, Teku doesn't load keys when web3signer comes up.