### PR TITLE
Rename RAPID_SYNC_URL to CHECKPOINT_SYNC_URL

### DIFF
--- a/default.env
+++ b/default.env
@@ -23,7 +23,7 @@ DEFAULT_GRAFFITI=true
 NETWORK=holesky
 # CL rapid sync via initial state/checkpoint. Please use one from https://eth-clients.github.io/checkpoint-sync-endpoints/
 # Alternatively, use an already synced CL that you trust. No trailing / for Teku, please.
-RAPID_SYNC_URL=https://holesky.beaconstate.info
+CHECKPOINT_SYNC_URL=https://holesky.beaconstate.info
 # Doppelganger protection - set to "true" to enable. This will intentionally skip two epochs on client start, and attempt to
 # detect duplicates of the validator(s) already running. Note this is NOT foolproof, though it can be useful when moving a node
 DOPPELGANGER=false
@@ -372,4 +372,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=28
+ENV_VERSION=29

--- a/erigon.yml
+++ b/erigon.yml
@@ -32,7 +32,7 @@ services:
       - COMPOSE_FILE=${COMPOSE_FILE}
       - CL_P2P_PORT=${CL_P2P_PORT:-9000}
       - CL_REST_PORT=${CL_REST_PORT:-5052}
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL:-}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL:-}
       - MEV_BOOST=${MEV_BOOST:-false}
       - MEV_NODE=${MEV_NODE:-}
     volumes:

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -117,7 +117,7 @@ else  # Erigon v3
       __caplin+=" --caplin.states-archive=true --caplin.blobs-archive=true --caplin.blobs-no-pruning=true --caplin.blocks-archive=true"
     fi
     if [ -n "${RAPID_SYNC_URL}" ]; then
-      __caplin+=" --caplin.checkpoint-sync-url=${RAPID_SYNC_URL}/eth/v2/debug/beacon/states/finalized"
+      __caplin+=" --caplin.checkpoint-sync-url=${CHECKPOINT_SYNC_URL}/eth/v2/debug/beacon/states/finalized"
       echo "Checkpoint sync enabled"
     else
       __caplin+=" --caplin.checkpoint-sync.disable=true"

