### PR TITLE
Node exporter scrapes all interfaces

### DIFF
--- a/default.env
+++ b/default.env
@@ -155,6 +155,12 @@ OBOL_P2P_PORT=3610
 EE_PORT=8551
 # Consensus layer REST port. Only for distributed setups, this should otherwise be left alone
 CL_REST_PORT=5052
+# Node exporter is direct on host, make sure it doesn't conflict
+# If ufw is "in front of" Docker, make sure to allow this traffic
+# sudo ufw allow from 172.16.0.0/12 to any port 9199 comment "node-exporter from docker"
+# sudo ufw allow from 192.168.0.0/16 to any port 9199 comment "node-exporter from docker"
+NODE_EXPORTER_PORT=9199
+
 
 # Additional parameters for the EL client. For example, on low-memory machines,
 # you may want to use it to lower Geth cache, or to increase it on high-memory machines
@@ -422,10 +428,12 @@ DEPCLI_DOCKERFILE=Dockerfile.binary
 TRAEFIK_TAG=v3.5
 DDNS_TAG=v2
 
+# Path to mount to node-exporter if needed for --collector.textfile.directory
+NODE_EXPORTER_COLLECTOR_MOUNT_PATH=/dev/null
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.
 NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker.+)($|/)'
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=42
+ENV_VERSION=43

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -61,22 +61,29 @@ services:
       - '--path.rootfs=/host'
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
-      # - '--collector.textfile.directory=/etc/node-exporter/'
-      - '--collector.filesystem.ignored-mount-points=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
+      - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
       - '--no-collector.ipvs'
+      - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}'
+      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
+      - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
     pid: host
+    network_mode: host  # See all network interfaces
     restart: unless-stopped
+    environment:
+      - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
     volumes:
       - /:/host:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /proc:/host/proc:ro,rslave
       - /sys:/host/sys:ro,rslave
       - /etc/localtime:/etc/localtime:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:ro
     <<: *logging
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics
-      - metrics.port=9100
+      - metrics.host=host.docker.internal
+      - metrics.port=${NODE_EXPORTER_PORT:-9199}
       - metrics.instance=node-exporter
       - metrics.network=${NETWORK}
 

--- a/grafana.yml
+++ b/grafana.yml
@@ -54,22 +54,29 @@ services:
       - '--path.rootfs=/host'
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
-      # - '--collector.textfile.directory=/etc/node-exporter/'
-      - '--collector.filesystem.ignored-mount-points=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
+      - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
       - '--no-collector.ipvs'
+      - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}'
+      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
+      - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
     pid: host
+    network_mode: host  # See all network interfaces
     restart: unless-stopped
+    environment:
+      - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
     volumes:
       - /:/host:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /proc:/host/proc:ro,rslave
       - /sys:/host/sys:ro,rslave
       - /etc/localtime:/etc/localtime:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:ro
     <<: *logging
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics
-      - metrics.port=9100
+      - metrics.host=host.docker.internal
+      - metrics.port=${NODE_EXPORTER_PORT:-9199}
       - metrics.instance=node-exporter
       - metrics.network=${NETWORK}
 

--- a/prometheus/base-config.yml
+++ b/prometheus/base-config.yml
@@ -43,6 +43,14 @@ scrape_configs:
           - __address__
           - __meta_docker_container_label_metrics_port
         target_label: __address__
+      # Optional: metrics.host overrides __address__
+      - action: replace
+        source_labels:
+          - __meta_docker_container_label_metrics_host
+          - __meta_docker_container_label_metrics_port
+        regex: (.+);(\d+)
+        replacement: $1:$2
+        target_label: __address__
       # Optional: Sets Prometheus 'job' label using metrics.job, otherwise uses the compose service name
       - action: replace
         regex: (.+)


### PR DESCRIPTION
**What I did**

node-exporter uses host networking. This allows it to see and report on all interfaces, not just the docker bridge network. While this is useful, this means we need to teach users to add rules when they place ufw "in front of" docker, which we can do in the relevant cloud security docs. And ofc now there is a port exposed to host that must not conflct

This relies on #2312 