### PR TITLE
Switch Lodestar docker build to debian

### DIFF
--- a/lodestar/Dockerfile.binary
+++ b/lodestar/Dockerfile.binary
@@ -7,7 +7,7 @@ FROM ${DOCKER_REPO}:${DOCKER_TAG}
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apk update && apk add --no-cache ca-certificates tzdata bash su-exec git && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/Dockerfile.binary
+++ b/lodestar/Dockerfile.binary
@@ -7,7 +7,7 @@ FROM ${DOCKER_REPO}:${DOCKER_TAG}
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash su-exec git && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash gosu git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/Dockerfile.binary
+++ b/lodestar/Dockerfile.binary
@@ -7,7 +7,7 @@ FROM ${DOCKER_REPO}:${DOCKER_TAG}
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash su-exec git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -7,7 +7,7 @@ ARG DOCKER_REPO
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git g++ make python3 python3-setuptools bash && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/app
 
@@ -18,7 +18,7 @@ RUN bash -c "cd .. && rm -rf app && git clone ${SRC_REPO} app && cd app && git c
 
 FROM node:22.4-slim
 
-RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash su-exec git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:22.4-slim AS builder
 
 # Here only to avoid build-time errors
 ARG DOCKER_TAG
@@ -7,7 +7,7 @@ ARG DOCKER_REPO
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apk update && apk add --no-cache git g++ make python3 py3-setuptools bash && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/app
 
@@ -16,9 +16,9 @@ RUN bash -c "cd .. && rm -rf app && git clone ${SRC_REPO} app && cd app && git c
   && if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:ls-pr; git checkout ls-pr; else git checkout ${BUILD_TARGET}; fi \
   && yarn install --non-interactive --frozen-lockfile && yarn build"
 
-FROM node:22-alpine
+FROM node:22.4-slim
 
-RUN apk update && apk add --no-cache ca-certificates tzdata bash su-exec git && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -18,7 +18,7 @@ RUN bash -c "cd .. && rm -rf app && git clone ${SRC_REPO} app && cd app && git c
 
 FROM node:22.4-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash su-exec git && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash gosu git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG USER=lsconsensus
 ARG UID=10002

--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ "$(id -u)" = '0' ]; then
   chown -R lsvalidator:lsvalidator /var/lib/lodestar
-  exec su-exec lsvalidator docker-entrypoint.sh "$@"
+  exec gosu lsvalidator docker-entrypoint.sh "$@"
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ "$(id -u)" = '0' ]; then
   chown -R lsconsensus:lsconsensus /var/lib/lodestar
-  exec su-exec lsconsensus docker-entrypoint.sh "$@"
+  exec gosu lsconsensus docker-entrypoint.sh "$@"
 fi
 
 # Remove old low-entropy token, related to Sigma Prime security audit


### PR DESCRIPTION
We are switching the node base image in our next release from alpine to debian.

See https://github.com/ChainSafe/lodestar/pull/7004 for rationale / more details.

Keeping as draft until release is out. I think I caught all relevant places and at least binary deploy works for me with our current rc.