### PR TITLE
Lodestar 1.20 flags update

### DIFF
--- a/lodestar.yml
+++ b/lodestar.yml
@@ -61,8 +61,6 @@ services:
       - 0.0.0.0
       - --rest.port
       - ${CL_REST_PORT:-5052}
-      - --rest.namespace
-      - "beacon,config,events,node,validator,lightclient,debug"
       - --port
       - ${CL_P2P_PORT:-9000}
       - --nat

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -126,6 +126,8 @@ services:
       - /var/lib/lodestar/validators
       - --beaconNodes
       - ${CL_NODE}
+      - --http.requestWireFormat
+      - "ssz"
       - --keymanager
       - --keymanager.address
       - 0.0.0.0


### PR DESCRIPTION
With latest release (v1.20.0) we can remove the namespace flag as debug is enabled by default, and also enable SSZ requests for all APIs in the Lodestar-only setup.