### PR TITLE
Pass POSTGRES_USER during postgres upgrade

### DIFF
--- a/ethd
+++ b/ethd
@@ -967,7 +967,7 @@ __upgrade_postgres() {
   __dodocker pull "pgautoupgrade/pgautoupgrade:${__target_pg}-bookworm"
   __during_migrate=1
   __dodocker run --rm -v "${__source_vol}":"/var/lib/postgresql/data" \
-   -e PGAUTO_ONESHOT=yes -e POSTGRES_PASSWORD=postgres \
+   -e PGAUTO_ONESHOT=yes -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres \
    "pgautoupgrade/pgautoupgrade:${__target_pg}-bookworm"
 
   __migrated=1
@@ -982,7 +982,7 @@ __upgrade_postgres() {
 # shellcheck disable=SC2034
   PG_DOCKER_TAG=${__target_pg}-bookworm # To bookworm to avoid collation errors - also a faster PostgreSQL
   __update_value_in_env "${__var}" "${!__var}" "${__env_file}"
-  echo "Web3signer has been stopped. You'll need to run \"$__me up\" to start it again."
+  echo "Web3signer has been stopped. You'll need to run \"${__me} update\" and \"${__me} up\" to start it again."
   echo
   echo "A copy of your old slashing protection database is in the Docker volume ${__backup_vol}."
   echo "Confirm that everything works, and then delete it with \"docker volume rm ${__backup_vol}\"."


### PR DESCRIPTION
This can avoid `FATAL: role "root" does not exist`. While it may not actually be "FATAL", it's cleaner to hand the `POSTGRES_USER` in during migration.
