### PR TITLE
Revert "Screen sessions are started as the owner (#2076)"

### DIFF
--- a/ethd
+++ b/ethd
@@ -1523,7 +1523,7 @@ update() {
 # Find old lingering screen sessions and close them
       local __old_sessions
       set +e
-      __old_sessions=$(${__as_owner} screen -ls 2>/dev/null | awk -v name="${__screen_session}" -v status="Detached" '$0 ~ name && $0 ~ status {print $1}')
+      __old_sessions=$(screen -ls 2>/dev/null | awk -v name="${__screen_session}" -v status="Detached" '$0 ~ name && $0 ~ status {print $1}')
       set -e
       if [ -n "${__old_sessions}" ]; then
         local __session_id
@@ -1531,7 +1531,7 @@ update() {
         while IFS= read -r __session_id; do
           if [ -n "${__session_id}" ]; then
             echo "Closing screen session ${__session_id}"
-            ${__as_owner} screen -S "${__session_id}" -X quit
+            screen -S "${__session_id}" -X quit
           fi
         done <<< "$__old_sessions"
         echo
@@ -1549,8 +1549,8 @@ update() {
 #
 #   exec bash replaces bash -c , so that the user is still inside screen at the end
 #
-      ${__as_owner} screen -S "${__screen_session}" -dma bash -c "${BASH_SOURCE[0]} update \"\$@\"; exec bash" dummy "$@"
-      ${__as_owner} screen -RR "${__screen_session}"
+      screen -S "${__screen_session}" -dma bash -c "${BASH_SOURCE[0]} update \"\$@\"; exec bash" dummy "$@"
+      screen -RR "${__screen_session}"
       exit 0
     fi
   fi


### PR DESCRIPTION
This reverts commit 53137fec277d49da6f032c0c600c7893d09cbe6b.

Yes, it's unintuitive to have screen sessions owned by root when a user does `sudo ethd update`

But by running screen as owner, I negate user intent for just update

In that case, maybe consider negating user intent with `sudo` entirely and always run as the user - but that needs a longer think
