### PR TITLE
Error handler recognizes when it already ran

### DIFF
--- a/ethd
+++ b/ethd
@@ -3819,6 +3819,12 @@ __handle_error() {
   if [ "$__exit_code" -eq 0 ]; then
     return 0
   fi
+
+  if [[ -n "${__handler_ran:-}" ]]; then
+    return 0
+  fi
+  __handler_ran=1
+
   echo
   if [ "$__exit_code" -eq 130 ]; then
     echo "$__me terminated by user"


### PR DESCRIPTION
Error handler now runs twice because we'e trapping `ERR` and `EXIT`, see example below. Make it know it already ran so this doesn't happen.

```
service "validator" is not running

./ethd terminated with exit code 1 on line 21
This happened during ./ethd version 

./ethd terminated with exit code 1 on line 1
This happened during ./ethd version 
```
