### PR TITLE
Prysm resolve w3s warnings

### DIFF
--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -60,7 +60,6 @@ services:
       - 0.0.0.0
       - --monitoring-port
       - "8009"
-      - --web
       - --grpc-gateway-host
       - 0.0.0.0
       - --grpc-gateway-port
@@ -70,8 +69,6 @@ services:
       - consensus:5052
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --wallet-password-file
-      - /var/lib/prysm/password.txt
     labels:
       - traefik.enable=true
       - traefik.http.routers.prysm.entrypoints=web,websecure

--- a/prysm.yml
+++ b/prysm.yml
@@ -139,7 +139,6 @@ services:
       - 0.0.0.0
       - --monitoring-port
       - "8009"
-      - --web
       - --grpc-gateway-host
       - 0.0.0.0
       - --grpc-gateway-port
@@ -149,8 +148,6 @@ services:
       - consensus:5052
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --wallet-password-file
-      - /var/lib/prysm/password.txt
     depends_on:
       - consensus
     labels:

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -49,7 +49,7 @@ fi
 if [ "${WEB3SIGNER}" = "true" ]; then
   __w3s_url="--validators-external-signer-url http://web3signer:9000 --validators-external-signer-public-keys http://web3signer:9000/api/v1/eth2/publicKeys"
 else
-  __w3s_url=""
+  __w3s_url="--web --wallet-password-file /var/lib/prysm/password.txt"
 fi
 
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then


### PR DESCRIPTION
Resolve warnings caused by `--web` and `--wallet-password-file` when starting the Prysm validator with web3signer.