### PR TITLE
Do not conflict v6 p2p with prometheus

### DIFF
--- a/default.env
+++ b/default.env
@@ -94,7 +94,7 @@ PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000
 CL_QUIC_PORT=9001
 # Some clients need a separate port for IPv6
-CL_IPV6_P2P_PORT=9090
+CL_IPV6_P2P_PORT=9010
 # Local grafana dashboard port. Do not expose to Internet, it is insecure http
 GRAFANA_PORT=3000
 # Local Siren UI port


### PR DESCRIPTION
Some users may run prometheus in systemd, and this would create a conflict when upgrading and V6 is enabled. Happened to 1 user so far.