### PR TITLE
Prysm http

### DIFF
--- a/.github/workflows/test-prysm-geth.yml
+++ b/.github/workflows/test-prysm-geth.yml
@@ -31,6 +31,9 @@ jobs:
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
+          CL_NODE=consensus:4000
+          var=CL_NODE
+          set_value_in_env
       - name: Start Prysm/Geth
         run: ./ethd up
       - name: Pause for 30 seconds

--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -56,9 +56,9 @@ services:
       - /var/lib/prysm/
       - --rpc-host
       - 0.0.0.0
-      - --grpc-gateway-host
+      - --http-host
       - 0.0.0.0
-      - --grpc-gateway-port
+      - --http-port
       - ${CL_REST_PORT:-5052}
       # Allow larger messages so credential change messages can be sent
       - --rpc-max-page-size

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -53,7 +53,7 @@ services:
       - --keymanager-token-file
       - /var/lib/prysm/auth-token
       - --beacon-rpc-provider
-      - ${CL_NODE:-http://consensus:4000}
+      - ${CL_NODE:-consensus:4000}
       - --verbosity
       - ${LOG_LEVEL}
       - --accept-terms-of-use
@@ -61,18 +61,13 @@ services:
       - 0.0.0.0
       - --monitoring-port
       - "8009"
-      - --grpc-gateway-host
+      - --http-host
       - 0.0.0.0
-      - --grpc-gateway-port
+      - --http-port
       - ${KEY_API_PORT:-7500}
-      - --grpc-gateway-corsdomain=*
-      - --beacon-rpc-gateway-provider
-      - consensus:5052
+      - --http-cors-domain=*
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --enable-beacon-rest-api
-      - --beacon-rest-api-provider
-      - ${CL_NODE:-http://consensus:5052}
     labels:
       - traefik.enable=true
       - traefik.http.routers.prysm.entrypoints=web,websecure
@@ -114,9 +109,7 @@ services:
       - validator
       - exit
       - --wallet-dir=/var/lib/prysm/
-      - --enable-beacon-rest-api
-      - --beacon-rest-api-provider
-      - ${CL_NODE:-http://consensus:5052}
+      - --beacon-rpc-provider=${CL_NODE:-consensus:4000}
       - --wallet-password-file=/var/lib/prysm/password.txt
       - --${NETWORK}
 

--- a/prysm.yml
+++ b/prysm.yml
@@ -57,11 +57,11 @@ services:
       - /var/lib/prysm/
       - --rpc-host
       - 0.0.0.0
-      - --grpc-gateway-host
+      - --http-host
       - 0.0.0.0
-      - --grpc-gateway-port
+      - --http-port
       - ${CL_REST_PORT:-5052}
-      - --grpc-gateway-corsdomain=*
+      - --http-cors-domain=*
       # Allow larger messages so credential change messages can be sent
       - --rpc-max-page-size
       - "200000"
@@ -139,18 +139,15 @@ services:
       - 0.0.0.0
       - --monitoring-port
       - "8009"
-      - --grpc-gateway-host
+      - --http-host
       - 0.0.0.0
-      - --grpc-gateway-port
+      - --http-port
       - ${KEY_API_PORT:-7500}
-      - --grpc-gateway-corsdomain=*
-      - --beacon-rpc-gateway-provider
+      - --http-cors-domain=*
+      - --beacon-rest-api-provider
       - consensus:5052
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-      - --enable-beacon-rest-api
-      - --beacon-rest-api-provider
-      - ${CL_NODE:-http://consensus:5052}
     depends_on:
       - consensus
     labels:
@@ -194,9 +191,7 @@ services:
       - validator
       - exit
       - --wallet-dir=/var/lib/prysm/
-      - --enable-beacon-rest-api
-      - --beacon-rest-api-provider
-      - ${CL_NODE:-http://consensus:5052}
+      - --beacon-rpc-provider=consensus:4000
       - --wallet-password-file=/var/lib/prysm/password.txt
       - --${NETWORK}
     depends_on:


### PR DESCRIPTION
The CSM work switched Prysm to REST, which is still experimental. Undid that

The latest Prsym uses `--http` instead of `--grpc-gateway`, make that change