### PR TITLE
Besu 25.6.0 for history expiry, and mention resync

### DIFF
--- a/ethd
+++ b/ethd
@@ -2587,8 +2587,8 @@ prune-history() {
       ;;
     *besu.yml* )
       __client="Besu"
-      __min_ver="25.6.0-RC1"
-      __extra_msg="This may require up to 200GiB of additional storage before pruning finishes.\nIn 3 days, run \"${__me} restart execution\" to remove the Besu pruner, see Besu release notes."
+      __min_ver="25.6.0"
+      __extra_msg="This may require up to 200GiB of additional storage before pruning finishes.\nIn 3 days, run \"${__me} restart execution\" to remove the Besu pruner, see Besu release notes.\nA resync saves more space than a prune: You can set \"EL_MINIMAL_NODE=true\" manually with \"nano .env\" and then resync with \"./ethd resync-execution\"."
       __prune_marker="/var/lib/besu/prune-history-marker"
       ;;
     *reth.yml* )


### PR DESCRIPTION
**What I did**

Document `25.6.0` as the minimum Besu version for history expiry, and mention that a fresh sync saves more space than a prune.
