### PR TITLE
Update default docker repos for Prysm

### DIFF
--- a/default.env
+++ b/default.env
@@ -287,10 +287,10 @@ PRYSM_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=
 PRYSM_SRC_REPO=https://github.com/OffchainLabs/prysm
 PRYSM_DOCKER_TAG=stable
 PRYSM_DOCKER_VC_TAG=stable
-PRYSM_DOCKER_CTL_TAG=latest
-PRYSM_DOCKER_REPO=gcr.io/prysmaticlabs/prysm/beacon-chain
-PRYSM_DOCKER_VC_REPO=gcr.io/prysmaticlabs/prysm/validator
-PRYSM_DOCKER_CTL_REPO=gcr.io/prysmaticlabs/prysm/cmd/prysmctl
+PRYSM_DOCKER_CTL_TAG=stable
+PRYSM_DOCKER_REPO=gcr.io/offchainlabs/prysm/beacon-chain
+PRYSM_DOCKER_VC_REPO=gcr.io/offchainlabs/prysm/validator
+PRYSM_DOCKER_CTL_REPO=gcr.io/offchainlabs/prysm/cmd/prysmctl
 PRYSM_DOCKERFILE=Dockerfile.binary
 
 # Lodestar


### PR DESCRIPTION
Prysm's repo moved to offchainlabs. Old repo still works as well