### PR TITLE
Erigon http.api for custom and named networks

### DIFF
--- a/erigon.yml
+++ b/erigon.yml
@@ -75,6 +75,9 @@ services:
       - --metrics
       - --metrics.addr
       - 0.0.0.0
+# Erigon needs this to be explicit. When it's covered by defaults, remove
+      - --http.api
+      - web3,eth,net,engine
       - --http
       - --http.addr
       - 0.0.0.0

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -51,7 +51,7 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     erigon init --datadir /var/lib/erigon "/var/lib/erigon/testnet/${config_dir}/genesis.json"
   fi
 else
-  __network="--chain ${NETWORK} --http.api web3,eth,net,engine"
+  __network="--chain ${NETWORK}"
 fi
 
 __caplin=""


### PR DESCRIPTION
I had this in the entrypoint, then removed it for custom - should come out to the yml

Ideally we don't set it at all so the user can decide what they want. According to Patches Erigon requires this parameter to have a functioning http API at all, though