### PR TITLE
Improve NODE_EXPORTER_IGNORE_MOUNT_REGEX

### DIFF
--- a/default.env
+++ b/default.env
@@ -413,7 +413,7 @@ TRAEFIK_TAG=v3.4
 DDNS_TAG=v2
 
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.
-NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
+NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker.+)($|/)'
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd
 DOCKER_ROOT=/var/lib/docker
 

--- a/ethd
+++ b/ethd
@@ -122,11 +122,13 @@ __handle_docker() {
 
     __var=NODE_EXPORTER_IGNORE_MOUNT_REGEX
     __get_value_from_env "${__var}" "${__env_file}" "__value"
-    __regex="^'\^/\(dev\|proc\|sys\|run\|.+/\.\+\)\(\$\|/\)'$"
+# Match either of the patterns Eth Docker uses. Leave alone if there are user changes to the var
+# Match literal `'^/(dev|proc|sys|run|some/path/.+)($|/)'` or `'^/(dev|proc|sys|run|var/snap/.+|some/path/.+)($|/)'
+    __regex="^'\^\/\(dev\|proc\|sys\|run\|(var\/snap\/\.\+\|)?[a-zA-Z/]+\/\.\+\)\(\\$\|\/\)'$"
     if [[ "${__value}" =~ ${__regex} ]]; then
 # This gets used, but shellcheck doesn't recognize that
 # shellcheck disable=SC2034
-      NODE_EXPORTER_IGNORE_MOUNT_REGEX="'^/(dev|proc|sys|run|${DOCKER_ROOT#/}/.+)($|/)'"
+      NODE_EXPORTER_IGNORE_MOUNT_REGEX="'^/(dev|proc|sys|run|var/snap/.+|${DOCKER_ROOT#/}/.+)($|/)'"
       __update_value_in_env "${__var}" "${!__var}" "${__env_file}"
     fi
   fi


### PR DESCRIPTION
**What I did**

On Ubuntu Desktop, `/var/snap` mounts are counted twice in the disk space panel. Add `var/snap/.+` to the exclude regex to fix that

In `ethd`, I am looking for a vanilla (not user-changed) value of `NODE_EXPORTER_IGNORE_MOUNT_REGEX`, and if I find it, adjust it to the user's `${DOCKER_ROOT}`. Which is a lovely theory, but never actually worked because the regex was wrong.

With some spirited `grep -E` troubleshooting, I now have a working regex. Testing `__regex="^'\^\/\(dev\|proc\|sys\|run\|(var\/snap\/\.\+\|)?[a-zA-Z/]+\/\.\+\)\(\\$\|\/\)'$"` against various values, I get:

```
it matched '^/(dev|proc|sys|run|var/lib/docker/.+)($|/)'
it matched '^/(dev|proc|sys|run|var/snap/.+|var/lib/docker/.+)($|/)'
it matched '^/(dev|proc|sys|run|var/snap/.+|mnt/.+)($|/)'
it matched '^/(dev|proc|sys|run|var/snap/.+|mnt/docker/.+)($|/)'
it matched '^/(dev|proc|sys|run|mnt/docker/.+)($|/)'
it didn't match '^/(dev|proc|sys|run|var/snap/snoo/.+|var/lib/docker/.+)($|/)'
it didn't match '^/(dev|proc|sys|run|var/snap/.+|var/lib/docker/.+|snoo)($|/)'
it didn't match '^/(dev|proc|sys|run|snoo|var/snap/.+|var/lib/docker/.+)($|/)'
it didn't match '^/(dev|proc|sys|run|var/snap/.+|snoo|var/lib/docker/.+)($|/)'
```

