### PR TITLE
Update base-config.yml

### DIFF
--- a/prometheus/base-config.yml
+++ b/prometheus/base-config.yml
@@ -61,5 +61,5 @@ scrape_configs:
         - source_labels: [__meta_docker_container_label_metrics_network]
           target_label: network
 
-scrape_config_files:
+scrape_configs_files:
   - /etc/prometheus/conf.d/*.yml


### PR DESCRIPTION
This change fixes a critical configuration parameter typo in the Prometheus base configuration. The correct parameter name is scrape_configs_files (with an 's'). This parameter is used to include additional configuration files from the conf.d directory. Without this correction, Prometheus might fail to load additional scrape configurations, potentially missing important metrics collection targets.
