### PR TITLE
Remove unsafe Obol monitoring endpoint

### DIFF
--- a/prometheus/obol-prom.yml
+++ b/prometheus/obol-prom.yml
@@ -1,5 +1,5 @@
 remote_write:
-  - url: https://vm.monitoring.gcp.obol.tech/write
+  - url: 
     authorization:
       credentials: OBOL_PROM_REMOTE_WRITE_TOKEN
     write_relabel_configs:


### PR DESCRIPTION
I propose to remove the link https://vm.monitoring.gcp.obol.tech/write from prometheus/obol-prom.yml for the following reasons:
 The link is flagged as potentially malicious by Phantom security system
 Service returns 401 error (unavailable)
 Using this link may pose a security risk
Suggestions:
Either completely remove this link
Or replace with a current secure link from the Obol team