### PR TITLE
Teku VC - use default for early-attestations-enabled

### DIFF
--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -48,7 +48,6 @@ services:
       - --data-path=/var/lib/teku
       - --log-destination=CONSOLE
       - --validator-keys=/var/lib/teku/validator-keys:/var/lib/teku/validator-passwords
-      - --validators-early-attestations-enabled=false
       - --validator-api-enabled=true
       - --validator-api-interface=0.0.0.0
       - --validator-api-port=${KEY_API_PORT:-7500}


### PR DESCRIPTION
Teku as a stand alone validator client was producing delayed attestations compared to other validator clients on the same machine.  Digging into the settings, I found that this is due to the '--validators-early-attestations-enabled=false' setting in the teku-vc-only.yml file.  [Teku documentation](https://docs.teku.consensys.io/reference/cli) states that "The default is true.
  Set this option to false if running a validator client connected to a load balanced beacon node (including most hosted beacon nodes such as [Infura](https://infura.io/)), and validator effectiveness is poor."  In my opinion, it should just use the default behavior since according to the documentation the non-default setting is not for a standard home staking setup.  Note also that the teku-allin1.yml file does not have this setting, so this PR brings the two files related to Teku validator clients into alignment.