### PR TITLE
Ci nimbus gnosis

### DIFF
--- a/.github/workflows/build-nimbus-gnosis.yml
+++ b/.github/workflows/build-nimbus-gnosis.yml
@@ -1,0 +1,64 @@
+name: Source build Nimbus on Gnosis
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  schedule:
+    - cron: "42 7 * * 2"  # Weekly Tuesday at 7:42 AM UTC
+  workflow_dispatch:
+
+jobs:
+  build-nimbus:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create .env file
+        run: cp default.env .env
+      - name: Set Nimbus/Nethermind
+        run: |
+          source ./.github/helper.sh
+          COMPOSE_FILE=nimbus.yml:nethermind.yml
+          var=COMPOSE_FILE
+          set_value_in_env
+          FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+          var=FEE_RECIPIENT
+          set_value_in_env
+          NIM_DOCKERFILE=Dockerfile.sourcegnosis
+          var=NIM_DOCKERFILE
+          set_value_in_env
+          NETWORK=gnosis
+          var=NETWORK
+          set_value_in_env
+      - name: Build clients
+        run: ./ethd update
+      - name: Start Nimbus/Nethermind
+        run: ./ethd up
+      - name: Pause for 30 seconds
+        run: sleep 30
+      - name: Test Nimbus CL
+        run: ./.github/check-service.sh consensus
+      - name: Test Nimbus VC
+        run: ./.github/check-service.sh validator
+      - name: Test Nethermind
+        run: ./.github/check-service.sh execution
+      - name: Set Nimbus/Nethermind w/ VC
+        run: |
+          source ./.github/helper.sh
+          COMPOSE_FILE=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
+          var=COMPOSE_FILE
+          set_value_in_env
+      - name: Start Nimbus/Nethermind
+        run: ./ethd up
+      - name: Pause for 30 seconds
+        run: sleep 30
+      - name: Test Nimbus CL
+        run: ./.github/check-service.sh consensus
+      - name: Test Nimbus VC
+        run: ./.github/check-service.sh validator
+      - name: Test Nethermind
+        run: ./.github/check-service.sh execution


### PR DESCRIPTION
Nimbus needs to be source-built for Gnosis specifically. This ensures the Gnosis source  build gets tested once a week