### PR TITLE
Enhance Message Clarity with Improved Grammar

### DIFF
--- a/default.env
+++ b/default.env
@@ -114,7 +114,7 @@ EL_RPC_PORT=8545
 # Note that for Erigon, this needs to match EL_RPC_PORT *if* you use traefik, and only then
 # Do not change it for Erigon and el-shared.yml
 EL_WS_PORT=8546
-# Erigon's torrent port. Don't make this 42070, that'll fail
+# Erigon's torrent port. Don't make this 42070, as it will fail
 ERIGON_TORRENT_PORT=42069
 # Erigon's second and third P2P port, used for multiple eth/xx P2P protocols
 ERIGON_P2P_PORT_2=30304

--- a/ethd
+++ b/ethd
@@ -410,7 +410,7 @@ __get_docker_free_space() { # set __free_space to what's available to Docker
 
   __regex='^[0-9]+$'
   if ! [[ "${__free_space}" =~ $__regex ]] ; then
-    echo "Unable to determine free disk space. This is likely a bug."
+    echo "Unable to determine free disk space. This is likely to be a bug."
     if [[ "$OSTYPE" == "darwin"* ]]; then
       echo "df reports $(__dodocker run --rm -v macos-space-check:/dummy busybox df -P /dummy) and __free_space is ${__free_space}"
     else


### PR DESCRIPTION
Changes:
  Erigon Port Comment:
  - # Erigon's torrent port. Don't make this 42070, that'll fail
  + # Erigon's torrent port. Don't make this 42070, as it will fail
  - Added "as" for improved sentence structure.
 
  Disk Space Error Message:
   - echo "Unable to determine free disk space. This is likely a bug."
  + echo "Unable to determine free disk space. This is likely to be a bug."
  - Added "to be" to enhance grammatical accuracy.