### PR TITLE
Adjust Lighthouse default target peers to 200

### DIFF
--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -72,7 +72,7 @@ services:
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
       - --target-peers
-      - ${CL_MAX_PEER_COUNT:-100}
+      - ${CL_MAX_PEER_COUNT:-200}
       - --execution-endpoint
       - ${EL_NODE}
       - --execution-jwt

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -73,7 +73,7 @@ services:
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
       - --target-peers
-      - ${CL_MAX_PEER_COUNT:-100}
+      - ${CL_MAX_PEER_COUNT:-200}
       - --execution-endpoint
       - ${EL_NODE}
       - --execution-jwt


### PR DESCRIPTION
**What I did**

Lighthouse default `--target-peers` are now `200`. I am unsure when this changed from `100`. 

Shout out to @sauliusgrigaitis for pointing this out
