### PR TITLE
Aliases do not use variables

### DIFF
--- a/default.env
+++ b/default.env
@@ -193,14 +193,15 @@ EL_NODE=http://execution:8551
 CL_NODE=http://consensus:5052
 # Used by "ethd keys", adjust this if you have multiple Eth Docker stacks connected to the same Docker bridge network
 VC_ALIAS=vc
-# For a Vero N of M, set aliases for CL, EL, MEV and Web3signer to distinguish the different stacks
-W3S_ALIAS=${NETWORK}-web3signer
-PG_ALIAS=${NETWORK}-postgres
-CL_ALIAS=${NETWORK}-consensus
-EL_ALIAS=${NETWORK}-execution
-MEV_ALIAS=${NETWORK}-mev
-# MEV-boost address. This would only be changed for Vouch setups
-MEV_NODE=http://${MEV_ALIAS}:18550
+# For a Vero N of M, set aliases for CL, EL, MEV and Web3signer to distinguish the different stacks, by replacing the entire alias
+# or by replacing just "uniqueprefix"
+W3S_ALIAS=uniqueprefix-web3signer
+PG_ALIAS=uniqueprefix-postgres
+CL_ALIAS=uniqeprefix-consensus
+EL_ALIAS=uniqueprefix-execution
+MEV_ALIAS=uniqueprefix-mev
+# MEV-boost address. This would be changed for commit boost and Vouch setups
+MEV_NODE=http://mev-boost:18550
 # Web3signer address - match service name or alias, or it can be remote
 W3S_NODE=http://web3signer:9000
 # Consensus client addresses for Charon in Obol setup


### PR DESCRIPTION
Resolves #2148 . I've had multiple users now where these aliases break their setup. They likely have ancient Compose versions, and, it's better to be less flexible now than needing to support a sizeable part of the user base that doesn't auto upgrade.

Alternative, or alongside this: Check for docker compose version and if it's below a certain threshold, run an apt update && apt dist-upgrade -y for the user, possibly narrowly just for docker and docker compose.

Or bomb out and tell them to please do it, giving them agency.

Or like this ... just side-step the issue for now.
 