### PR TITLE
Add restart option to cadvisor

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -103,6 +103,7 @@ services:
     <<: *logging
 
   cadvisor:
+    restart: "unless-stopped"
     image: gcr.io/cadvisor/cadvisor:v0.47.2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/grafana.yml
+++ b/grafana.yml
@@ -98,6 +98,7 @@ services:
     <<: *logging
 
   cadvisor:
+    restart: "unless-stopped"
     image: gcr.io/cadvisor/cadvisor:v0.47.2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
Sometimes cadvisor is stopped and its needed for collection of metrics to see container performance on a server. Starting up the container usually works without errors, have not identified why it stops in the first place.

Adding this will auto restart whenever it stops.