### PR TITLE
ethd install starts systemd-logind

### DIFF
--- a/ethd
+++ b/ethd
@@ -357,6 +357,7 @@ continue? (no/yes) " __yn
       ${__auto_sudo} apt-get update
       ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
         docker-buildx-plugin
+      ${__auto_sudo} systemctl start systemd-logind
       echo "Installed docker-ce and docker-compose-plugin"
     else
       echo "Docker is already installed"
@@ -396,6 +397,7 @@ continue? (no/yes) " __yn
       ${__auto_sudo} apt-get update
       ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
         docker-buildx-plugin
+      ${__auto_sudo} systemctl start systemd-logind
       echo "Installed docker-ce and docker-compose-plugin"
     else
       echo "Docker is already installed"


### PR DESCRIPTION
Otherwise `systemctl status docker` fails and thus `./ethd config` fails during QuickStart, because it can't verify that Docker is running

This is an issue on minimal Debian (everything deselected during tasksel), but I haven't encountered it elsewhere