### PR TITLE
Erigon don't persist receipts

### DIFF
--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -59,16 +59,16 @@ if [ "${ARCHIVE_NODE}" = "true" ]; then
   __prune="--prune.mode=archive --prune.distance=0"
 elif [ "${MINIMAL_NODE}" = "aggressive" ]; then
   echo "Erigon minimal node with aggressive expiry"
-  __prune="--prune.mode=minimal"
+  __prune="--prune.mode=minimal --experiment.persist.receipts.v2=false"
 elif [ "${MINIMAL_NODE}" = "true" ]; then
   case "${NETWORK}" in
     mainnet | sepolia )
       echo "Erigon minimal node with pre-merge history expiry"
-      __prune="--prune.mode=full"
+      __prune="--prune.mode=full --experiment.persist.receipts.v2=false"
       ;;
     * )
       echo "There is no pre-merge history for ${NETWORK} network, Erigon will use \"full\" pruning."
-      __prune="--prune.mode=full"
+      __prune="--prune.mode=full --experiment.persist.receipts.v2=false"
       ;;
   esac
 else


### PR DESCRIPTION
**What I did**

Add ` --experiment.persist.receipts.v2=false` to expired nodes. This is the current default.

Erigon 3.1 will add `--persist.receipts=true` as the default, and still support ` --experiment.persist.receipts.v2`. Persisted receipts are useful for full and archive nodes; not useful for expired nodes which are presumably for staking. 300GB extra storage for faster eth_getLogs() isn't worth it, there.

This change will keep the current behavior for expired nodes when 3.1 is out. In future, the parameter can be changed to `--persist.receipts=false`.