### PR TITLE
Mention prune-history when space is low

### DIFF
--- a/ethd
+++ b/ethd
@@ -717,6 +717,8 @@ __check_disk_space() {
   __get_value_from_env "${__var}" "${__env_file}" "__auto_prune"
   __var="NETWORK"
   __get_value_from_env "${__var}" "${__env_file}" "NETWORK"
+  __var="EL_MINIMAL_NODE"
+  __get_value_from_env "${__var}" "${__env_file}" "__el_minimal"
 
   if [ "${NETWORK}" = "mainnet" ] || [ "${NETWORK}" = "gnosis" ]; then
     __min_free=314572800
@@ -728,9 +730,12 @@ __check_disk_space() {
     __safe_prune=25
   fi
 
-# Literal match intended
-# shellcheck disable=SC2076
-  if [[ "${__value}" =~ "nethermind.yml" ]] && [[ "${__free_space}" -lt "${__min_free}" ]]; then
+# shellcheck disable=SC2154
+  if [[ "${NETWORK}" = "mainnet" && "${__free_space}" -lt 104857600 && "${__el_minimal}" = "false" ]]; then
+    echo
+    echo "You have less than 100 GiB free and are not using pre-merge history expiry."
+    echo "Consider running \"${__me} prune-history\" to free up some space".
+  elif [[ "${__value}" = *"nethermind.yml"* ]] && [[ "${__free_space}" -lt "${__min_free}" ]]; then
     echo
     echo "You are running Nethermind and have less than ${__min_gib} GiB of free disk space."
 # shellcheck disable=SC2154
@@ -743,14 +748,14 @@ Full\". Free space:"
     echo
     __display_docker_dir
     __display_docker_volumes
-  elif [[ "${__value}" =~ "geth.yml" ]] && [[ "${__free_space}" -lt 104857600 ]]; then
+  elif [[ "${__value}" = *"geth.yml"* ]] && [[ "${__free_space}" -lt 104857600 ]]; then
     echo
     echo "You are running Geth and have less than 100 GiB of free disk space."
     echo "You may resync from scratch to use PBSS and slow on-disk DB growth, with \"$__me resync-execution\"."
     echo
     __display_docker_dir
     __display_docker_volumes
-  elif [[ "${__value}" =~ "besu.yml" ]] && [[ "${__free_space}" -lt 52428800 ]]; then
+  elif [[ "${__value}" = *"besu.yml"* ]] && [[ "${__free_space}" -lt 52428800 ]]; then
     echo
     echo "You are running Besu and have less than 50 GiB of free disk space."
     echo
@@ -763,8 +768,6 @@ Full\". Free space:"
     echo
     __display_docker_dir
     echo
-    echo "Pruning does not appear an option for your client mix."
-    echo "If total space is less than 1.8 TiB, consider cloning to a larger drive."
     __display_docker_volumes
   fi
 }


### PR DESCRIPTION
**What I did**

Change the warning message shown to users on low disk space: Check whether history expiry is on, and if not, let them know that's an option.

Otherwise, use much of the same logic as before. Remove the mention of a 1.8TB drive, that's too specific and outdated.
