### PR TITLE
default.env has more language around EL_MINIMAL_NODE

### DIFF
--- a/default.env
+++ b/default.env
@@ -184,6 +184,9 @@ CL_ARCHIVE_NODE=false
 CL_MINIMAL_NODE=true
 # Set this to true to sync a node that does not carry all historical data, see EIP-4444
 # Only meaningful for mainnet and sepolia, may fail on hoodi
+# This expires pre-merge blocks and receipts as of June 2025, see https://hackmd.io/@hBXHLw_9Qq2va4pRtI4bIA/ryzBaf7fJx
+# Consider using `./ethd prune-history`, which guides you as to whether to prune in-place
+# or resync, depending on client
 # Erigon also has an \"aggressive\" mode that prunes even more
 # EL_ARCHIVE_NODE must be false for this to take effect
 EL_MINIMAL_NODE=false


### PR DESCRIPTION
**What I did**

Added some language to `default.env` to point out that `EL_MINIMAL_NODE` expires pre-merge history right now, not
full EIP-4444, and that `./ethd prune-history` exists.
