### PR TITLE
Use Teku for Ephemery

### DIFF
--- a/ethd
+++ b/ethd
@@ -3059,7 +3059,8 @@ __query_validator_client() {
     "nimbus-vc-only.yml" "Nimbus validator client" 3>&1 1>&2 2>&3)
   elif [ "${NETWORK}" = "ephemery" ]; then
     CONSENSUS_CLIENT=$(whiptail --notags --title "Select validator client" --menu \
-    "Which validator client do you want to run?" 9 65 1 \
+    "Which validator client do you want to run?" 9 65 2 \
+    "teku-vc-only.yml" "Teku validator client" \
     "lodestar-vc-only.yml" "Lodestar validator client" \
     3>&1 1>&2 2>&3)
   elif [ "${__deployment}" = "rocket" ]; then
@@ -3112,7 +3113,8 @@ __query_consensus_client() {
     3>&1 1>&2 2>&3)
   elif [ "${NETWORK}" = "ephemery" ]; then
     CONSENSUS_CLIENT=$(whiptail --notags --title "Select consensus client" --menu \
-    "Which consensus client do you want to run?" 9 65 1 \
+    "Which consensus client do you want to run?" 9 65 2 \
+    "teku.yml" "Teku (Java) - consensus and validator client" \
     "lodestar.yml" "Lodestar (TypeScript) - consensus and validator client" \
     3>&1 1>&2 2>&3)
   elif uname -m | grep -q aarch64 || uname -m | grep -q arm64; then
@@ -3163,7 +3165,8 @@ __query_consensus_only_client() {
     3>&1 1>&2 2>&3)
   elif [ "${NETWORK}" = "ephemery" ]; then
     CONSENSUS_CLIENT=$(whiptail --notags --title "Select consensus client" --menu \
-    "Which consensus client do you want to run?" 9 65 1 \
+    "Which consensus client do you want to run?" 9 65 2 \
+    "teku-cl-only.yml" "Teku (Java) - consensus client" \
     "lodestar-cl-only.yml" "Lodestar (TypeScript) - consensus client" \
     3>&1 1>&2 2>&3)
   elif uname -m | grep -q aarch64 || uname -m | grep -q arm64; then


### PR DESCRIPTION
Lodestar was throwing errors, reported by a user on Discord

As per https://github.com/ephemery-testnet/ephemery-resources/blob/master/client-implementations.md we'd need a special build for Lodestar

Teku and Besu are ready with main images, tested locally

Users who want an experimental client are advanced and can source-build via `.env`, `./ethd config` should offer a seamless experience