### PR TITLE
Default traefik tag is 3.4

### DIFF
--- a/default.env
+++ b/default.env
@@ -409,7 +409,7 @@ DEPCLI_DOCKER_REPO=ghcr.io/eth-educators/ethstaker-deposit-cli
 DEPCLI_DOCKERFILE=Dockerfile.binary
 
 # traefik and ddns-updater
-TRAEFIK_TAG=v3.3
+TRAEFIK_TAG=v3.4
 DDNS_TAG=v2
 
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.


### PR DESCRIPTION
**What I did**

Updated the default traefik tag to 3.4. No need to force users to use it
