### PR TITLE
Calling docker-entrypoint-vc as root calls itself after chown

### DIFF
--- a/lighthouse/docker-entrypoint-vc.sh
+++ b/lighthouse/docker-entrypoint-vc.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ "$(id -u)" = '0' ]; then
   chown -R lhvalidator:lhvalidator /var/lib/lighthouse
-  exec gosu lhvalidator docker-entrypoint.sh "$@"
+  exec gosu lhvalidator docker-entrypoint-vc.sh "$@"
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then

--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ "$(id -u)" = '0' ]; then
   chown -R lsvalidator:lsvalidator /var/lib/lodestar
-  exec gosu lsvalidator docker-entrypoint.sh "$@"
+  exec gosu lsvalidator docker-entrypoint-vc.sh "$@"
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ "$(id -u)" = '0' ]; then
   chown -R prysmvalidator:prysmvalidator /var/lib/prysm
-  exec gosu prysmvalidator docker-entrypoint.sh "$@"
+  exec gosu prysmvalidator docker-entrypoint-vc.sh "$@"
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then

--- a/teku/docker-entrypoint-vc.sh
+++ b/teku/docker-entrypoint-vc.sh
@@ -2,7 +2,7 @@
 
 if [ "$(id -u)" = '0' ]; then
   chown -R teku:teku /var/lib/teku
-  exec gosu teku docker-entrypoint.sh "$@"
+  exec gosu teku docker-entrypoint-vc.sh "$@"
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then


### PR DESCRIPTION
The entrypoint scripts have a feature where they'll chown the datadir and call themselves with exec gosu non-root-user - this is intended as a way for users to relatively easily fix permissions issues, if they have to.

Clearly it's never been used by anyone: `docker-entrypoint-vc.sh` would have tried to call `docker-entrypoint.sh`, which is the entrypoint for the consensus client.