### PR TITLE
Clearly identify Nethermind during ethd version

### DIFF
--- a/ethd
+++ b/ethd
@@ -4046,6 +4046,7 @@ version() {
       echo
       ;;&
     *nethermind.yml* )
+      echo "Nethermind version"
       __docompose exec execution /nethermind/nethermind --version
       echo
       ;;&


### PR DESCRIPTION
Nethermind 1.30 no longer prints its own name