### PR TITLE
Make trace work for ethd keys import

### DIFF
--- a/ethd
+++ b/ethd
@@ -2617,6 +2617,10 @@ __prep-keyimport() {
         __args+="${__args:+ }--debug"
         shift
         ;;
+      --trace)
+        __args+="${__args:+ }--trace"
+        shift
+        ;;
       *)
         echo "Error: Unknown option: $1" >&2
         exit 1


### PR DESCRIPTION
**What I did**

`ethd keys import` is handled by `ethd` first because of `--path`, and so `--trace` didn't work. Fixed that
