### PR TITLE
feat: :sparkles: added max peers to Reth (EL)

### DIFF
--- a/reth.yml
+++ b/reth.yml
@@ -84,7 +84,7 @@ services:
       - --authrpc.jwtsecret
       - /var/lib/reth/ee-secret/jwtsecret
       - --max-outbound-peers
-      - ${EL_MAX_PEER_COUNT:-50}
+      - ${EL_MAX_PEER_COUNT:-100}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/reth.yml
+++ b/reth.yml
@@ -83,6 +83,8 @@ services:
       - ${EE_PORT:-8551}
       - --authrpc.jwtsecret
       - /var/lib/reth/ee-secret/jwtsecret
+      - --max-outbound-peers
+      - ${EL_MAX_PEER_COUNT:-50}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics


### PR DESCRIPTION
Adds the maximum number of peers that can connect to Reth using the `EL_MAX_PEER_COUNT`` variable of the .env

Note: the default value in reth is 100, but I set it to 50 following Geht (EL) configuration, even with the value in my local .env at 40 peers it works fine. If necessary I can change it to 100


docs: https://reth.rs/cli/reth/node.html?highlight=MAX_OUTBOUND_PEERS#reth-node

```txt
--max-outbound-peers <MAX_OUTBOUND_PEERS>
          Maximum number of outbound requests. default: 100
```


![image](https://github.com/user-attachments/assets/ee7d5281-bf5d-473b-aa93-52d85c6791b9)


