### PR TITLE
Exact match for --help

### DIFF
--- a/ethd
+++ b/ethd
@@ -4475,7 +4475,7 @@ fi
 trap '__handle_error $? $LINENO' ERR
 trap '__handle_error $? $LINENO' EXIT
 
-if [[ "$#" -eq 0 || "$*" =~ "-h" ]]; then # Lazy match for -h and --help but also --histogram, so careful here
+if [[ "$#" -eq 0 || "$*" = "--help" || "$*" = "-h" || "$*" = "update --help" || "$*" = "update -h" ]]; then
   help "$@"
   exit 0
 fi


### PR DESCRIPTION
`./ethd cmd run --rm validator --help` for example would previously be caught by the lazy match and print `./ethd --help`, which is definitely not intended.

Match exactly instead, there are only a handful of strings after all.
