### PR TITLE
Increase web3signer heap to 6g

### DIFF
--- a/web3signer.yml
+++ b/web3signer.yml
@@ -22,7 +22,7 @@ services:
       - web3signer-keys:/var/lib/web3signer
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - JAVA_OPTS=${W3S_HEAP:--Xmx4g}
+      - JAVA_OPTS=${W3S_HEAP:--Xmx6g}
       - NETWORK=${NETWORK}
       - PG_ALIAS=${PG_ALIAS:-${NETWORK}-postgres}
     networks:


### PR DESCRIPTION
A user reports that even 4g wasn't enough. This isn't expected, web3signer should be happy with even 2g - but as it isn't. let's bump the default. We can reduce it if/when web3signer uses less memory

"I'm not sure. I set the LOG_LEVEL to `info` and still got hit with `java.lang.OutOfMemoryError` until I upped the heap to 5g. I have plenty of memory, so I'm not too worried about it right now. It is curious though."