### PR TITLE
Fix typo in datasource.yml comment and remove duplicate wget

### DIFF
--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -10,7 +10,7 @@ deleteDatasources:
     orgId: 1
 
 # list of datasources to insert/update depending
-# whats available in the database
+# what's available in the database
 datasources:
   - name: Prometheus
     type: prometheus

--- a/lighthouse/Dockerfile.source
+++ b/lighthouse/Dockerfile.source
@@ -30,7 +30,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   wget \
   tzdata \
   git \
-  wget \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 # rsync for migration


### PR DESCRIPTION

Changes:
1. grafana/datasource.yml:
- Old: "# whats available in the database"
- New: "# what's available in the database"

2. lighthouse/Dockerfile.source:
- Removed duplicate wget package from apt-get install list

Improvements:
- Added missing apostrophe in "what's" (what is) to improve documentation grammar
- Removed redundant wget package installation
- No functional changes, just cleanup