--- a/ethd
+++ b/ethd
@@ -1202,7 +1202,7 @@ __env_migrate() {
     MEV_MIN_BID MEV_NODE CL_MAX_PEER_COUNT CL_MIN_PEER_COUNT EL_MAX_PEER_COUNT EL_MIN_PEER_COUNT DOMAIN ACME_EMAIL \
     ANCIENT_DIR AUTOPRUNE_NM LOGS_LABEL CF_DNS_API_TOKEN CF_ZONE_API_TOKEN CF_ZONE_ID AWS_PROFILE AWS_HOSTED_ZONE_ID \
     GRAFANA_HOST SIREN_HOST DISTRIBUTED BESU_HEAP TEKU_HEAP PROM_HOST HOST_IP SHARE_IP PRYSM_HOST EE_HOST \
-    EL_HOST EL_LB EL_WS_HOST EL_WS_LB CL_HOST CL_LB VC_HOST DDNS_SUBDOMAIN IPV6 DDNS_PROXY RAPID_SYNC_URL \
+    EL_HOST EL_LB EL_WS_HOST EL_WS_LB CL_HOST CL_LB VC_HOST DDNS_SUBDOMAIN IPV6 DDNS_PROXY CHECKPOINT_SYNC_URL \
     CL_NODE OBOL_CL_NODE BEACON_STATS_API BEACON_STATS_MACHINE EL_P2P_PORT CL_P2P_PORT WEB3SIGNER PRYSM_PORT \
     DOPPELGANGER PRYSM_UDP_PORT CL_QUIC_PORT GRAFANA_PORT SIREN_PORT PROMETHEUS_PORT KEY_API_PORT TRAEFIK_WEB_PORT \
     TRAEFIK_WEB_HTTP_PORT CL_REST_PORT EL_RPC_PORT EL_WS_PORT EE_PORT ERIGON_TORRENT_PORT LOG_LEVEL JWT_SECRET \
@@ -1226,8 +1226,8 @@ __env_migrate() {
     GRANDINE_SRC_BUILD_TARGET GRANDINE_SRC_REPO GRANDINE_DOCKER_TAG GRANDINE_DOCKER_REPO GRANDINE_DOCKERFILE \
     SIREN_DOCKER_TAG SIREN_DOCKER_REPO SSV_DKG_TAG DEPCLI_DOCKERFILE CONTRIBUTOOR_DOCKER_REPO CONTRIBUTOOR_DOCKER_TAG)
 
-  __old_vars=( XATU_KEY ERIGON_P2P_PORT_2 OBOL_EL_NODE ARCHIVE_NODE )
-  __new_vars=( CONTRIBUTOOR_USERNAME EL_P2P_PORT_2 EL_RPC_NODE EL_ARCHIVE_NODE )
+  __old_vars=( XATU_KEY ERIGON_P2P_PORT_2 OBOL_EL_NODE ARCHIVE_NODE RAPID_SYNC_URL )
+  __new_vars=( CONTRIBUTOOR_USERNAME EL_P2P_PORT_2 EL_RPC_NODE EL_ARCHIVE_NODE CHECKPOINT_SYNC_URL )
 
 # Always make sure we have a SIREN password
   __var="SIREN_PASSWORD"
@@ -1272,7 +1272,7 @@ __env_migrate() {
   for __var in "${__all_vars[@]}"; do
     __value=$(__get_value_from_env "${__var}" "${__env_file}.source")
     if [ -n "${__value}" ] || [ "${__var}" = "GRAFFITI" ] || [ "${__var}" = "MEV_RELAYS" ] \
-        || [ "${__var}" = "ETH_DOCKER_TAG" ] || [ "${__var}" = "RAPID_SYNC_URL" ] \
+        || [ "${__var}" = "ETH_DOCKER_TAG" ] || [ "${__var}" = "CHECKPOINT_SYNC_URL" ] \
         || [ "${__var}" = "OBOL_CHARON_CL_ENDPOINTS" ]; then
       if [ "${__var}" = "COMPOSE_FILE" ]; then
         __migrate_compose_file
@@ -1304,7 +1304,7 @@ __env_migrate() {
       fi
 # Literal match intended
 # shellcheck disable=SC2076
-      if [[ "${__var}" = "RAPID_SYNC_URL" && "${__value}" =~ "eth2-beacon-mainnet.infura.io" ]]; then
+      if [[ "${__var}" = "CHECKPOINT_SYNC_URL" && "${__value}" =~ "eth2-beacon-mainnet.infura.io" ]]; then
         __value="https://beaconstate.info"
       fi
       if [[ "${__var}" = "HOST_IP" && "${__value: -1}" = ":" ]]; then
@@ -1818,13 +1818,13 @@ resync-consensus() {
   fi
 
   # Can we checkpoint sync?
-  __var="RAPID_SYNC_URL"
+  __var="CHECKPOINT_SYNC_URL"
   __value=$(__get_value_from_env "${__var}" "${__env_file}")
   echo "This will stop ${__cl_client} and delete its database to force a resync."
   if [ -z "${__value}" ]; then
-    read -rp "WARNING - RAPID_SYNC_URL not set, resync may take days. Do you wish to continue? (No/yes) " __yn
+    read -rp "WARNING - CHECKPOINT_SYNC_URL not set, resync may take days. Do you wish to continue? (No/yes) " __yn
   else
-    read -rp "RAPID_SYNC_URL set, resync should finish in minutes. Do you wish to continue? (No/yes) " __yn
+    read -rp "CHECKPOINT_SYNC_URL set, resync should finish in minutes. Do you wish to continue? (No/yes) " __yn
   fi
   case $__yn in
     [Yy][Ee][Ss] ) ;;
@@ -3264,38 +3264,38 @@ consensus client? (right-click to paste)" 10 60 "${REMOTE_BEACON}" 3>&1 1>&2 2>&
 
 __query_checkpoint_beacon() {
   if [ "${__minty_fresh}" -eq 1 ] || [ "${__network_change}" -eq 1 ]; then
-    RAPID_SYNC_URL=""
+    CHECKPOINT_SYNC_URL=""
   else
-    __var="RAPID_SYNC_URL"
-    RAPID_SYNC_URL=$(__get_value_from_env "${__var}" "${__env_file}")
+    __var="CHECKPOINT_SYNC_URL"
+    CHECKPOINT_SYNC_URL=$(__get_value_from_env "${__var}" "${__env_file}")
   fi
-  if [ -z "${RAPID_SYNC_URL}" ]; then
+  if [ -z "${CHECKPOINT_SYNC_URL}" ]; then
     case "${NETWORK}" in
       "sepolia")
-        RAPID_SYNC_URL="https://sepolia.beaconstate.info"
+        CHECKPOINT_SYNC_URL="https://sepolia.beaconstate.info"
         ;;
       "holesky")
-        RAPID_SYNC_URL="https://holesky.beaconstate.info"
+        CHECKPOINT_SYNC_URL="https://holesky.beaconstate.info"
         ;;
       "ephemery")
-        RAPID_SYNC_URL="https://ephemery.beaconstate.ethstaker.cc/"
+        CHECKPOINT_SYNC_URL="https://ephemery.beaconstate.ethstaker.cc/"
         ;;
       "mainnet")
