### PR TITLE
Typo in Command Reference: 'ethd' Should Be 'ethdo'

### DIFF
--- a/.eth/ethdo/README.md
+++ b/.eth/ethdo/README.md
@@ -10,7 +10,7 @@ This follows the [ethdo instructions](https://github.com/wealdtech/ethdo/blob/ma
 [Metrika](https://app.metrika.co/ethereum/dashboard/withdrawals-overview) will let you see whether your validator has a withdrawal address set.
 If yes, that is where consensus layer rewards will be swept automatically (every 4-5 days at ~500,000 validators total) and where your funds will be sent when exiting.
 
-You can use `./ethd keys list` to get a list of your validator public keys that are currently active on your system.
+You can use `./ethdo keys list` to get a list of your validator public keys that are currently active on your system.
 
 ## Offline preparation
 


### PR DESCRIPTION
The text mentions the use of **ethdo**, which is a tool for managing Ethereum validator keys. However, the command `./ethd keys list` does not match the name of this tool (**ethdo**), and it seems to be a typo.

The correct command should be:

```bash
./ethdo keys list

Reasons:

1. ethdo is the known tool, and ethd is not mentioned as a separate program in this context.
2. In other parts of the text, ethdo is used (e.g., "ethdo --connection"), confirming the typo