### PR TITLE
DDNS updates v6 address

### DIFF
--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -53,7 +53,7 @@ services:
     restart: "unless-stopped"
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - 'CONFIG={"settings": [{"provider": "cloudflare", "zone_identifier": "${CF_ZONE_ID}", "domain": "${DDNS_SUBDOMAIN}.${DOMAIN}", "ttl": 1, "token": "${CF_DNS_API_TOKEN}", "proxied": ${DDNS_PROXY}, "ip_version": "ipv4"}]}'
+      - 'CONFIG={"settings": [{"provider": "cloudflare", "zone_identifier": "${CF_ZONE_ID}", "domain": "${DDNS_SUBDOMAIN}.${DOMAIN}", "ttl": 1, "token": "${CF_DNS_API_TOKEN}", "proxied": ${DDNS_PROXY}, "ip_version": "ipv4"},{"provider": "cloudflare", "zone_identifier": "${CF_ZONE_ID}", "domain": "${DDNS_SUBDOMAIN}.${DOMAIN}", "ttl": 1, "token": "${CF_DNS_API_TOKEN}", "proxied": ${DDNS_PROXY}, "ip_version": "ipv6"}]}'
     volumes:
       - /etc/localtime:/etc/localtime:ro
     <<: *logging


### PR DESCRIPTION
By duplicating the config. Tested on dual-stack and IPV4 only. On v4-only, the v6 probe fails and DDNS does not attempt to update the v6 address, as expected.

Addresses #1735 . Duplicating config is not clean, but appears to work with CloudFlare. This can be changed to "ipv4 and ipv6" if or when ddns-updater gains that functionality.