### PR TITLE
reth: revert pruning for Transaction Lookup

### DIFF
--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -84,7 +84,7 @@ if [ "${ARCHIVE_NODE}" = "true" ]; then
   echo "Reth archive node without pruning"
   __prune=""
 elif [ "${MINIMAL_NODE}" = "true" ]; then
-  __prune="--block-interval 5 --prune.senderrecovery.full --prune.accounthistory.distance 10064 --prune.storagehistory.distance 10064 --prune.transactionlookup.distance 10064"
+  __prune="--block-interval 5 --prune.senderrecovery.full --prune.accounthistory.distance 10064 --prune.storagehistory.distance 10064"
   case ${NETWORK} in
     mainnet|sepolia )
       echo "Reth minimal node with pre-merge history expiry"


### PR DESCRIPTION
**What I did**

Reverts https://github.com/ethstaker/eth-docker/pull/2257

`--prune.transcationlookup` doesn't work well with `--prune.bodies.pre-merge`. Reth team is aware of the issue and the fix will be out in the next release, in the meantime we need to remove this flag for the minimal set up of a node.

**Related issue**

```
execution-1  | 2025-09-09T10:24:02.992856Z  INFO Executing stage pipeline_stages=14/15 stage=Prune checkpoint=23320302 target=23324505
execution-1  | 2025-09-09T10:24:03.441885Z  WARN Could not find block or tx number on a range request segment=Transactions number=0
execution-1  | 2025-09-09T10:24:03.442140Z  WARN Stage encountered a non-fatal error: unable to find Transactions static file for transaction id 0. Retrying... stage=Prune
execution-1  | 2025-09-09T10:24:03.442239Z  INFO Preparing stage pipeline_stages=14/15 stage=Prune checkpoint=23320302 target=23324505
```

source: https://t.me/paradigm_reth/45176
