### PR TITLE
Migrate to new volume names

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -28,7 +28,8 @@ services:
       - ARCHIVE_NODE=${ARCHIVE_NODE:-}
       - NETWORK=${NETWORK}
     volumes:
-      - besu-eth1-data:/var/lib/besu
+      - besu-eth1-data:/var/lib/besu-og
+      - besu-el-data:/var/lib/besu
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/besu/ee-secret
     ports:
@@ -86,12 +87,13 @@ services:
     user: "10001:10001"
     restart: "no"
     volumes:
-      - besu-eth1-data:/var/lib/besu
+      - besu-el-data:/var/lib/besu
     entrypoint: ["/bin/sh","-c"]
     command: /bin/sh
 
 volumes:
   besu-eth1-data:
+  besu-el-data:
   jwtsecret:
 
 networks:

--- a/besu/Dockerfile.binary
+++ b/besu/Dockerfile.binary
@@ -22,6 +22,8 @@ RUN set -eux; \
 # verify that the binary works
         gosu nobody true
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/besu-og && chown -R ${USER}:${USER} /var/lib/besu-og
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/besu/ee-secret && chown -R ${USER}:${USER} /var/lib/besu && chmod -R 700 /var/lib/besu && chmod 777 /var/lib/besu/ee-secret
 

--- a/besu/Dockerfile.source
+++ b/besu/Dockerfile.source
@@ -46,6 +46,8 @@ RUN adduser \
     --ingroup "${USER}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/besu-og && chown -R ${USER}:${USER} /var/lib/besu-og
 RUN mkdir -p /var/lib/besu/ee-secret && chown -R besu:besu /var/lib/besu && chmod -R 700 /var/lib/besu && chmod 777 /var/lib/besu/ee-secret
 
 # Cannot assume buildkit, hence no chmod

--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -6,6 +6,15 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu besu "${BASH_SOURCE[0]}" "$@"
 fi
 
+# Migrate from old to new volume
+if [[ -d /var/lib/besu-og && ! -f /var/lib/besu-og/migrationdone \
+    && $(ls -A /var/lib/besu-og/) ]]; then
+  echo "Migrating from old Besu volume to new one"
+  find /var/lib/besu-og/ -mindepth 1 -maxdepth 1 ! -name 'ee-secret' -exec mv -t /var/lib/besu/ {} +
+  touch /var/lib/besu-og/migrationdone
+  echo "Migration completed, data is now in volume \"besu-el-data\""
+fi
+
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/besu/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"

--- a/ethd
+++ b/ethd
@@ -1331,10 +1331,10 @@ resync-execution() {
 
   case "${value}" in
     *erigon.yml* ) __el_volume='erigon-el-data'; __el_client="erigon";;
-    *geth.yml* ) __el_volume='geth-eth1-data'; __el_client="geth";;
+    *geth.yml* ) __el_volume='geth-el-data'; __el_client="geth";;
     *reth.yml* ) __el_volume='reth-el-data'; __el_client="reth";;
-    *besu.yml* ) __el_volume='besu-eth1-data'; __el_client="besu";;
-    *nethermind.yml* ) __el_volume='nm-eth1-data'; __el_client="nethermind";;
+    *besu.yml* ) __el_volume='besu-el-data'; __el_client="besu";;
+    *nethermind.yml* ) __el_volume='nethermind-el-data'; __el_client="nethermind";;
     * ) echo "You do not appear to be running an execution layer client. Nothing to do."; return 0;;
   esac
 
