### PR TITLE
add network label to services

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -79,6 +79,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=6060
       - metrics.instance=execution
+      - metrics.network=${NETWORK}
 
   set-prune-marker:
     profiles: ["tools"]

--- a/central-metrics.yml
+++ b/central-metrics.yml
@@ -21,3 +21,4 @@ services:
       - metrics.path=/metrics
       - metrics.port=9090
       - metrics.instance=ethereum-metrics-exporter
+      - metrics.network=${NETWORK}

--- a/erigon.yml
+++ b/erigon.yml
@@ -101,6 +101,7 @@ services:
       - metrics.path=/debug/metrics/prometheus
       - metrics.port=6060
       - metrics.instance=execution
+      - metrics.network=${NETWORK}
 
 volumes:
   erigon-el-data:

--- a/geth.yml
+++ b/geth.yml
@@ -81,6 +81,7 @@ services:
       - metrics.path=/debug/metrics/prometheus
       - metrics.port=6060
       - metrics.instance=execution
+      - metrics.network=${NETWORK}
 
 volumes:
   geth-eth1-data:

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -39,6 +39,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9090
       - metrics.instance=prometheus
+      - metrics.network=${NETWORK}
 
   ethereum-metrics-exporter:
     restart: "unless-stopped"
@@ -77,6 +78,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9100
       - metrics.instance=node-exporter
+      - metrics.network=${NETWORK}
 
   blackbox-exporter:
     restart: "unless-stopped"
@@ -103,6 +105,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=7979
       - metrics.instance=json-exporter
+      - metrics.network=${NETWORK}
 
   cadvisor:
     restart: "unless-stopped"
@@ -122,6 +125,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8080
       - metrics.instance=cadvisor
+      - metrics.network=${NETWORK}
 
   promtail:
     image: grafana/promtail:latest
@@ -142,6 +146,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9080
       - metrics.instance=promtail
+      - metrics.network=${NETWORK}
 
 volumes:
   prom-data:

--- a/grafana.yml
+++ b/grafana.yml
@@ -31,6 +31,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9090
       - metrics.instance=prometheus
+      - metrics.network=${NETWORK}
 
   ethereum-metrics-exporter:
     restart: "unless-stopped"
@@ -45,6 +46,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9090
       - metrics.instance=ethereum-metrics-exporter
+      - metrics.network=${NETWORK}
 
   node-exporter:
     image: prom/node-exporter:latest
@@ -69,6 +71,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9100
       - metrics.instance=node-exporter
+      - metrics.network=${NETWORK}
 
   blackbox-exporter:
     restart: "unless-stopped"
@@ -95,6 +98,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=7979
       - metrics.instance=json-exporter
+      - metrics.network=${NETWORK}
 
   cadvisor:
     restart: "unless-stopped"
@@ -114,6 +118,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8080
       - metrics.instance=cadvisor
+      - metrics.network=${NETWORK}
 
   promtail:
     image: grafana/promtail:latest
@@ -136,6 +141,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9080
       - metrics.instance=promtail
+      - metrics.network=${NETWORK}
 
   loki:
     image: grafana/loki:latest
@@ -151,6 +157,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=3100
       - metrics.instance=loki
+      - metrics.network=${NETWORK}
 
   grafana:
     restart: "unless-stopped"
@@ -179,6 +186,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=3000
       - metrics.instance=grafana
+      - metrics.network=${NETWORK}
 
 volumes:
   grafana-data:

--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -105,6 +105,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   wipe-db:
     profiles: ["tools"]

--- a/grandine-cl-only.yml
+++ b/grandine-cl-only.yml
@@ -94,6 +94,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   wipe-db:
     profiles: ["tools"]

--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -86,6 +86,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   set-cl-prune-marker:
     profiles: ["tools"]

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -77,6 +77,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -91,6 +91,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   validator:
     restart: "unless-stopped"
@@ -155,6 +156,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -85,6 +85,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
 volumes:
   lsconsensus-data:

--- a/lodestar-vc-only.yml
+++ b/lodestar-vc-only.yml
@@ -71,6 +71,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -87,6 +87,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   validator:
     restart: "unless-stopped"
@@ -145,6 +146,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -89,6 +89,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=6060
       - metrics.instance=execution
+      - metrics.network=${NETWORK}
 
 volumes:
   nm-eth1-data:

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -84,6 +84,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   wipe-db:
     profiles: ["tools"]

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -80,6 +80,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
 # Uses keystore-m file and CL, so does belong here
   validator-exit:

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -63,6 +63,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -80,6 +80,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   validator:
     restart: "unless-stopped"
@@ -126,6 +127,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/prometheus/base-config.yml
+++ b/prometheus/base-config.yml
@@ -58,6 +58,8 @@ scrape_configs:
           source_labels:
           - __meta_docker_container_label_metrics_instance
           target_label: instance
+        - source_labels: [__meta_docker_container_label_metrics_network]
+          target_label: network
 
 scrape_config_files:
   - /etc/prometheus/conf.d/*.yml

--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -89,6 +89,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
 volumes:
   prysmconsensus-data:

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -80,6 +80,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   create-wallet:
     profiles: ["tools"]

--- a/prysm.yml
+++ b/prysm.yml
@@ -91,6 +91,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   validator:
     restart: "unless-stopped"
@@ -156,6 +157,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   create-wallet:
     profiles: ["tools"]

--- a/reth.yml
+++ b/reth.yml
@@ -89,6 +89,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=6060
       - metrics.instance=execution
+      - metrics.network=${NETWORK}
 
 volumes:
   reth-el-data:

--- a/ssv.yml
+++ b/ssv.yml
@@ -28,6 +28,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=15000
       - metrics.instance=ssv-node
+      - metrics.network=${NETWORK}
 
 volumes:
   ssv-data:

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -91,6 +91,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   wipe-db:
     profiles: ["tools"]

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -82,6 +82,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
 volumes:
   tekuconsensus-data:

--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -67,6 +67,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/teku.yml
+++ b/teku.yml
@@ -82,6 +82,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8008
       - metrics.instance=consensus
+      - metrics.network=${NETWORK}
 
   validator:
     restart: "unless-stopped"
@@ -134,6 +135,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8009
       - metrics.instance=validator
+      - metrics.network=${NETWORK}
 
   validator-exit:
     profiles: ["tools"]

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -51,6 +51,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8080
       - metrics.instance=traefik
+      - metrics.network=${NETWORK}
     <<: *logging
 
 volumes:

--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -45,6 +45,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=8080
       - metrics.instance=traefik
+      - metrics.network=${NETWORK}
     <<: *logging
 
   cf-ddns:

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -45,6 +45,7 @@ services:
       - metrics.path=/metrics
       - metrics.port=9001
       - metrics.instance=web3signer
+      - metrics.network=${NETWORK}
 
   postgres:
     restart: "unless-stopped"


### PR DESCRIPTION
This will add a network label for every service there is metrics.scrape label. This label will be used by prometheus together with the rest when scraping the services for metrics and allow one to differentiate in promQL and/or grafana query between instances of eth-docker running on different networks like sepolia, mainnet, holesky...etc

When this is used together with `https://github.com/CryptoManufaktur-io/central-proxy-docker` then prometheus will add a label network with the value of eth-docker network to all metrics scrapped