### PR TITLE
[OBOL] Fix metrics exporter CL url

### DIFF
--- a/central-metrics.yml
+++ b/central-metrics.yml
@@ -13,7 +13,7 @@ services:
     image: samcm/ethereum-metrics-exporter:debian-latest
     entrypoint:
       - /ethereum-metrics-exporter
-      - --consensus-url=${CL_NODE}
+      - --consensus-url=http://consensus:${CL_REST_PORT:-5052}
       - --execution-url=http://execution:${EL_RPC_PORT:-8545}
     <<: *logging
     labels:

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -46,7 +46,7 @@ services:
     image: samcm/ethereum-metrics-exporter:debian-latest
     entrypoint:
       - /ethereum-metrics-exporter
-      - --consensus-url=${CL_NODE}
+      - --consensus-url=http://consensus:${CL_REST_PORT:-5052}
       - --execution-url=http://execution:${EL_RPC_PORT:-8545}
     <<: *logging
     labels:

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -37,7 +37,7 @@ services:
     image: samcm/ethereum-metrics-exporter:debian-latest
     entrypoint:
       - /ethereum-metrics-exporter
-      - --consensus-url=${CL_NODE}
+      - --consensus-url=http://consensus:${CL_REST_PORT:-5052}
       - --execution-url=http://execution:${EL_RPC_PORT:-8545}
     <<: *logging
 

--- a/grafana.yml
+++ b/grafana.yml
@@ -38,7 +38,7 @@ services:
     image: samcm/ethereum-metrics-exporter:debian-latest
     entrypoint:
       - /ethereum-metrics-exporter
-      - --consensus-url=${CL_NODE}
+      - --consensus-url=http://consensus:${CL_REST_PORT:-5052}
       - --execution-url=http://execution:${EL_RPC_PORT:-8545}
     <<: *logging
     labels:


### PR DESCRIPTION
Fixing the issue where the exporter was collecting metrics from `charon`, not from CL node