### PR TITLE
Correctly detect last Reth that touched the DB

### DIFF
--- a/ethd
+++ b/ethd
@@ -1062,7 +1062,7 @@ repair-reth() {
   # Check for last Reth that touched the DB
     set +e
     __docompose exec -T -u root execution /bin/bash -c 'apt-get update && apt-get install -y --no-install-recommends jq'
-    __reth_db_version=$(__docompose exec -T execution /bin/bash -c 'reth db --datadir /var/lib/reth list VersionHistory --json --quiet | grep "\[" -A 50 | jq -r .[0][1].version')
+    __reth_db_version=$(__docompose exec -T execution /bin/bash -c 'reth db --datadir /var/lib/reth list VersionHistory -r -l 1 --json --quiet | grep "\[" -A 50 | jq -r .[0][1].version')
     __exitstatus=$?
     set -e
 


### PR DESCRIPTION
**What I did**

Need `-r -l 1` in the query, otherwise I get the Reth that synced the DB, not the last Reth to touch it
