### PR TITLE
Reduce w3s heap. 10k keys take 700MB

### DIFF
--- a/web3signer.yml
+++ b/web3signer.yml
@@ -22,6 +22,7 @@ services:
       - web3signer-keys:/var/lib/web3signer
       - /etc/localtime:/etc/localtime:ro
     environment:
+      - JAVA_OPTS=-Xmx2g
       - NETWORK=${NETWORK}
     depends_on:
       postgres:


### PR DESCRIPTION
On a 64 GiB machine, it allocates 16 GiB with default heap, and that's not reasonable