### PR TITLE
Retain pretty compose output in screen

### DIFF
--- a/ethd
+++ b/ethd
@@ -1532,7 +1532,7 @@ update() {
 #
 #   exec bash replaces bash -c , so that the user is still inside screen at the end
 #
-      screen -S "${__screen_session}" -dm bash -c "${BASH_SOURCE[0]} update \"\$@\"; exec bash" dummy "$@"
+      screen -S "${__screen_session}" -dma bash -c "${BASH_SOURCE[0]} update \"\$@\"; exec bash" dummy "$@"
       screen -r "${__screen_session}"
       exit 0
     fi


### PR DESCRIPTION
Without -a, the progress indicators use a new line each, instead of updating the current line