### PR TITLE
support multiple consensus nodes in nimbus-vc

### DIFF
--- a/default.env
+++ b/default.env
@@ -167,7 +167,6 @@ DISTRIBUTED=
 EL_NODE=http://execution:8551
 # Consensus client address. This could be comma-separated for Lighthouse, Nimbus or Teku VC clients, with failover,
 # or could just be a remote consensus client URL for "validator only" setups.
-# For Nimbus VC client, put the first beacon node here, and use VC_EXTRAS for additional.
 CL_NODE=http://consensus:5052
 # MEV-boost address. This would only be changed for Vouch setups
 MEV_NODE=http://mev-boost:18550

--- a/default.env
+++ b/default.env
@@ -165,7 +165,7 @@ JWT_SECRET=
 DISTRIBUTED=
 # Authenticated execution client endpoint. This default uses the execution node container.
 EL_NODE=http://execution:8551
-# Consensus client address. This could be comma-separated for Lighthouse or Teku VC clients, with failover,
+# Consensus client address. This could be comma-separated for Lighthouse, Nimbus or Teku VC clients, with failover,
 # or could just be a remote consensus client URL for "validator only" setups.
 # For Nimbus VC client, put the first beacon node here, and use VC_EXTRAS for additional.
 CL_NODE=http://consensus:5052

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -32,6 +32,7 @@ services:
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
       - MEV_BOOST=${MEV_BOOST}
+      - CL_NODE=${CL_NODE}
       - DOPPELGANGER=${DOPPELGANGER}
       - LOG_LEVEL=${LOG_LEVEL}
       - VC_EXTRAS=${VC_EXTRAS:-}
@@ -49,7 +50,6 @@ services:
       - /usr/local/bin/nimbus_validator_client
       - --data-dir=/var/lib/nimbus
       - --non-interactive
-      - --beacon-node=${CL_NODE}
       - --metrics
       - --metrics-port=8009
       - --metrics-address=0.0.0.0

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -32,7 +32,7 @@ else
   __mev_boost=""
 fi
 
-# accomodate comma separated list of concensus nodes
+# accomodate comma separated list of consensus nodes
 NODES=$(echo $CL_NODE | tr ',' ' ')
 for NODE in $NODES; do
   __beacon_nodes="$__beacon_nodes --beacon-node=$NODE"

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -33,10 +33,10 @@ else
 fi
 
 # accomodate comma separated list of consensus nodes
-NODES=$(echo "$CL_NODE" | tr ',' ' ')
+__nodes=$(echo "$CL_NODE" | tr ',' ' ')
 __beacon_nodes=()
-for NODE in $NODES; do
-  __beacon_nodes+=("--beacon-node=$NODE")
+for __node in $__nodes; do
+  __beacon_nodes+=("--beacon-node=$__node")
 done
 
 __log_level="--log-level=${LOG_LEVEL^^}"

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -33,9 +33,10 @@ else
 fi
 
 # accomodate comma separated list of consensus nodes
-NODES=$(echo $CL_NODE | tr ',' ' ')
+NODES=$(echo "$CL_NODE" | tr ',' ' ')
+__beacon_nodes=()
 for NODE in $NODES; do
-  __beacon_nodes="$__beacon_nodes --beacon-node=$NODE"
+  __beacon_nodes+=("--beacon-node=$NODE")
 done
 
 __log_level="--log-level=${LOG_LEVEL^^}"
@@ -66,9 +67,9 @@ fi
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@"${__beacon_nodes} ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" ${__beacon_nodes[@]} ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@"${__beacon_nodes} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" ${__beacon_nodes[@]} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 fi

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -32,6 +32,12 @@ else
   __mev_boost=""
 fi
 
+# accomodate comma separated list of concensus nodes
+NODES=$(echo $CL_NODE | tr ',' ' ')
+for NODE in $NODES; do
+  __beacon_nodes="$__beacon_nodes --beacon-node=$NODE"
+done
+
 __log_level="--log-level=${LOG_LEVEL^^}"
 
 # Web3signer URL
@@ -60,9 +66,9 @@ fi
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@"${__beacon_nodes} ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@"${__beacon_nodes} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 fi

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -67,9 +67,9 @@ fi
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__beacon_nodes[@]} ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__beacon_nodes[@]} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__att_aggr} ${VC_EXTRAS}
 fi


### PR DESCRIPTION
pass CL_NODE into docker-entrypoint-vc.sh script, parse in script giving ability to pass multiple '--beacon-node=http://blah:5052' to the validator client via comma separated .env CL_NODE in the same way that you can with other validator clients
(refer to https://nimbus.guide/validator-client-options.html)