### PR TITLE
Do not suggest our own graffiti

### DIFF
--- a/default.env
+++ b/default.env
@@ -16,9 +16,9 @@ https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22ab
 # Set a minimum MEV bid (e.g. 0.05), used by mev-boost.yml. If empty, no minimum is used.
 MEV_MIN_BID=
 # Graffiti to use for validator
-GRAFFITI=🐡s in spaaaace
+GRAFFITI=
 # Set to true to use the client's default Graffiti. Overrides GRAFFITI
-DEFAULT_GRAFFITI=false
+DEFAULT_GRAFFITI=true
 # Merged network to use. If using main net, set to mainnet.
 NETWORK=holesky
 # CL rapid sync via initial state/checkpoint. Please use one from https://eth-clients.github.io/checkpoint-sync-endpoints/


### PR DESCRIPTION
Using the default graffiti makes it easier to track CL/EL  versions. Leave it to the user to decide whether they want graffiti.