### PR TITLE
v2.15.0.0 and Nethermind 1.30.0 data-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Eth Docker uses a "semver-ish" scheme.
 large.
 - Second through fourth digit, [semver](https://semver.org/).
 
-This is Eth Docker v2.14.0.2
+This is Eth Docker v2.15.0.0

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -83,9 +83,9 @@ fi
 
 # New or old datadir
 if [ -d /var/lib/nethermind-og/nethermind_db ]; then
-  __datadir="--datadir /var/lib/nethermind-og"
+  __datadir="--data-dir /var/lib/nethermind-og"
 else
-  __datadir="--datadir /var/lib/nethermind"
+  __datadir="--data-dir /var/lib/nethermind"
 fi
 
 # Word splitting is desired for the command line parameters


### PR DESCRIPTION
Nethermind 1.30.0 deprecates `--datadir` for `--data-dir`. Make that change and signal a breaking change with the Eth Docker version number