### PR TITLE
CI build --non-interactive to avoid screen

### DIFF
--- a/.github/workflows/build-besu.yml
+++ b/.github/workflows/build-besu.yml
@@ -32,7 +32,7 @@ jobs:
           var=BESU_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Teku/Besu w/ VC

--- a/.github/workflows/build-deposit.yml
+++ b/.github/workflows/build-deposit.yml
@@ -29,4 +29,4 @@ jobs:
           var=DEPCLI_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive

--- a/.github/workflows/build-erigon.yml
+++ b/.github/workflows/build-erigon.yml
@@ -32,7 +32,7 @@ jobs:
           var=ERIGON_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Lodestar/Erigon w/ VC

--- a/.github/workflows/build-geth.yml
+++ b/.github/workflows/build-geth.yml
@@ -35,7 +35,7 @@ jobs:
           var=GETH_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Prysm/Geth w/ VC

--- a/.github/workflows/build-grandine.yml
+++ b/.github/workflows/build-grandine.yml
@@ -29,7 +29,7 @@ jobs:
           var=GRANDINE_DOCKERFILE
           set_value_in_env
       - name: Build Grandine
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Start Grandine/Reth
         run: ./ethd up
       - name: Pause for 30 seconds

--- a/.github/workflows/build-lighthouse.yml
+++ b/.github/workflows/build-lighthouse.yml
@@ -32,7 +32,7 @@ jobs:
           var=LH_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Lighthouse/Reth w/ VC

--- a/.github/workflows/build-lodestar.yml
+++ b/.github/workflows/build-lodestar.yml
@@ -32,7 +32,7 @@ jobs:
           var=LS_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Lodestar/Erigon w/ VC

--- a/.github/workflows/build-nethermind.yml
+++ b/.github/workflows/build-nethermind.yml
@@ -32,7 +32,7 @@ jobs:
           var=NM_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Nimbus/Nethermind w/ VC

--- a/.github/workflows/build-nimbus-el.yml
+++ b/.github/workflows/build-nimbus-el.yml
@@ -32,7 +32,7 @@ jobs:
           var=NIMEL_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Nimbus/Nimbus w/ VC

--- a/.github/workflows/build-nimbus-gnosis.yml
+++ b/.github/workflows/build-nimbus-gnosis.yml
@@ -35,7 +35,7 @@ jobs:
           var=NETWORK
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Start Nimbus/Nethermind
         run: ./ethd up
       - name: Pause for 30 seconds

--- a/.github/workflows/build-nimbus-slottime.yml
+++ b/.github/workflows/build-nimbus-slottime.yml
@@ -32,7 +32,7 @@ jobs:
           var=NIM_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Start Nimbus/Nethermind
         run: ./ethd up
       - name: Pause for 30 seconds

--- a/.github/workflows/build-nimbus.yml
+++ b/.github/workflows/build-nimbus.yml
@@ -32,7 +32,7 @@ jobs:
           var=NIM_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Start Nimbus/Nethermind
         run: ./ethd up
       - name: Pause for 30 seconds

--- a/.github/workflows/build-prysm.yml
+++ b/.github/workflows/build-prysm.yml
@@ -35,7 +35,7 @@ jobs:
           var=PRYSM_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Prysm/Geth w/ VC

--- a/.github/workflows/build-reth.yml
+++ b/.github/workflows/build-reth.yml
@@ -29,7 +29,7 @@ jobs:
           var=RETH_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Lighthouse/Reth w/ VC

--- a/.github/workflows/build-teku.yml
+++ b/.github/workflows/build-teku.yml
@@ -32,7 +32,7 @@ jobs:
           var=TEKU_DOCKERFILE
           set_value_in_env
       - name: Build clients
-        run: ./ethd update
+        run: ./ethd update --non-interactive
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
       - name: Set Teku/Besu w/ VC


### PR DESCRIPTION
Adding `screen` to `ethd update` messes with CI. `--non-interactive` has it run without screen.
