### PR TITLE
Support Besu pre-merge history expiry

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -26,6 +26,7 @@ services:
       - JWT_SECRET=${JWT_SECRET:-}
       - EL_EXTRAS=${EL_EXTRAS:-}
       - ARCHIVE_NODE=${EL_ARCHIVE_NODE:-}
+      - MINIMAL_NODE=${EL_MINIMAL_NODE:-}
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
     volumes:
@@ -87,7 +88,7 @@ services:
     user: "10001:10001"
     restart: "no"
     volumes:
-      - besu-eth1-data:/var/lib/besu
+      - besu-el-data:/var/lib/besu
     entrypoint: ["/bin/sh","-c"]
     command: /bin/sh
 

--- a/ethd
+++ b/ethd
@@ -2535,26 +2535,38 @@ prune-history() {
   case "${__value}" in
     *geth.yml* )
       __client="Geth"
+      __min_ver="master / latest"
+      __extra_msg=""
       __prune_marker="/var/lib/geth/prune-marker"
       ;;
     *nimbus-el.yml* )
       __client="Nimbus"
+      __min_ver="v0.10.0"
+      __extra_msg=""
       __prune_marker=""
       ;;
     *nethermind.yml* )
       __client="Nethermind"
+      __min_ver="v1.31.9"
+      __extra_msg=""
       __prune_marker=""
       ;;
     *besu.yml* )
       __client="Besu"
-      __prune_marker=""
-      ;;&
+      __min_ver="25.6.0-RC1"
+      __extra_msg="This may require up to 150GB of additional storage before pruning finishes.\nIn 3 days, run \"${__me} restart execution\" to remove the Besu pruner, see Besu release notes."
+      __prune_marker="/var/lib/besu/prune-history-marker"
+      ;;
     *reth.yml* )
       __client="Reth"
+      __min_ver="vTBD"
+      __extra_msg=""
       __prune_marker=""
       ;;&
     *erigon.yml* )
       __client="Erigon"
+      __min_ver="vTBD"
+      __extra_msg=""
       __prune_marker=""
       ;;&
     * )
@@ -2572,6 +2584,10 @@ prune-history() {
     exit 1
   fi
 
+  echo "Pruning pre-merge history requires ${__client} {__min_ver} or later."
+  if [ -n "${__extra_msg:-}" ]; then
+    echo -e "${__extra_msg}"
+  fi
   if [ -z "${__prune_marker}" ]; then  # Full resync
     if [ $__non_interactive = 0 ]; then
       __warning="WARNING - this will stop ${__client} and resync it from scratch without pre-merge history. Do you wish to continue? (No/Yes) "


### PR DESCRIPTION
A followup PR will be needed when Besu changes its flags. `--Xsnapsync-synchronizer-pre-merge-headers-only-enabled=true` may become `--snapsync-synchronizer-pre-merge-headers-only-enabled=true` and be default.

For now, if `EL_MINIMAL_NODE=true`, sync with `--Xsnapsync-synchronizer-pre-merge-headers-only-enabled=true`.

`./ethd prune-history` runs `storage prune-pre-merge-blocks` then on restart enables RocksDB garbage collection with `--Xhistory-expiry-prune`. This should free space within 2-6 hours. To be on the safe side, it's kept active for 48 hours, and if Besu restarts after that, the flag is removed.

Docs: https://github.com/hyperledger/besu/releases/tag/25.6.0-RC1

Because Besu may need additional space, I want to offer this to users before they run out entirely. I've added a __min_ver and __extra_msg to inform users of the version they need, and any additional requirements.
