### PR TITLE
Fix dkg_output mod update asking for sudo when not needed

### DIFF
--- a/ethd
+++ b/ethd
@@ -203,9 +203,12 @@ prep_conffiles() {
     ${__as_owner} cp ssv-config/dkg-config-sample.yaml ssv-config/dkg-config.yaml
   fi
 # Make sure local user owns the dkg output dir and everything in it
-  if find .eth/dkg_output \! -user "${OWNER}" -o \! -group "${OWNER_GROUP}" -o \! -perm 755 | grep -q .; then
+  if find .eth/dkg_output \! -user "${OWNER}" -o \! -group "${OWNER_GROUP}" | grep -q .; then
     ${__auto_sudo} chown -R "${OWNER}:${OWNER_GROUP}" .eth/dkg_output
-    ${__auto_sudo} chmod -R 755 .eth/dkg_output
+  fi
+# Make sure the dkg output dir and its contents are mod 0755
+  if find .eth/dkg_output \! -perm 755 | grep -q .; then
+    chmod -R 755 .eth/dkg_output
   fi
 # Create ext-network.yml if it doesn't exist
   if [ ! -f "ext-network.yml" ]; then


### PR DESCRIPTION
If a user already owns .eth/dkg_output, there is no need to escalate to root to fix its non-0755 perms. Instead, just run the chmod as the current user.