### PR TITLE
Support doppelganger protection in SSV >= 2.3.1

### DIFF
--- a/ssv.yml
+++ b/ssv.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - CONFIG_PATH=/config/config.yaml
       - HOME=/tmp
+      - ENABLE_DOPPELGANGER_PROTECTION=${DOPPELGANGER:-false}
     command: make BUILD_PATH=/go/bin/ssvnode start-node
     labels:
       - metrics.scrape=true


### PR DESCRIPTION
This was added with 2.3.1. For previous versions, this environment var is ignored, which makes this a non-breaking change