-        RAPID_SYNC_URL="https://beaconstate.info"
+        CHECKPOINT_SYNC_URL="https://beaconstate.info"
         ;;
       "gnosis")
-        RAPID_SYNC_URL="https://checkpoint.gnosischain.com"
+        CHECKPOINT_SYNC_URL="https://checkpoint.gnosischain.com"
         ;;
       *)
-        RAPID_SYNC_URL=""
+        CHECKPOINT_SYNC_URL=""
         ;;
     esac
   fi
 
-  RAPID_SYNC_URL=$(whiptail --title "Configure CL checkpoint sync URL" --inputbox "What is the URL for your CL \
-checkpoint sync provider? (right-click to paste)" 10 65 "${RAPID_SYNC_URL}" 3>&1 1>&2 2>&3)
+  CHECKPOINT_SYNC_URL=$(whiptail --title "Configure CL checkpoint sync URL" --inputbox "What is the URL for your CL \
+checkpoint sync provider? (right-click to paste)" 10 65 "${CHECKPOINT_SYNC_URL}" 3>&1 1>&2 2>&3)
 
-  echo "Your checkpoint sync URL is:" "${RAPID_SYNC_URL}"
+  echo "Your checkpoint sync URL is:" "${CHECKPOINT_SYNC_URL}"
 }
 
 
@@ -3327,9 +3327,9 @@ __query_graffiti() {
 }
 
 
