### PR TITLE
Set Nethermind ancient barrier to first PoS block

### DIFF
--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -83,7 +83,7 @@ elif [[ ! "${NETWORK}" =~ ^https?:// ]]; then  # Only configure prune parameters
     case "${NETWORK}" in
       mainnet )
         echo "Methermind minimal node with pre-merge history expiry"
-        __prune+=" --Sync.AncientBodiesBarrier=15537392 --Sync.AncientReceiptsBarrier=15537392"
+        __prune+=" --Sync.AncientBodiesBarrier=15537394 --Sync.AncientReceiptsBarrier=15537394"
         ;;
       sepolia )
         echo "Relying on Nethermind default expiry for Sepolia minimal node"


### PR DESCRIPTION
This barrier is "The earliest body downloaded with fast sync when `DownloadBodiesInFastSync` is set to `true`.", analogous for receipts.

Sepolia: Terminal PoW block https://sepolia.etherscan.io/block/1450408, PoS transition block https://sepolia.etherscan.io/block/1450409
Mainnet: Terminal PoW block https://etherscan.io/block/15537393, PoS transition block https://etherscan.io/block/15537394

Therefore, to expire all PoW block history:
Sepolia, expire `1450408` and earlier
Mainnet, expire `15537393` and earlier