### PR TITLE
New config defaults to Postgres 17

### DIFF
--- a/default.env
+++ b/default.env
@@ -296,7 +296,7 @@ GRANDINE_DOCKERFILE=Dockerfile.binary
 # Web3Signer
 W3S_DOCKER_TAG=latest
 W3S_DOCKER_REPO=consensys/web3signer
-PG_DOCKER_TAG=16-bookworm
+PG_DOCKER_TAG=17-bookworm
 
 # Besu
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"


### PR DESCRIPTION
Otherwise --refresh-targets would bring a user back to 16. Also, ethd update now offers 17. Not having it in default.env was an oversight