### PR TITLE
Allow Prometheus to scrape targets on host.docker.internal

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -34,6 +34,8 @@ services:
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
     <<: *logging
+    extra_hosts:  # So we can scrape targets on the host
+      - "host.docker.internal:host-gateway"
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -27,6 +27,8 @@ services:
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
     <<: *logging
+    extra_hosts:  # So we can scrape targets on the host
+      - "host.docker.internal:host-gateway"
     depends_on:
       - blackbox-exporter
       - json-exporter

--- a/grafana.yml
+++ b/grafana.yml
@@ -26,6 +26,8 @@ services:
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
     <<: *logging
+    extra_hosts:  # So we can scrape targets on the host
+      - "host.docker.internal:host-gateway"
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/prometheus/.gitignore
+++ b/prometheus/.gitignore
@@ -1,5 +1,2 @@
 # Ensure user-added configs don't get mixed up in git
-.conf.d/*
-!.conf.d/ping.yml
-!.conf.d/coingecko.yml
 custom-prom.yml

--- a/prometheus/conf.d/.gitignore
+++ b/prometheus/conf.d/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!ping.yml
+!coingecko.yml
+!*.sample

--- a/prometheus/conf.d/host-scrape.yml.sample
+++ b/prometheus/conf.d/host-scrape.yml.sample
@@ -1,0 +1,8 @@
+scrape_configs:
+  # Give the job a name
+  - job_name: 'myjob'
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    static_configs:
+      # Scrape something directly on the host. For a docker service, do "<service-name>:<port>" instead
+      - targets: ['host.docker.internal:9090']


### PR DESCRIPTION
**What I did**

Add the ability to scrape `host.docker.internal` and provide a sample file in `prometheus/conf.d`

This means users can scrape things they run on the host or have exposed to the host
