### PR TITLE
Add Vero support to `./ethd version`

### DIFF
--- a/ethd
+++ b/ethd
@@ -4260,6 +4260,10 @@ version() {
       __docompose exec validator grandine --version
       echo
       ;;&
+    *vero-vc-only* )
+      __docompose exec validator python main.py --version
+      echo
+      ;;&
     *geth.yml* )
       __docompose exec execution geth version
       echo


### PR DESCRIPTION
Vero supports the `--version` flag in the v1 release candidates so adding it here.