### PR TITLE
Set Vero stop grace period to 1m

### DIFF
--- a/vero-vc-only.yml
+++ b/vero-vc-only.yml
@@ -23,6 +23,7 @@ services:
     image: vero:local
     pull_policy: never
     user: vero
+    stop_grace_period: 1m
     environment:
       - MEV_BOOST=${MEV_BOOST}
       - VC_EXTRAS=${VC_EXTRAS:-}


### PR DESCRIPTION
From Vero sample compose yml:

    # It's recommended to set the `stop_grace_period` value
    # (or equivalent, e.g. `terminationGracePeriodSeconds` in k8s)
    # to at least 30 seconds.
    # This is because Vero defers the shutdown process if it detects
    # an upcoming validator duty, opting to complete the duty before
    # shutting down.
    # This feature can make the shutdown process take several seconds.