### PR TITLE
Increase pruning cache size to 4096MB for Nethermind for 30+GB machines.

### DIFF
--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -74,8 +74,8 @@ else
       __prune="${__prune} --Pruning.FullPruningThresholdMb=51200"
     fi
   fi
-  if [ "${__memtotal}" -gt 30 ]; then
-    __prune="${__prune} --Pruning.FullPruningMemoryBudgetMb=16384 --Init.StateDbKeyScheme=HalfPath"
+  if [ "${__memtotal}" -ge 30 ]; then
+    __prune="${__prune} --Pruning.CacheMb=4096 --Pruning.FullPruningMemoryBudgetMb=16384 --Init.StateDbKeyScheme=HalfPath"
   fi
   echo "Using pruning parameters:"
   echo "${__prune}"


### PR DESCRIPTION
First of all, thanks to @yorickdowne for your continued support to the project, it was instrumental for me setting up the validator infra easily. 
Two changes on this PR:
- Changing the Pruning.CacheMb to 4096 for 30GB+ RAM machines.
Running HalfPath NM changes in pre-release, I noticed a change in how the database grows now. More specifically, I noticed that low default Pruning.CacheMb value leads to some kind of "write amplification".
The growth graph for 1GB (default) value looks like:
![image](https://github.com/eth-educators/eth-docker/assets/878254/9ce2e010-6ec2-4b02-9bbe-9fde24aa623d)
I.e. it has a lot of incidental writes then deletes; results in about 200GBW per day on the SSD for the whole validator node.
3GB still exposes some of this pattern:
![image](https://github.com/eth-educators/eth-docker/assets/878254/0eb7dc17-8786-4576-94b4-c659613c69dd)
4GB seems to work fine; it significantly reduces the GBW per day to about 110-120 (from ~200).
![image](https://github.com/eth-educators/eth-docker/assets/878254/1af6f83f-f183-4222-8158-cf206047aafe)
8GB starts to consume way too much RAM, and results in higher incidental block processing times when pruning is running.
- Changing the RAM check conditions in bash scripts to -ge 30 from -gt 30. On my 32GB NUC, due to system reserved memory, the actual available RAM reported is less and is about 30.8 GB, when rounded down, it's exactly 30 (and it fails the gt 30 check at that point). I think the spirit of the script is checking for 32GB, however, due to reserved RAM, it - I think - doesn't always work as intended. 