### PR TITLE
Switch Erigon users to new repo

### DIFF
--- a/erigon/Dockerfile.binary
+++ b/erigon/Dockerfile.binary
@@ -14,7 +14,16 @@ ARG GID=10002
 
 USER root
 
-RUN apk --no-cache add shadow bash su-exec git jq && groupmod -g "${GID}" ${USER} && usermod -u "${UID}" -g "${GID}" ${USER}
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
+  ca-certificates \
+  tzdata \
+  gosu \
+  git \
+  jq \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN groupmod -g "${GID}" ${USER} && usermod -u "${UID}" -g "${GID}" ${USER}
 
 RUN mkdir -p /var/lib/erigon/ee-secret && chown -R ${USER}:${USER} /var/lib/erigon && chmod -R 700 /var/lib/erigon && chmod 777 /var/lib/erigon/ee-secret
 

--- a/erigon/Dockerfile.source
+++ b/erigon/Dockerfile.source
@@ -1,5 +1,5 @@
 # Build Erigon in a stock Go build container
-FROM golang:1.23-alpine AS builder
+FROM golang:1.23-bookworm AS builder
 
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG
@@ -8,21 +8,26 @@ ARG DOCKER_REPO
 ARG BUILD_TARGET
 ARG SRC_REPO
 
-RUN apk update && apk add --no-cache make gcc g++ musl-dev linux-headers git bash
-
 WORKDIR /src
-RUN bash -c "git clone --recurse-submodules -j8 ${SRC_REPO} erigon && cd erigon && git config advice.detachedHead false && git fetch --all --tags && \
+RUN bash -c "git clone ${SRC_REPO} erigon && cd erigon && git config advice.detachedHead false && git fetch --all --tags && \
 if [[ ${BUILD_TARGET} =~ pr-.+ ]]; then git fetch origin pull/$(echo ${BUILD_TARGET} | cut -d '-' -f 2)/head:erigon-pr; git checkout erigon-pr; else git checkout ${BUILD_TARGET}; fi && make BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon"
 
 # Pull all binaries into a second stage deploy container
-FROM alpine:3
+FROM debian:bookworm-slim
 
 ARG USER=erigon
 ARG UID=10001
 # GID 10002 is deliberate so it can exchange secret with CL
 ARG GID=10002
 
-RUN apk add --no-cache libgcc libstdc++ bash ca-certificates tzdata su-exec git jq
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
+  ca-certificates \
+  tzdata \
+  gosu \
+  git \
+  jq \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup \
     --gid "${GID}" \

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ "$(id -u)" = '0' ]; then
   chown -R erigon:erigon /var/lib/erigon
-  exec su-exec erigon "${BASH_SOURCE[0]}" "$@"
+  exec gosu erigon "${BASH_SOURCE[0]}" "$@"
 fi
 
 if [ -n "${JWT_SECRET}" ]; then

--- a/ethd
+++ b/ethd
@@ -1167,12 +1167,12 @@ __env_migrate() {
         if [[ "${__var}" = "LH_DOCKER_TAG" && "${__value}" = "latest-modern" ]]; then # LH 5.2 ditched latest-modern
           __value="latest"
         fi
-#        if [[ "${__var}" = "ERIGON_DOCKER_TAG" && "${__value}" = "stable" ]]; then # Erigon switched to latest
-#          __value="latest"
-#        fi
-#        if [[ "${__var}" = "ERIGON_DOCKER_REPO" && "${__value}" = "thorax/erigon" ]]; then # Erigon new repo
-#          __value="erigontech/erigon"
-#        fi
+        if [[ "${__var}" = "ERIGON_DOCKER_TAG" && "${__value}" = "stable" ]]; then # Erigon switched to latest
+          __value="latest"
+        fi
+        if [[ "${__var}" = "ERIGON_DOCKER_REPO" && "${__value}" = "thorax/erigon" ]]; then # Erigon new repo
+          __value="erigontech/erigon"
+        fi
         sed -i'.original' -e "s~^\(${__var}\s*=\s*\).*$~\1${__value}~" "${__env_file}"
       fi
     done

--- a/grandine/Dockerfile.source
+++ b/grandine/Dockerfile.source
@@ -30,7 +30,6 @@ RUN set -eux; \
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
-  wget \
   tzdata \
   git \
   curl \

--- a/reth/Dockerfile.binary
+++ b/reth/Dockerfile.binary
@@ -15,7 +15,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   tzdata \
   gosu \
   git \
-  wget \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/reth/Dockerfile.source
+++ b/reth/Dockerfile.source
@@ -27,7 +27,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   tzdata \
   gosu \
   git \
-  wget \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This new image supports amd64 again, and `latest` tag works

The Erigon team switched from alpine to debian

Unrelated cleanup: Remove unused `wget` from Reth, and Grandine source build

Erigon source build was tested locally, as there is no CI for source builds