### PR TITLE
Remove Prysm deprecated `--enable-debug-rpc-endpoints`

### DIFF
--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -87,7 +87,6 @@ services:
       - "8008"
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --enable-debug-rpc-endpoints
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/prysm.yml
+++ b/prysm.yml
@@ -89,7 +89,6 @@ services:
       - "8008"
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --enable-debug-rpc-endpoints
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics


### PR DESCRIPTION
Deprecated with Prysm `v5.1.0`. Removal now means no failures later.