### PR TITLE
Update Lodestar beacon max-old-space-size to 8192

### DIFF
--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -40,7 +40,7 @@ services:
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
       - CL_P2P_PORT=${CL_P2P_PORT:-9000}
-      - NODE_OPTIONS=${LODESTAR_HEAP:---max-old-space-size=4096}
+      - NODE_OPTIONS=${LODESTAR_HEAP:---max-old-space-size=8192}
     ports:
       - ${HOST_IP:-}${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -40,7 +40,7 @@ services:
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
       - CL_P2P_PORT=${CL_P2P_PORT:-9000}
-      - NODE_OPTIONS=${LODESTAR_HEAP:---max-old-space-size=4096}
+      - NODE_OPTIONS=${LODESTAR_HEAP:---max-old-space-size=8192}
     ports:
       - ${HOST_IP:-}${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp

--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -65,4 +65,6 @@ RUN chmod -R 755 /usr/local/bin/*
 
 USER lsconsensus
 
-ENTRYPOINT ["node", "--max-old-space-size=16384", "/usr/app/node_modules/.bin/lodestar"]
+ENV NODE_OPTIONS=--max-old-space-size=8192
+
+ENTRYPOINT ["node", "/usr/app/node_modules/.bin/lodestar"]


### PR DESCRIPTION
**Motivation**
- https://github.com/ChainSafe/lodestar/pull/6343

**Description**

Update Lodestar beacon max-old-space-size to 8192

