### PR TITLE
Lighthouse archive node aggressively backfills

### DIFF
--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -60,7 +60,7 @@ if [ -n "${RAPID_SYNC_URL}" ]; then
   echo "Checkpoint sync enabled"
   if [ "${ARCHIVE_NODE}" = "true" ]; then
     echo "Lighthouse archive node without pruning"
-    __prune="--reconstruct-historic-states --genesis-backfill"
+    __prune="--reconstruct-historic-states --genesis-backfill --disable-backfill-rate-limiting"
   else
     __prune=""
   fi


### PR DESCRIPTION
3 days instead of 2 weeks

This does assume an archive node has the oomph to handle it ... but arguably it better