### PR TITLE
Enable cadvisor to detect OOMs

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -116,6 +116,9 @@ services:
       - /var/run:/var/run
       - /sys:/sys:ro,rslave
       - ${DOCKER_ROOT:-/var/lib/docker}:/var/lib/docker:ro,rslave
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    privileged: true
     command:
       - --docker_only
       - --housekeeping_interval=30s

--- a/grafana.yml
+++ b/grafana.yml
@@ -109,6 +109,9 @@ services:
       - /var/run:/var/run
       - /sys:/sys:ro,rslave
       - ${DOCKER_ROOT:-/var/lib/docker}:/var/lib/docker:ro,rslave
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    privileged: true
     command:
       - --docker_only
       - --housekeeping_interval=30s


### PR DESCRIPTION
This resolves `Could not configure a source for OOM detection, disabling OOM events: open /dev/kmsg: no such file or directory`

For this to work in Docker, both the `/dev/kmsg` device and the `privileged: true` are required