### PR TITLE
Support SSV-DKG 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Eth Docker uses a "semver-ish" scheme.
 large.
 - Second through fourth digit, [semver](https://semver.org/).
 
-This is Eth Docker v2.15.0.2
+This is Eth Docker v2.15.1.0

--- a/ssv-config/dkg-config-sample.yaml
+++ b/ssv-config/dkg-config-sample.yaml
@@ -1,9 +1,10 @@
-privKey: /config/encrypted_private_key.json
-privKeyPassword: /config/password.pass
+privKey: ./config/encrypted_private_key.json
+privKeyPassword: ./config/password.pass
 operatorID: <YOUR_OPERATOR_ID>
 port: 3030
 logLevel: info
 logFormat: json
 logLevelFormat: capitalColor
-logFilePath: /output/debug.log
-outputPath: /output
+logFilePath: ./output/debug.log
+outputPath: ./output
+ethEndpointURL: http://execution:8545

--- a/ssv-dkg.yml
+++ b/ssv-dkg.yml
@@ -20,9 +20,9 @@ services:
     restart: "unless-stopped"
     image: ${SSV_DKG_REPO:-ssvlabs/ssv-dkg}:${SSV_DKG_TAG:-latest}
     volumes:
-      - ./ssv-config:/config
-      - ssv-dkg-tls:/ssl
-      - .eth/dkg_output:/output
+      - ./ssv-config:/ssv-dkg/config
+      - ssv-dkg-tls:/ssv-dkg/data/ssl
+      - .eth/dkg_output:/ssv-dkg/output
       - /etc/localtime:/etc/localtime:ro
     ports:
       - ${HOST_IP:-}:${SSV_DKG_PORT}:${SSV_DKG_PORT}/tcp
@@ -30,7 +30,7 @@ services:
     command: >
       start-operator
       --configPath
-      /config/dkg-config.yaml
+      ./config/dkg-config.yaml
       --port
       ${SSV_DKG_PORT}
 


### PR DESCRIPTION
DKG 3.x requires all paths to start with `.`. Its `~` is `/ssv-dkg`

Merging without review because I need it now for Lido SSV
