### PR TITLE
Introduce alias for web3signer

### DIFF
--- a/commit-boost-pbs.yml
+++ b/commit-boost-pbs.yml
@@ -14,6 +14,10 @@ services:
       CB_METRICS_PORT: 10000
     volumes:
     - ./commit-boost/cb-config.toml:/cb-config.toml:ro
+    networks:
+      default:
+        aliases:
+          - ${NETWORK}-cb-pbs # This allows multiple Eth Docker stacks all connected to the same central traefik
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/default.env
+++ b/default.env
@@ -183,6 +183,8 @@ EL_NODE=http://execution:8551
 CL_NODE=http://consensus:5052
 # MEV-boost address. This would only be changed for Vouch setups
 MEV_NODE=http://mev-boost:18550
+# Web3signer address
+W3S_NODE=http://web3signer:9000
 # Used by "ethd keys", adjust this if you have multiple Eth Docker stacks connected to the same Docker bridge network
 VC_ALIAS=vc
 # Consensus client addresses for Charon in Obol setup
@@ -369,4 +371,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=29
+ENV_VERSION=30

--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -42,6 +42,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - DOPPELGANGER=${DOPPELGANGER:-false}
       - ARCHIVE_NODE=${CL_ARCHIVE_NODE:-false}
       - MINIMAL_NODE=${MINIMAL_NODE:-true}
@@ -141,6 +142,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - consensus

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -108,9 +108,9 @@ fi
 
 # Web3signer URL
 if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
-  __w3s_url="--web3signer-urls http://web3signer:9000"
+  __w3s_url="--web3signer-urls ${W3S_NODE}"
   while true; do
-    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+    if curl -s -m 5 "${W3S_NODE}" &> /dev/null; then
         echo "web3signer is up, starting Grandine"
         break
     else

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -123,6 +123,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -210,6 +210,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/lodestar-vc-only.yml
+++ b/lodestar-vc-only.yml
@@ -32,6 +32,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     volumes:
@@ -117,6 +118,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -105,6 +105,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     volumes:
@@ -194,6 +195,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -55,7 +55,7 @@ fi
 
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
-  __w3s_url="--externalSigner.url http://web3signer:9000 --externalSigner.fetch"
+  __w3s_url="--externalSigner.url ${W3S_NODE} --externalSigner.fetch"
 else
   __w3s_url=""
 fi

--- a/mev-boost.yml
+++ b/mev-boost.yml
@@ -19,6 +19,10 @@ services:
         - DOCKER_REPO=${MEV_DOCKER_REPO:-flashbots/mev-boost}
     image: mev-boost:local
     pull_policy: never
+    networks:
+      default:
+        aliases:
+          - ${NETWORK}-mev-boost # This allows multiple Eth Docker stacks all connected to the same central traefik
     entrypoint:
       - /app/mev-boost
       - -addr

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -46,6 +46,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - EMBEDDED_VC=true
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     ports:
@@ -139,6 +140,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - consensus

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -39,6 +39,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     networks:
       default:
@@ -92,6 +93,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -102,6 +102,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
       - CL_NODE=${CL_NODE}
     networks:
@@ -156,6 +157,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -43,9 +43,9 @@ __log_level="--log-level=${LOG_LEVEL^^}"
 
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
-  __w3s_url="--web3-signer-url=http://web3signer:9000"
+  __w3s_url="--web3-signer-url=${W3S_NODE}"
   while true; do
-    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+    if curl -s -m 5 "${W3S_NODE}" &> /dev/null; then
         echo "Web3signer is up, starting Nimbus"
         break
     else

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -96,9 +96,9 @@ fi
 
 # Web3signer URL
 if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
-  __w3s_url="--web3-signer-url=http://web3signer:9000"
+  __w3s_url="--web3-signer-url=${W3S_NODE}"
   while true; do
-    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+    if curl -s -m 5 "${W3S_NODE}" &> /dev/null; then
         echo "Web3signer is up, starting Nimbus"
         break
     else

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -36,6 +36,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     networks:
@@ -160,6 +161,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
       - PRYSM=true
     depends_on:

