### PR TITLE
metrics-exporter debian-latest for central-metrics

### DIFF
--- a/central-metrics.yml
+++ b/central-metrics.yml
@@ -10,7 +10,7 @@ x-logging: &logging
 services:
   ethereum-metrics-exporter:
     restart: "unless-stopped"
-    image: samcm/ethereum-metrics-exporter:0.24.0-debian
+    image: samcm/ethereum-metrics-exporter:debian-latest
     entrypoint:
       - /ethereum-metrics-exporter
       - --consensus-url=${CL_NODE}


### PR DESCRIPTION
To match all other yml files where ethereum-metrics-exporter is used