### PR TITLE
Make web3signer heap configurable

### DIFF
--- a/default.env
+++ b/default.env
@@ -154,6 +154,8 @@ VC_EXTRAS=
 # to 8g. If left empty, the defaults in besu.yml and teku.yml are used.
 BESU_HEAP=
 TEKU_HEAP=
+# Heap for Web3signer. Defaults to -Xmx4g; -Xmx2g should also work in many setups
+W3S_HEAP=
 # Heap for Lodestar. Sets NODE_OPTIONS to this value, for example --max-old-space-size=8192.
 # If left empty, the default in lodestar.yml will be used.
 LODESTAR_HEAP=
@@ -382,4 +384,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=32
+ENV_VERSION=33

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -22,7 +22,7 @@ services:
       - web3signer-keys:/var/lib/web3signer
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - JAVA_OPTS=-Xmx2g
+      - JAVA_OPTS=${W3S_HEAP:--Xmx4g}
       - NETWORK=${NETWORK}
       - PG_ALIAS=${PG_ALIAS:-${NETWORK}-postgres}
     networks:


### PR DESCRIPTION
User reported that -Xmx2g failed with heap OOM. Default to 4g and make it configurable