### PR TITLE
Grandine back-sync in entrypoint

### DIFF
--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -80,7 +80,6 @@ services:
       - ${CL_QUIC_PORT:-9001}
       - --target-peers
       - ${CL_MAX_PEER_COUNT:-80}
-      - --back-sync
       - --eth1-rpc-urls
       - ${EL_NODE}
       - --jwt-secret


### PR DESCRIPTION
Fixes an oversight: back-sync is in docker-entrypoint for archive Grandine nodes, and shouldn't be in grandine-allin1.yml
