### PR TITLE
Replace default cadvisor dashboard

### DIFF
--- a/grafana/provision.sh
+++ b/grafana/provision.sh
@@ -185,7 +185,7 @@ case "$CLIENT" in
     ;;&
   !(*grafana-rootless*) )
       # cadvisor and node exporter dashboard
-      __id=10619
+      __id=19724
       __revision=$(wget -t 3 -T 10 -qO - https://grafana.com/api/dashboards/${__id} | jq .revision)
       __url="https://grafana.com/api/dashboards/${__id}/revisions/${__revision}/download"
       __file='/etc/grafana/provisioning/dashboards/docker-host-container-overview.json'


### PR DESCRIPTION
**What I did**

Replaced what we have, which shows several "No Data" because metrics names changed and it was last updated in 2019, with something last updated in 2023.

Which the "optimal" dashboard is always up for debate - this is at least better
