### PR TITLE
Fix grafana

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -67,7 +67,7 @@ services:
     pid: host
     restart: unless-stopped
     volumes:
-      - '/:/host:ro,rslave'
+      - /:/host:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -112,10 +112,10 @@ services:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /:/rootfs:ro
+      - /:/rootfs:ro,rslave
       - /var/run:/var/run
       - /sys:/sys:ro
-      - /var/lib/docker:/var/lib/docker:ro
+      - /var/lib/docker:/var/lib/docker:ro,rslave
     command:
       - --docker_only
       - --housekeeping_interval=30s
@@ -134,7 +134,7 @@ services:
       - /etc/machine-id:/etc/machine-id:ro
       - ./promtail:/etc/promtail
       - promtail-data:/tmp
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro,rslave
     entrypoint: ./etc/promtail/entrypoint.sh
     command: ["/usr/bin/promtail"]
     environment:

--- a/grafana.yml
+++ b/grafana.yml
@@ -60,7 +60,7 @@ services:
     pid: host
     restart: unless-stopped
     volumes:
-      - '/:/host:ro,rslave'
+      - /:/host:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -105,10 +105,10 @@ services:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /:/rootfs:ro
+      - /:/rootfs:ro,rslave
       - /var/run:/var/run
       - /sys:/sys:ro
-      - /var/lib/docker:/var/lib/docker:ro
+      - /var/lib/docker:/var/lib/docker:ro,rslave
     command:
       - --docker_only
       - --housekeeping_interval=30s
@@ -127,7 +127,7 @@ services:
       - /etc/machine-id:/etc/machine-id:ro
       - ./promtail:/etc/promtail
       - promtail-data:/tmp
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro,rslave
     entrypoint: ./etc/promtail/entrypoint.sh
     command: ["/usr/bin/promtail"]
     environment:


### PR DESCRIPTION
Docker 27.3.0 enforces `rslave` or `rshared` on any bind mount that contain its data root.