### PR TITLE
Teku to 6g heap

### DIFF
--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
-      - JAVA_OPTS=${TEKU_HEAP:--Xmx4g}
+      - JAVA_OPTS=${TEKU_HEAP:--Xmx6g}
       - RAPID_SYNC_URL=${RAPID_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/teku.yml
+++ b/teku.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
-      - JAVA_OPTS=${TEKU_HEAP:--Xmx4g}
+      - JAVA_OPTS=${TEKU_HEAP:--Xmx6g}
       - RAPID_SYNC_URL=${RAPID_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}


### PR DESCRIPTION
To handle non-finality events. This may not be sufficient yet, but appears to resolve OOM on current Holesky.