--- a/prysm.yml
+++ b/prysm.yml
@@ -113,6 +113,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     networks:
@@ -245,6 +246,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
       - PRYSM=true
     depends_on:

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -47,8 +47,8 @@ fi
 
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
-  __w3s_url="--validators-external-signer-url http://web3signer:9000 \
-  --validators-external-signer-public-keys http://web3signer:9000/api/v1/eth2/publicKeys \
+  __w3s_url="--validators-external-signer-url ${W3S_NODE} \
+  --validators-external-signer-public-keys ${W3S_NODE}/api/v1/eth2/publicKeys \
   --validators-external-signer-key-file=/var/lib/prysm/w3s-keys.txt"
 
   if [ ! -f /var/lib/prysm/w3s-keys.txt ]; then

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -44,6 +44,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - EMBEDDED_VC=true
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
@@ -148,6 +149,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - consensus

--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -34,6 +34,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     networks:
@@ -105,6 +106,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/teku.yml
+++ b/teku.yml
@@ -106,6 +106,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
     networks:
@@ -178,6 +179,7 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
       - KEY_API_PORT=${KEY_API_PORT:-7500}
       - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
     depends_on:
       - validator

--- a/teku/docker-entrypoint-vc.sh
+++ b/teku/docker-entrypoint-vc.sh
@@ -65,9 +65,9 @@ fi
 
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
-  __w3s_url="--validators-external-signer-url http://web3signer:9000"
+  __w3s_url="--validators-external-signer-url ${W3S_NODE}"
 #  while true; do
-#    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+#    if curl -s -m 5 ${W3S_NODE} &> /dev/null; then
 #        echo "web3signer is up, starting Teku"
 #        break
 #    else

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -114,9 +114,9 @@ fi
 
 # Web3signer URL
 if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
-  __w3s_url="--validators-external-signer-url http://web3signer:9000"
+  __w3s_url="--validators-external-signer-url ${W3S_NODE}"
 #  while true; do
-#    if curl -s -m 5 http://web3signer:9000 &> /dev/null; then
+#    if curl -s -m 5 ${W3S_NODE} &> /dev/null; then
 #        echo "web3signer is up, starting Teku"
 #        break
 #    else

