### PR TITLE
Nethermind remove null Pushgateway

### DIFF
--- a/nethermind.yml
+++ b/nethermind.yml
@@ -73,8 +73,6 @@ services:
       - --JsonRpc.JwtSecretFile=/var/lib/nethermind/ee-secret/jwtsecret
       - --Metrics.Enabled
       - "true"
-      - --Metrics.PushGatewayUrl
-      - ""
       - --Metrics.ExposeHost
       - 0.0.0.0
       - --Metrics.ExposePort


### PR DESCRIPTION
Nethermind 1.31 no longer accepts a null pushgateway. It also might not have a default value, which makes this parameter unnecessary.
