### PR TITLE
Fixed sed command which appears to be broken on Mac

### DIFF
--- a/ethd
+++ b/ethd
@@ -648,20 +648,20 @@ ssv_switch() {
   echo "Making changes to ssv-config/config.yaml"
   var="NETWORK"
   NETWORK=$(sed -n -e "s/^${var}=\(.*\)/\1/p" "${ENV_FILE}" || true)
-  sed -i'' 's/blox-ssv2.yml/ssv.yml/' "${ENV_FILE}".source
+  sed -i '' 's/blox-ssv2.yml/ssv.yml/' "${ENV_FILE}".source
   if ! grep -q "LogFilePath:" ssv-config/config.yaml; then
-    sed -i'' '/global:/a\  LogFilePath: /tmp/ssv/debug.log' ssv-config/config.yaml
+    sed -i '' '/global:/a\  LogFilePath: /tmp/ssv/debug.log' ssv-config/config.yaml
   fi
   if ! grep -q "MetricsAPIPort:" ssv-config/config.yaml; then
-    sed -i'' '$a\MetricsAPIPort: 15000' ssv-config/config.yaml
+    sed -i '' '$a\MetricsAPIPort: 15000' ssv-config/config.yaml
   fi
   if ! grep -q "ssv:" ssv-config/config.yaml; then
     sed -i '/^  Network:/d' ssv-config/config.yaml # Remove old eth2 Network line if present
-    sed -i'' '$a\ssv:' ssv-config/config.yaml
+    sed -i '' '$a\ssv:' ssv-config/config.yaml
     if [ "${NETWORK}" = "holesky" ]; then
-      sed -i'' '$a\  Network: holesky' ssv-config/config.yaml
+      sed -i '' '$a\  Network: holesky' ssv-config/config.yaml
     elif [ "${NETWORK}" = "mainnet" ]; then
-      sed -i'' '$a\  Network: mainnet' ssv-config/config.yaml
+      sed -i '' '$a\  Network: mainnet' ssv-config/config.yaml
     else
       echo "${NETWORK} is not something that works with SSV."
       echo "Please fix this manually before running $__me update again."
@@ -2794,7 +2794,7 @@ query_dkg() {
     __ssv_operator_id=$(whiptail --title "Register SSV operator" --inputbox "\n1. Your SSV node public key:\n\n${__public_key}\n\n2. Register your operator in the SSV network with the public key\n\n3. Input your Operator ID \
 (right-click to paste)" 22 85 3>&1 1>&2 2>&3)
     if [[ -n "${__ssv_operator_id}" && ! "${__ssv_operator_id}" = "-1" ]]; then
-      sed -i'' "s|operatorID: .*|operatorID: ${__ssv_operator_id}|" ./ssv-config/dkg-config.yaml
+      sed -i '' "s|operatorID: .*|operatorID: ${__ssv_operator_id}|" ./ssv-config/dkg-config.yaml
       echo "Your SSV Operator ID is: ${__ssv_operator_id}"
     else
       echo "Please manually edit \"./ssv-config/dkg-config.yaml\" with your SSV Operator ID"
@@ -2915,9 +2915,9 @@ config() {
       ;;
     "ssv")
       if [ "${NETWORK}" = "holesky" ]; then
-        sed -i'' 's/  Network: .*/  Network: holesky/' ssv-config/config.yaml
+        sed -i '' 's/  Network: .*/  Network: holesky/' ssv-config/config.yaml
       elif [ "${NETWORK}" = "mainnet" ]; then
-        sed -i'' 's/  Network: .*/  Network: mainnet/' ssv-config/config.yaml
+        sed -i '' 's/  Network: .*/  Network: mainnet/' ssv-config/config.yaml
       else
         echo "${NETWORK} is not something that works with SSV."
         echo "Please choose Holešovice or Mainnet when running $__me config again"


### PR DESCRIPTION
The `sed` command as currently expressed appears to be not working on a Mac terminal. Simply adding a space after the `-i` argument appears to fix it:

```
massi@MacBook-Pro:~/dev/eth-docker|⇒   sed -i'' 's/  Network: .*/  Network: holesky/' ssv-config/config.yaml
sed: 1: "ssv-config/config.yaml": unterminated substitute pattern
massi@MacBook-Pro:~/dev/eth-docker|⇒   sed -i '' 's/  Network: .*/  Network: holesky/' ssv-config/config.yaml
massi@MacBook-Pro:~/dev/eth-docker|⇒  
```