-__query_rapid_sync() {
+__query_checkpoint_sync() {
   if [[ "${NETWORK}" =~ ^https?:// ]]; then
-    RAPID_SYNC_URL=""
+    CHECKPOINT_SYNC_URL=""
     return
   fi
   __query_checkpoint_beacon
@@ -3868,7 +3868,7 @@ config() {
     CL_NODE="http://consensus:5052"
 
     __query_execution_client
-    __query_rapid_sync
+    __query_checkpoint_sync
     __query_mev
     __query_grafana
     __query_coinbase
@@ -4052,7 +4052,7 @@ config() {
   __update_value_in_env "${__var}" "${!__var:-"true"}" "${__env_file}"
   __var=CL_NODE
   __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
-  __var=RAPID_SYNC_URL
+  __var=CHECKPOINT_SYNC_URL
   __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"
   __var=COMPOSE_FILE
   __update_value_in_env "${__var}" "${!__var-}" "${__env_file}"

--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -30,7 +30,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/grandine/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/grandine-cl-only.yml
+++ b/grandine-cl-only.yml
@@ -30,7 +30,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/grandine/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -58,11 +58,11 @@ else
 fi
 
 # Check whether we should rapid sync
-if [ -n "${RAPID_SYNC_URL}" ]; then
-  __rapid_sync="--checkpoint-sync-url=${RAPID_SYNC_URL}"
+if [ -n "${CHECKPOINT_SYNC_URL}" ]; then
+  __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL}"
   echo "Checkpoint sync enabled"
 else
-  __rapid_sync=""
+  __checkpoint_sync=""
 fi
 
 # Check whether we should send stats to beaconcha.in
@@ -125,9 +125,9 @@ fi
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${__ipv6} --graffiti "${GRAFFITI}" ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} --graffiti "${GRAFFITI}" ${CL_EXTRAS} ${VC_EXTRAS}
 fi

--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/lighthouse/beacon/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -31,7 +31,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/lighthouse/beacon/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -55,8 +55,8 @@ else
 fi
 
 # Check whether we should rapid sync
-if [ -n "${RAPID_SYNC_URL}" ]; then
-  __rapid_sync="--checkpoint-sync-url=${RAPID_SYNC_URL}"
+if [ -n "${CHECKPOINT_SYNC_URL}" ]; then
+  __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL}"
   echo "Checkpoint sync enabled"
   if [ "${ARCHIVE_NODE}" = "true" ]; then
     echo "Lighthouse archive node without pruning"
@@ -65,7 +65,7 @@ if [ -n "${RAPID_SYNC_URL}" ]; then
     __prune=""
   fi
 else
-  __rapid_sync="--allow-insecure-genesis-sync"
+  __checkpoint_sync="--allow-insecure-genesis-sync"
   __prune=""
 fi
 
@@ -112,5 +112,5 @@ if [ -f /var/lib/lighthouse/beacon/prune-marker ]; then
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${CL_EXTRAS}
+  exec "$@" ${__network} ${__mev_boost} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${CL_EXTRAS}
 fi

--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/lodestar/consensus/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/lodestar/consensus/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -71,16 +71,16 @@ else
 fi
 
 # Check whether we should rapid sync
-if [ -n "${RAPID_SYNC_URL}" ]; then
+if [ -n "${CHECKPOINT_SYNC_URL}" ]; then
   if [ "${ARCHIVE_NODE}" = "true" ]; then
     echo "Lodestar archive node cannot use checkpoint sync: Syncing from genesis."
-    __rapid_sync="--chain.archiveBlobEpochs Infinity"
+    __checkpoint_sync="--chain.archiveBlobEpochs Infinity"
   else
-    __rapid_sync="--checkpointSyncUrl=${RAPID_SYNC_URL}"
+    __checkpoint_sync="--checkpointSyncUrl=${CHECKPOINT_SYNC_URL}"
     echo "Checkpoint sync enabled"
   fi
 else
-  __rapid_sync=""
+  __checkpoint_sync=""
 fi
 
 if [ "${IPV6}" = "true" ]; then
@@ -100,4 +100,4 @@ fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__ipv6} ${__network} ${__mev_boost} ${__beacon_stats} ${__rapid_sync} ${CL_EXTRAS}
+exec "$@" ${__ipv6} ${__network} ${__mev_boost} ${__beacon_stats} ${__checkpoint_sync} ${CL_EXTRAS}

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -33,7 +33,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -32,7 +32,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -32,7 +32,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -53,18 +53,18 @@ else
   __network="--network=${NETWORK}"
 fi
 
-if [ -n "${RAPID_SYNC_URL:+x}" ] && [ ! -f "/var/lib/nimbus/setupdone" ]; then
+if [ -n "${CHECKPOINT_SYNC_URL:+x}" ] && [ ! -f "/var/lib/nimbus/setupdone" ]; then
     if [ "${ARCHIVE_NODE}" = "true" ]; then
         echo "Starting checkpoint sync with backfill and archive reindex. Nimbus will restart when done."
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-        /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=true --reindex ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${RAPID_SYNC_URL}"
+        /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=true --reindex ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
         touch /var/lib/nimbus/setupdone
     else
         echo "Starting checkpoint sync. Nimbus will restart when done."
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-        /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${RAPID_SYNC_URL}"
+        /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
         touch /var/lib/nimbus/setupdone
     fi
 fi

--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -32,7 +32,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/prysm/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/prysm.yml
+++ b/prysm.yml
@@ -33,7 +33,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/prysm/ee-secret
     environment:
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -57,11 +57,11 @@ else
 fi
 
 # Check whether we should rapid sync
-if [ -n "${RAPID_SYNC_URL:+x}" ]; then
-  __rapid_sync="--checkpoint-sync-url=${RAPID_SYNC_URL}"
+if [ -n "${CHECKPOINT_SYNC_URL:+x}" ]; then
+  __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL}"
   echo "Checkpoint sync enabled"
 else
-  __rapid_sync=""
+  __checkpoint_sync=""
 fi
 
 # Check whether we should use MEV Boost
@@ -87,7 +87,7 @@ if [[ "${NETWORK}" = "sepolia" ]]; then
   fi
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" "--genesis-state=$GENESIS" ${__network} ${__rapid_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
+  exec "$@" "--genesis-state=$GENESIS" ${__network} ${__checkpoint_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
 elif [[ "${NETWORK}" = "holesky" ]]; then
   GENESIS=/var/lib/prysm/genesis.ssz
   if [ ! -f "$GENESIS" ]; then
@@ -96,9 +96,9 @@ elif [[ "${NETWORK}" = "holesky" ]]; then
   fi
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" "--genesis-state=$GENESIS" ${__network} ${__rapid_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
+  exec "$@" "--genesis-state=$GENESIS" ${__network} ${__checkpoint_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__rapid_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
+  exec "$@" ${__network} ${__checkpoint_sync} ${__prune} ${__mev_boost} ${CL_EXTRAS}
 fi

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -31,7 +31,7 @@ services:
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
       - JAVA_OPTS=${TEKU_HEAP:--Xmx6g}
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -30,7 +30,7 @@ services:
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
       - JAVA_OPTS=${TEKU_HEAP:--Xmx7g}
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/teku.yml
+++ b/teku.yml
@@ -30,7 +30,7 @@ services:
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
       - JAVA_OPTS=${TEKU_HEAP:--Xmx7g}
-      - RAPID_SYNC_URL=${RAPID_SYNC_URL}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
       - MEV_NODE=${MEV_NODE}

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -38,21 +38,21 @@ if [[ -O "/var/lib/teku/ee-secret/jwtsecret" ]]; then
 fi
 
 # Check whether we should rapid sync
-if [ -n "${RAPID_SYNC_URL:+x}" ]; then
+if [ -n "${CHECKPOINT_SYNC_URL:+x}" ]; then
     if [ "${ARCHIVE_NODE}" = "true" ]; then
         echo "Teku archive node cannot use checkpoint sync: Syncing from genesis."
-        __rapid_sync="--ignore-weak-subjectivity-period-enabled=true"
+        __checkpoint_sync="--ignore-weak-subjectivity-period-enabled=true"
       if [ "${NETWORK}" = "holesky" ]; then
-        __rapid_sync+=" --initial-state=https://checkpoint-sync.holesky.ethpandaops.io/eth/v2/debug/beacon/states/genesis"
+        __checkpoint_sync+=" --initial-state=https://checkpoint-sync.holesky.ethpandaops.io/eth/v2/debug/beacon/states/genesis"
       fi
     else
-        __rapid_sync="--checkpoint-sync-url=${RAPID_SYNC_URL}"
+        __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL}"
         echo "Checkpoint sync enabled"
     fi
 else
-    __rapid_sync="--ignore-weak-subjectivity-period-enabled=true"
+    __checkpoint_sync="--ignore-weak-subjectivity-period-enabled=true"
     if [ "${NETWORK}" = "holesky" ]; then
-      __rapid_sync+=" --initial-state=https://checkpoint-sync.holesky.ethpandaops.io/eth/v2/debug/beacon/states/genesis"
+      __checkpoint_sync+=" --initial-state=https://checkpoint-sync.holesky.ethpandaops.io/eth/v2/debug/beacon/states/genesis"
     fi
 fi
 
@@ -75,7 +75,7 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
   fi
   bootnodes="$(paste -s -d, "/var/lib/teku/testnet/${config_dir}/bootstrap_nodes.txt")"
   set +e
-  __rapid_sync="--initial-state=/var/lib/teku/testnet/${config_dir}/genesis.ssz --ignore-weak-subjectivity-period-enabled=true"
+  __checkpoint_sync="--initial-state=/var/lib/teku/testnet/${config_dir}/genesis.ssz --ignore-weak-subjectivity-period-enabled=true"
   __network="--network=/var/lib/teku/testnet/${config_dir}/config.yaml --p2p-discovery-bootnodes=${bootnodes} \
 --data-storage-non-canonical-blocks-enabled=true --Xlog-include-p2p-warnings-enabled \
 --metrics-block-timing-tracking-enabled --Xmetrics-blob-sidecars-storage-enabled=true \
@@ -159,9 +159,9 @@ fi
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} "--validators-graffiti=${GRAFFITI}" ${__w3s_url} ${__mev_boost} ${__rapid_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} "--validators-graffiti=${GRAFFITI}" ${__w3s_url} ${__mev_boost} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
 fi


### PR DESCRIPTION
When Eth Docker implemented this feature, there wasn't a consensus yet to call it "checkpoint sync"

This renaming makes it more obvious to the user what the variable does

However, it also touches the yml and entrypoint for every CL client