### PR TITLE
chore(env): add pruning warning and EIP-4444 data retention info

### DIFF
--- a/default.env
+++ b/default.env
@@ -182,10 +182,15 @@ CL_ARCHIVE_NODE=false
 # Set this to true to sync a minimal CL node - in use with Grandine and Teku, for example
 # CL_ARCHIVE_NODE must be false for this to take effect
 CL_MINIMAL_NODE=true
-# Set this to true to sync a node that does not carry all historical data, see EIP-4444
+# Set this to true to sync a node that does not carry more than 1 year of historical data, see EIP-4444
 # Only meaningful for mainnet and sepolia, may fail on hoodi
 # Erigon also has an \"aggressive\" mode that prunes even more
 # EL_ARCHIVE_NODE must be false for this to take effect
+# ⚠️ WARNING:
+# - Historical data older than 1 year will be deleted.
+# - Pruning can take 2 to 10 hours depending on hardware.
+# - Requires at least 50GB of free disk space.
+# - During pruning, the node cannot validate unless a fallback is configured.
 EL_MINIMAL_NODE=false
 # Era URLs, see https://eth-clients.github.io/history-endpoints/
 # Era1 is for pre-merge data, Era for post-merge. If these URLs are

--- a/default.env
+++ b/default.env
@@ -183,10 +183,10 @@ CL_ARCHIVE_NODE=false
 # CL_ARCHIVE_NODE must be false for this to take effect
 CL_MINIMAL_NODE=true
 # Set this to true to sync a node that does not carry more than 1 year of historical data, see EIP-4444
-# Only meaningful for mainnet and sepolia, may fail on hoodi
-# Erigon also has an \"aggressive\" mode that prunes even more
-# EL_ARCHIVE_NODE must be false for this to take effect
 # ⚠️ WARNING:
+# - Only meaningful for mainnet and sepolia, may fail on hoodi
+# - Erigon also has an \"aggressive\" mode that prunes even more
+# - EL_ARCHIVE_NODE must be false for this to take effect
 # - Historical data older than 1 year will be deleted.
 # - Pruning can take 2 to 10 hours depending on hardware.
 # - Requires at least 50GB of free disk space.


### PR DESCRIPTION
**What I did**

Added a clear warning and descriptive comments in the .env file regarding the use of EL_MINIMAL_NODE and its implications under EIP-4444.

Clarified that enabling minimal mode limits historical data to 1 year and included pruning duration (2–10 hours), disk space requirements (≥50 GB), and validator risks if no fallback is configured.

