### PR TITLE
Update pre-commit-hooks to 5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     - id: trailing-whitespace-fixer
     - id: end-of-file-fixer


### PR DESCRIPTION
Mainly "just because", don't let CI dependencies get too old