@@ -1368,15 +1368,13 @@ resync-consensus() {
   value=$(sed -n -e "s/^${var}=\(.*\)/\1/p" "${ENV_FILE}" || true)
 
   case "${value}" in
-    *lighthouse.yml* ) __cl_volume='lhbeacon-data'; __cl_client="lighthouse";;
-    *lighthouse-cl-only.yml* ) __cl_volume='lhconsensus-data'; __cl_client="lighthouse";;
+    *lighthouse.yml* | *lighthouse-cl-only.yml* ) __cl_volume='lhconsensus-data'; __cl_client="lighthouse";;
     *teku-allin1.yml* ) __cl_volume='wipe-db'; __cl_client="teku";;
     *teku.yml* | *teku-cl-only.yml* ) __cl_volume='tekuconsensus-data'; __cl_client="teku";;
     *nimbus-allin1.yml* ) __cl_volume='wipe-db'; __cl_client="nimbus";;
     *nimbus.yml* | *nimbus-cl-only.yml* ) __cl_volume='nimbus-consensus-data'; __cl_client="nimbus";;
     *lodestar.yml* | *lodestar-cl-only.yml* ) __cl_volume='lsconsensus-data'; __cl_client="lodestar";;
-    *prysm.yml* ) __cl_volume='prysmbeacon-data'; __cl_client="prysm";;
-    *prysm-cl-only.yml* ) __cl_volume='prysmconsensus-data'; __cl_client="prysm";;
+    *prysm.yml* | *prysm-cl-only.yml* ) __cl_volume='prysmconsensus-data'; __cl_client="prysm";;
     *grandine-allin1.yml* ) __cl_volume='wipe-db'; __cl_client="grandine";;
     *grandine.yml* | *grandine-cl-only.yml* ) __cl_volume='grandineconsensus-data'; __cl_client="grandine";;
     * ) echo "You do not appear to be running a consensus layer client. Nothing to do."; return;;

--- a/geth.yml
+++ b/geth.yml
@@ -30,7 +30,8 @@ services:
       - IPV6=${IPV6:-false}
       - ANCIENT_DIR=${ANCIENT_DIR:-}
     volumes:
-      - geth-eth1-data:/var/lib/goethereum
+      - geth-eth1-data:/var/lib/goethereum-og
+      - geth-el-data:/var/lib/goethereum
       - ${ANCIENT_DIR:-.nada}:/var/lib/ancient
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/goethereum/ee-secret
@@ -84,6 +85,7 @@ services:
 
 volumes:
   geth-eth1-data:
+  geth-el-data:
   jwtsecret:
 
 networks:

--- a/geth/Dockerfile.binary
+++ b/geth/Dockerfile.binary
@@ -27,6 +27,8 @@ RUN adduser \
     --ingroup "${USER}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/goethereum-og && chown -R ${USER}:${USER} /var/lib/goethereum-og
 RUN mkdir -p /var/lib/goethereum/ee-secret && chown -R ${USER}:${USER} /var/lib/goethereum && chmod -R 700 /var/lib/goethereum && chmod 777 /var/lib/goethereum/ee-secret
 
 # Cannot assume buildkit, hence no chmod

--- a/geth/Dockerfile.source
+++ b/geth/Dockerfile.source
@@ -38,6 +38,8 @@ RUN adduser \
     --ingroup "${USER}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/goethereum-og && chown -R ${USER}:${USER} /var/lib/goethereum-og
 RUN mkdir -p /var/lib/goethereum/ee-secret && chown -R ${USER}:${USER} /var/lib/goethereum && chmod -R 700 /var/lib/goethereum && chmod 777 /var/lib/goethereum/ee-secret
 
 # Cannot assume buildkit, hence no chmod

--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -6,6 +6,15 @@ if [ "$(id -u)" = '0' ]; then
   exec su-exec geth docker-entrypoint.sh "$@"
 fi
 
+# Migrate from old to new volume
+if [[ -d /var/lib/goethereum-og && ! -f /var/lib/goethereum-og/migrationdone \
+    && $(ls -A /var/lib/goethereum-og/) ]]; then
+  echo "Migrating from old Geth volume to new one"
+  find /var/lib/goethereum-og/ -mindepth 1 -maxdepth 1 ! -name 'ee-secret' -exec mv -t /var/lib/goethereum/ {} +
+  touch /var/lib/goethereum-og/migrationdone
+  echo "Migration completed, data is now in volume \"geth-el-data\""
+fi
+
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/goethereum/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -26,7 +26,8 @@ services:
     user: lhconsensus
     stop_grace_period: 1m
     volumes:
-      - lhbeacon-data:/var/lib/lighthouse
+      - lhbeacon-data:/var/lib/lighthouse-og
+      - lhconsensus-data:/var/lib/lighthouse
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/lighthouse/beacon/ee-secret
     environment:
@@ -221,12 +222,13 @@ services:
     user: "10002:10002"
     restart: "no"
     volumes:
-      - lhbeacon-data:/var/lib/lighthouse
+      - lhconsensus-data:/var/lib/lighthouse
     entrypoint: ["/bin/sh","-c"]
     command: /bin/sh
 
 volumes:
   lhbeacon-data:
+  lhconsensus-data:
   lhvalidator-data:
   jwtsecret:
 

--- a/lighthouse/Dockerfile.binary
+++ b/lighthouse/Dockerfile.binary
@@ -20,6 +20,8 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/lighthouse-og && chown -R ${USER}:${USER} /var/lib/lighthouse-og
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/lighthouse/beacon/ee-secret && chown -R ${USER}:${USER} /var/lib/lighthouse/beacon && chmod -R 700 /var/lib/lighthouse/beacon && chmod 777 /var/lib/lighthouse/beacon/ee-secret
 # Cannot assume buildkit, hence no chmod

--- a/lighthouse/Dockerfile.source
+++ b/lighthouse/Dockerfile.source
@@ -47,6 +47,8 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/lighthouse-og && chown -R ${USER}:${USER} /var/lib/lighthouse-og
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/lighthouse/beacon/ee-secret && chown -R ${USER}:${USER} /var/lib/lighthouse/beacon && chmod -R 700 /var/lib/lighthouse/beacon && chmod 777 /var/lib/lighthouse/beacon/ee-secret
 # Cannot assume buildkit, hence no chmod

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -6,6 +6,15 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu lhconsensus docker-entrypoint.sh "$@"
 fi
 
+# Migrate from old to new volume
+if [[ -d /var/lib/lighthouse-og/beacon && ! -f /var/lib/lighthouse-og/beacon/migrationdone \
+    && $(ls -A /var/lib/lighthouse-og/beacon/) ]]; then
+  echo "Migrating from old Lighthouse volume to new one"
+  find /var/lib/lighthouse-og/beacon/ -mindepth 1 -maxdepth 1 ! -name 'ee-secret' -exec mv -t /var/lib/lighthouse/beacon/ {} +
+  touch /var/lib/lighthouse-og/beacon/migrationdone
+  echo "Migration completed, data is now in volume \"lhconsensus-data\""
+fi
+
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/lighthouse/beacon/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -29,7 +29,8 @@ services:
       - AUTOPRUNE_NM=${AUTOPRUNE_NM:-true}
       - NETWORK=${NETWORK}
     volumes:
-      - nm-eth1-data:/var/lib/nethermind
+      - nm-eth1-data:/var/lib/nethermind-og
+      - nethermind-el-data:/var/lib/nethermind
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/nethermind/ee-secret
     ports:
@@ -92,6 +93,7 @@ services:
 
 volumes:
   nm-eth1-data:
+  nethermind-el-data:
   jwtsecret:
 
 networks:

--- a/nethermind/Dockerfile.binary
+++ b/nethermind/Dockerfile.binary
@@ -36,6 +36,8 @@ RUN set -eux; \
 
 # This only goes so far. keystore, logs and nethermind_db are volumes and need to be chown'd in the entrypoint
 RUN chown -R ${USER}:${USER} /nethermind
+# Create mount point for old volume
+RUN mkdir -p /var/lib/nethermind-og && chown -R ${USER}:${USER} /var/lib/nethermind-og
 RUN mkdir -p /var/lib/nethermind/ee-secret && chown -R ${USER}:${USER} /var/lib/nethermind \
 && chmod -R 700 /var/lib/nethermind && chmod 777 /var/lib/nethermind/ee-secret
 

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -49,6 +49,8 @@ WORKDIR /nethermind
 COPY --from=build --chown=${USER}:${USER} /nethermind/out .
 
 RUN chown -R ${USER}:${USER} /nethermind
