### PR TITLE
Better logs for Reth existing and new sync

### DIFF
--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -82,9 +82,7 @@ fi
 
 if [ "${ARCHIVE_NODE}" = "true" ]; then
   echo "Reth archive node without pruning"
-  __prune=""
 else
-  __prune="--full"
   if [ ! -f "/var/lib/reth/reth.toml" ]; then  # Configure ssv, rocketpool, stakewise contracts
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
@@ -121,5 +119,5 @@ if [ -f /var/lib/reth/prune-marker ]; then
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__verbosity} ${__prune} ${__static} ${EL_EXTRAS}
+  exec "$@" ${__network} ${__verbosity} ${__static} ${EL_EXTRAS}
 fi


### PR DESCRIPTION
This doesn't change the actual behavior for existing `--full` or new syncs; but it improves the logs. 

Previous: Both new sync and old sync would show they are filtering receipts.

Now: New sync shows it's not filtering receipts, old sync shows it is filtering receipts

**No** change to actual pruning behavior, this only impacts logging on startup to make it accurate
