### PR TITLE
Erigon WS port is now separate

### DIFF
--- a/erigon.yml
+++ b/erigon.yml
@@ -87,6 +87,8 @@ services:
       - --http.vhosts=*
       - --http.corsdomain=*
       - --ws
+      - --ws.port
+      - ${EL_WS_PORT}
       # Allow RocketPool >=1.9 watchtower queries
       - --rpc.returndata.limit
       - "1000000"

--- a/ethd
+++ b/ethd
@@ -3606,7 +3606,6 @@ __query_execution_client() {
 # This gets used, but shellcheck doesn't recognize that
 # shellcheck disable=SC2034
     EL_NODE="http://execution:8551"
-    echo "Please remember to set your EL_WS_PORT to match EL_RPC_PORT for Erigon"
     return 0
   fi
 
@@ -3660,9 +3659,6 @@ __query_execution_client() {
 # This gets used, but shellcheck doesn't recognize that
 # shellcheck disable=SC2034
     EL_NODE="http://execution:8551"
-    if [ "${EXECUTION_CLIENT}" = "erigon.yml" ]; then
-        echo "Please remember to set your EL_WS_PORT to match EL_RPC_PORT for Erigon"
-    fi
   fi
 }
 


### PR DESCRIPTION
**What I did**

Erigon used to set the WS port the same as the RPC port. It is now a separate port, like on every other client. Configure the port in `erigon.yml` and remove the warnings from `./ethd config`