+# Create mount point for old volume
+RUN mkdir -p /var/lib/nethermind-og && chown -R ${USER}:${USER} /var/lib/nethermind-og
 RUN mkdir -p /var/lib/nethermind/ee-secret && chown -R ${USER}:${USER} /var/lib/nethermind \
 && chmod -R 700 /var/lib/nethermind && chmod 777 /var/lib/nethermind/ee-secret
 

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -6,6 +6,15 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu nethermind "${BASH_SOURCE[0]}" "$@"
 fi
 
+# Migrate from old to new volume
+if [[ -d /var/lib/nethermind-og && ! -f /var/lib/nethermind-og/migrationdone \
+    && $(ls -A /var/lib/nethermind-og/) ]]; then
+  echo "Migrating from old Nethermind volume to new one"
+  find /var/lib/nethermind-og/ -mindepth 1 -maxdepth 1 ! -name 'ee-secret' -exec mv -t /var/lib/nethermind/ {} +
+  touch /var/lib/nethermind-og/migrationdone
+  echo "Migration completed, data is now in volume \"nethermind-el-data\""
+fi
+
 # Move legacy xdai dir to gnosis
 if [ -d "/var/lib/nethermind/nethermind_db/xdai" ]; then
   mv /var/lib/nethermind/nethermind_db/xdai /var/lib/nethermind/nethermind_db/gnosis

--- a/prysm.yml
+++ b/prysm.yml
@@ -28,7 +28,8 @@ services:
     user: prysmconsensus
     stop_grace_period: 1m
     volumes:
-      - prysmbeacon-data:/var/lib/prysm
+      - prysmbeacon-data:/var/lib/prysm-og
+      - prysmconsensus-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/prysm/ee-secret
     environment:
@@ -248,6 +249,7 @@ services:
 
 volumes:
   prysmbeacon-data:
+  prysmconsensus-data:
   prysmvalidator-data:
   jwtsecret:
 

--- a/prysm/Dockerfile.binary
+++ b/prysm/Dockerfile.binary
@@ -36,6 +36,8 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/prysm-og && chown -R ${USER}:${USER} /var/lib/prysm-og
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/prysm/ee-secret && chown -R ${USER}:${USER} /var/lib/prysm && chmod -R 700 /var/lib/prysm && chmod 777 /var/lib/prysm/ee-secret
 

--- a/prysm/Dockerfile.source
+++ b/prysm/Dockerfile.source
@@ -46,6 +46,8 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+# Create mount point for old volume
+RUN mkdir -p /var/lib/prysm-og && chown -R ${USER}:${USER} /var/lib/prysm-og
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/prysm/ee-secret && chown -R ${USER}:${USER} /var/lib/prysm && chmod -R 700 /var/lib/prysm && chmod 777 /var/lib/prysm/ee-secret
 

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -6,6 +6,15 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu prysmconsensus docker-entrypoint.sh "$@"
 fi
 
+# Migrate from old to new volume
+if [[ -d /var/lib/prysm-og && ! -f /var/lib/prysm-og/migrationdone \
+    && $(ls -A /var/lib/prysm-og/) ]]; then
+  echo "Migrating from old Prysm volume to new one"
+  find /var/lib/prysm-og/ -mindepth 1 -maxdepth 1 ! -name 'ee-secret' -exec mv -t /var/lib/prysm/ {} +
+  touch /var/lib/prysm-og/migrationdone
+  echo "Migration completed, data is now in volume \"prysmconsensus-data\""
+fi
+
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/prysm/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"


### PR DESCRIPTION
Improves UX when switching between `client.yml` and `client-cl-only.yml`

Old volumes can then be removed after Pectra, when really everyone updated ethd and has gone through migration