### PR TITLE
Fix EL_NODE during RocketPool config

### DIFF
--- a/ethd
+++ b/ethd
@@ -3928,7 +3928,7 @@ config() {
   __var=COMPOSE_FILE
   __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
   __var=EL_NODE
-  __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
+  __update_value_in_env "${__var}" "${!__var:-"http://execution:8551"}" "${__env_file}"
   __var=JWT_SECRET
   __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
   __var=NETWORK


### PR DESCRIPTION
This crept in at some point: When configuring for RocketPool, `EL_NODE` is set to empty, as it's not assigned a value. The next `./ethd update` then brings the default in.

This sets a default in ethd.
