### PR TITLE
Caplin share files

### DIFF
--- a/caplin-traefik.yml
+++ b/caplin-traefik.yml
@@ -1,4 +1,4 @@
-# To be used in conjunction with erigon.yml
+# To be used in conjunction with erigon.yml when it is using Caplin
 # For remote validator setups only. Please be very cautious when exposing your consensus API port
 services:
   execution:


### PR DESCRIPTION
Clarify when to use caplin-traefik

Turns out we already had caplin-traefik and caplin-shared