### PR TITLE
Force permissions for keymanager `/tmp`

### DIFF
--- a/vc-utils/Dockerfile
+++ b/vc-utils/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq gosu
+# A user had root:984 and 755 permissions on /tmp. Root cause unknown; work around it
+RUN chmod 1777 /tmp
 COPY --chown=1000:1000 ./keymanager.sh /usr/local/bin/
 # Belt and suspenders
 RUN chmod -R 755 /usr/local/bin/*

--- a/vc-utils/keymanager.sh
+++ b/vc-utils/keymanager.sh
@@ -1220,6 +1220,7 @@ if [ "$(id -u)" = '0' ]; then
         exit 0
     fi
     if [ -f "$__token_file" ]; then
+        chmod 1777 /tmp  # A user had 755 and root:984. Root cause unknown; work around it
         cp "$__token_file" /tmp/api-token.txt
         chown "${OWNER_UID:-1000}":"${OWNER_UID:-1000}" /tmp/api-token.txt
         exec gosu "${OWNER_UID:-1000}":"${OWNER_UID:-1000}" "${BASH_SOURCE[0]}" "$@"


### PR DESCRIPTION
**What I did**

A user had `755` permissions and `root:984` for `/tmp` in the keymanager container.

I don't know why. Workaround is to set permissions during Dockerfile and then again when starting the container. Between those two, fingers crossed, it'll work.

Symptom was `curl: (23) Failure writing output to destination`

