### PR TITLE
Fixed JWT_SECRET value is not being saved in the .env file

### DIFF
--- a/ethd
+++ b/ethd
@@ -3264,6 +3264,8 @@ config() {
   set_value_in_env
   var=EL_NODE
   set_value_in_env
+  var=JWT_SECRET
+  set_value_in_env
   var=NETWORK
   set_value_in_env
   var=MEV_BOOST


### PR DESCRIPTION
Hi,

By using a Custom EL, the JWT_SECRET token entered in the Wizard does not get saved in the .env file, which later causes 'InvalidToken' issues when Consensus attempts to communicate.

```shell
consensus-1  | Feb 11 20:38:18.352 ERRO Error updating deposit contract cache   error: Invalid endpoint state: RequestFailed("eth_chainId call failed Auth(InvalidToken)"), retry_millis: 60000, service: beacon
```


The JWT token generates a new random value and does not use the one provided in the Wizard.
```shell
docker compose exec -it consensus cat /var/lib/lighthouse/beacon/ee-secret/jwtsecret
06835bd9def92b91e95a1bw93bbcaae646288c767a53d785dceaae8d26c2905a
```


After putting the correct JWT token, everything works normally.
```shell
consensus-1  | Feb 11 20:41:13.141 INFO Block production enabled                method: json rpc via http, endpoint: Auth { endpoint: "http://192.168.178.121:8551/", jwt_path: "/var/lib/lighthouse/beacon/ee-secret/jwtsecret", jwt_id: None, jwt_version: None }
```


Stack:
```
eth.docker: Version 2.6.1.0
Consensus version: Lighthouse/v4.6.0-c7e5dd1
Execution Layer: Custom 
```



Thanks.
