### PR TITLE
Prysm enable-quic is deprecated

### DIFF
--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -75,7 +75,6 @@ services:
       - ${PRYSM_UDP_PORT}
       - --p2p-quic-port
       - ${CL_QUIC_PORT}
-      - --enable-quic
       - --p2p-max-peers
       - ${CL_MAX_PEER_COUNT:-70}
       - --verbosity

--- a/prysm.yml
+++ b/prysm.yml
@@ -77,7 +77,6 @@ services:
       - ${PRYSM_UDP_PORT}
       - --p2p-quic-port
       - ${CL_QUIC_PORT}
-      - --enable-quic
       - --p2p-max-peers
       - ${CL_MAX_PEER_COUNT:-70}
       - --verbosity


### PR DESCRIPTION
Remove `--enable-quic`, as using QUIC is now the default