### PR TITLE
Add metrics to mev-boost

### DIFF
--- a/mev-boost.yml
+++ b/mev-boost.yml
@@ -35,4 +35,13 @@ services:
       - ${MEV_MIN_BID:-0}
       - -loglevel
       - ${LOG_LEVEL}
+      - -metrics
+      - -metrics-addr
+      - 0.0.0.0:18551
     <<: *logging
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=18551
+      - metrics.instance=mev-boost
+      - metrics.network=${NETWORK}


### PR DESCRIPTION
**What I did**

Add `-metrics` to `mev-boost.yml` and scrape them. A dashboard for mev-boost is not available from flashbots, however.

This is a breaking change and requires 1.10 or later
