### PR TITLE
Nethermind cachemb

### DIFF
--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -75,8 +75,7 @@ else
     fi
   fi
   if [ "${__memtotal}" -ge 30 ]; then
-# Investigating instability
-    __prune="${__prune} --Pruning.CacheMb=4096 --Pruning.FullPruningMemoryBudgetMb=16384 --Init.StateDbKeyScheme=HalfPath"
+    __prune="${__prune} --Pruning.FullPruningMemoryBudgetMb=16384 --Init.StateDbKeyScheme=HalfPath"
   fi
   echo "Using pruning parameters:"
   echo "${__prune}"


### PR DESCRIPTION
Do not increase `Pruning.CacheMb` based on RAM.

Users report the higher amount causes longer in-memory pruning runs and missed attestations.

Nethermind team as well recommend not touching the default, for performance reasons.
