### PR TITLE
[Lido Obol] Add `OBOL_CHARON_NICKNAME` env var

### DIFF
--- a/default.env
+++ b/default.env
@@ -91,6 +91,8 @@ SHARE_IP=
 
 # Relays to connect charon node
 OBOL_P2P_RELAYS=
+# External hostname or IP for P2P connections in Charon. Empy by default to avoid warnings.
+OBOL_P2P_EXTERNAL_HOSTNAME=
 
 # External Docker network if using ext-network.yml
 DOCKER_EXT_NETWORK=rocketpool_net
@@ -384,4 +386,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=33
+ENV_VERSION=34

--- a/default.env
+++ b/default.env
@@ -91,9 +91,9 @@ SHARE_IP=
 
 # Relays to connect charon node
 OBOL_P2P_RELAYS=
-# External hostname or IP for P2P connections in Charon. Empy by default to avoid warnings.
+# External hostname or IP for P2P connections in Charon. Empty by default
 OBOL_P2P_EXTERNAL_HOSTNAME=
-# Allows operators to set human readable nicknames in monitoring. Works from v1.3.0 only
+# Allows operators to set human readable nicknames in monitoring. Works from v1.3.0 only. Empty by default
 OBOL_CHARON_NICKNAME=
 
 # External Docker network if using ext-network.yml

--- a/default.env
+++ b/default.env
@@ -93,6 +93,8 @@ SHARE_IP=
 OBOL_P2P_RELAYS=
 # External hostname or IP for P2P connections in Charon. Empy by default to avoid warnings.
 OBOL_P2P_EXTERNAL_HOSTNAME=
+# Allows operators to set human readable nicknames in monitoring. Works from v1.3.0 only
+OBOL_CHARON_NICKNAME=
 
 # External Docker network if using ext-network.yml
 DOCKER_EXT_NETWORK=rocketpool_net

--- a/lido-obol.yml
+++ b/lido-obol.yml
@@ -26,6 +26,7 @@ services:
       - CHARON_FEATURE_SET_ENABLE=eager_double_linear,consensus_participate
       - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
       - CHARON_LOKI_SERVICE=charon
+      - CHARON_NICKNAME=${OBOL_CHARON_NICKNAME:-}
     ports:
       - ${OBOL_P2P_PORT:-3610}:${OBOL_P2P_PORT:-3610}/tcp # P2P TCP libp2p
     healthcheck:


### PR DESCRIPTION
This PR adds:
 -  **(only for Charon v1.3.0 and above)** possibility to set human readable nicknames in Obol monitoring via `OBOL_CHARON_NICKNAME` env var. These aim to make identifying operators more convenient;
 - `OBOL_P2P_EXTERNAL_HOSTNAME` in `default.env`.