### PR TITLE
Force libjemalloc-dev for Teku

### DIFF
--- a/teku/Dockerfile.binary
+++ b/teku/Dockerfile.binary
@@ -16,7 +16,7 @@ RUN groupmod -g "${UID}" ${USER} && usermod -u "${UID}" -g "${UID}" ${USER}
 
 RUN set -eux; \
         apt-get update; \
-        DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y gosu ca-certificates tzdata git; \
+        DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y gosu ca-certificates tzdata git libjemalloc-dev; \
         rm -rf /var/lib/apt/lists/*; \
 # verify that the binary works
         gosu nobody true

--- a/teku/Dockerfile.source
+++ b/teku/Dockerfile.source
@@ -31,6 +31,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   tzdata \
   git \
   adduser \
+  libjemalloc-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I noticed a warning that jemalloc was not installed, with the official Docker image. That shouldn't happen - but I can solve it easily by forcing libjemalloc-dev