--- a/vc-utils/keymanager.sh
+++ b/vc-utils/keymanager.sh
@@ -346,11 +346,11 @@ exit-sign() {
       if [ "${WEB3SIGNER}" = "true" ]; then
         __token=NIL
         __vc_api_container=${__api_container}
-        __api_container=web3signer
+        __api_container=${__w3s_container}
         __vc_service=${__service}
         __service=web3signer
         __vc_api_port=${__api_port}
-        __api_port=9000
+        __api_port=${__w3s_port}
         __vc_api_tls=${__api_tls}
         __api_tls=false
       else
@@ -468,11 +468,11 @@ validator-list() {
     if [ "${WEB3SIGNER}" = "true" ]; then
         __token=NIL
         __vc_api_container=${__api_container}
-        __api_container=web3signer
+        __api_container=${__w3s_container}
         __vc_service=${__service}
         __service=web3signer
         __vc_api_port=${__api_port}
-        __api_port=9000
+        __api_port=${__w3s_port}
         __vc_api_tls=${__api_tls}
         __api_tls=false
     else
@@ -507,9 +507,9 @@ validator-count() {
     if [ "${WEB3SIGNER}" = "true" ]; then
         __token=NIL
         __vc_api_container=${__api_container}
-        __api_container=web3signer
+        __api_container=${__w3s_container}
         __vc_api_port=${__api_port}
-        __api_port=9000
+        __api_port=${__w3s_port}
         __vc_api_tls=${__api_tls}
         __api_tls=false
     else
@@ -561,9 +561,9 @@ validator-delete() {
         if [ "${WEB3SIGNER}" = "true" ]; then
             __token=NIL
             __vc_api_container=${__api_container}
-            __api_container=web3signer
+            __api_container=${__w3s_container}
             __vc_api_port=${__api_port}
-            __api_port=9000
+            __api_port=${__w3s_port}
             __vc_api_tls=${__api_tls}
             __api_tls=false
         else
@@ -635,9 +635,9 @@ to delete it:"
         if [ "${WEB3SIGNER}" = "true" ]; then
             __token=NIL
             __vc_api_container=${__api_container}
-            __api_container=web3signer
+            __api_container=${__w3s_container}
             __vc_api_port=${__api_port}
-            __api_port=9000
+            __api_port=${__w3s_port}
             __vc_api_tls=${__api_tls}
             __api_tls=false
         else
@@ -884,9 +884,9 @@ and secrets directories into .eth/validator_keys instead."
         if [ "${WEB3SIGNER}" = "true" ]; then
             __token=NIL
             __vc_api_container=${__api_container}
-            __api_container=web3signer
+            __api_container=${__w3s_container}
             __vc_api_port=${__api_port}
-            __api_port=9000
+            __api_port=${__w3s_port}
             __vc_api_tls=${__api_tls}
             __api_tls=false
         else
@@ -938,8 +938,8 @@ and secrets directories into .eth/validator_keys instead."
             __api_container=${__vc_api_container}
             __api_port=${__vc_api_port}
             __api_tls=${__vc_api_tls}
-
-            jq --arg pubkey_value "$__pubkey" --arg url_value "http://web3signer:9000" '. | .remote_keys += [{"pubkey": $pubkey_value, "url": $url_value}]' <<< '{}' >/tmp/apidata.txt
+# shellcheck disable=SC2153
+            jq --arg pubkey_value "$__pubkey" --arg url_value "${W3S_NODE}" '. | .remote_keys += [{"pubkey": $pubkey_value, "url": $url_value}]' <<< '{}' >/tmp/apidata.txt
 
             get-token
             __api_data=@/tmp/apidata.txt
@@ -1019,9 +1019,9 @@ validator-register() {
     __api_path=eth/v1/keystores
     __token=NIL
     __vc_api_container=${__api_container}
-    __api_container=web3signer
+    __api_container=${__w3s_container}
     __vc_api_port=${__api_port}
-    __api_port=9000
+    __api_port=${__w3s_port}
     __vc_api_tls=${__api_tls}
     __api_tls=false
     __validator-list-call
@@ -1040,7 +1040,7 @@ validator-register() {
 
     __w3s_pubkeys="$(echo "$__result" | jq -r '.data[].validating_pubkey')"
     while IFS= read -r __pubkey; do
-         jq --arg pubkey_value "$__pubkey" --arg url_value "http://web3signer:9000" '. | .remote_keys += [{"pubkey": $pubkey_value, "url": $url_value}]' <<< '{}' >/tmp/apidata.txt
+         jq --arg pubkey_value "$__pubkey" --arg url_value "${W3S_NODE}" '. | .remote_keys += [{"pubkey": $pubkey_value, "url": $url_value}]' <<< '{}' >/tmp/apidata.txt
 
         __api_data=@/tmp/apidata.txt
         __api_path=eth/v1/remotekeys
@@ -1224,6 +1224,8 @@ __token_file_client="$1"
 __token_file=/tmp/api-token.txt
 __api_container=$2
 __api_port=${KEY_API_PORT:-7500}
+__w3s_container=$(echo "${W3S_NODE}" | awk -F[/:] '{print $4}')
+__w3s_port=$(echo "${W3S_NODE}" | awk -F[/:] '{print $5}')
 if [ -z "${TLS:+x}" ]; then
     __api_tls=false
 else

--- a/vero-vc-only.yml
+++ b/vero-vc-only.yml
@@ -30,6 +30,7 @@ services:
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER}
+      - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - LOG_LEVEL=${LOG_LEVEL}
     volumes:

--- a/vero/docker-entrypoint.sh
+++ b/vero/docker-entrypoint.sh
@@ -55,7 +55,7 @@ fi
 
 # Web3signer URL
 if [ "${WEB3SIGNER}" = "true" ]; then
-  __w3s_url="--remote-signer-url http://web3signer:9000"
+  __w3s_url="--remote-signer-url ${W3S_NODE}"
 else
   echo "Vero requires the use of web3signer.yml and WEB3SIGNER=true. Please reconfigure to use Web3Signer and start again"
   sleep 60

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -23,6 +23,10 @@ services:
       - /etc/localtime:/etc/localtime:ro
     environment:
       - NETWORK=${NETWORK}
+    networks:
+      default:
+        aliases:
+          - ${NETWORK}-web3signer # This allows multiple Eth Docker stacks all connected to the same central traefik
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Consider a deployment where holesky and hoodi are on one machine, both use web3signer and mev-boost, and both are connected to the same docker bridge network for central metrics collection.

This would currently break:
- web3signer:9000 is hard-coded in multiple locations
- mev-boost doesn't have an alias

Fix it by:
- Introducing an alias for mev-boost, which can then be referenced in `MEV_NODE`
- Introduce `W3S_NODE` and use it throughout. This means changes to almost every VC, and changes to the keymanager script
