### PR TITLE
Typo Update docker-entrypoint.sh

### DIFF
--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
   branch=$(awk -F'/tree/' '{print $2}' <<< "${NETWORK}" | cut -d'/' -f1)
   config_dir=$(awk -F'/tree/' '{print $2}' <<< "${NETWORK}" | cut -d'/' -f2-)
   echo "This appears to be the ${repo} repo, branch ${branch} and config directory ${config_dir}."
-  # For want of something more amazing, let's just fail if git fails to pull this
+  # For lack of something more sophisticated, let's just fail if git fails to pull this
   set -e
   if [ ! -d "/var/lib/lodestar/consensus/testnet/${config_dir}" ]; then
     mkdir -p /var/lib/lodestar/consensus/testnet


### PR DESCRIPTION
**Description**:  
This pull request addresses an issue with an unclear phrase in the bash script comments. The original comment reads:

```bash
# For want of something more amazing, let's just fail if git fails to pull this
```

The phrase "For want of something more amazing" is not incorrect from a technical perspective but sounds awkward and informal. A clearer, more appropriate version would be:

```bash
# For lack of something more sophisticated, let's just fail if git fails to pull this
```

**Importance**:  
While the original phrase is understandable, it could lead to confusion or misinterpretation due to its informality. By adjusting the wording to something more conventional, we ensure better readability and clarity in the script, especially for future developers who might maintain or contribute to this project. This small change helps improve the professionalism of the code and ensures that the comment communicates the intent clearly.
