### PR TITLE
Update ddns-updater config for 2.8

### DIFF
--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -53,7 +53,7 @@ services:
     restart: "unless-stopped"
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - 'CONFIG={"settings": [{"provider": "cloudflare", "zone_identifier": "${CF_ZONE_ID}", "domain": "${DOMAIN}", "host": "${DDNS_SUBDOMAIN}", "ttl": 1, "token": "${CF_DNS_API_TOKEN}", "proxied": ${DDNS_PROXY}, "ip_version": "ipv4"}]}'
+      - 'CONFIG={"settings": [{"provider": "cloudflare", "zone_identifier": "${CF_ZONE_ID}", "domain": "${DDNS_SUBDOMAIN}.${DOMAIN}", "ttl": 1, "token": "${CF_DNS_API_TOKEN}", "proxied": ${DDNS_PROXY}, "ip_version": "ipv4"}]}'
     volumes:
       - /etc/localtime:/etc/localtime:ro
     <<: *logging


### PR DESCRIPTION
ddns-updater upstream deprecated `host` and folded that into `domain`