### PR TITLE
Use client default max peers

### DIFF
--- a/.github/actions/test_client_stack/action.yml
+++ b/.github/actions/test_client_stack/action.yml
@@ -1,21 +1,35 @@
 name: "Test Client Stack"
 description: "A custom action to test CL, VC and EL"
 
+inputs:
+  test_cl:
+    type: string
+    default: "true"
+  test_vc:
+    type: string
+    default: "true"
+  test_el:
+    type: string
+    default: "true"
+
 runs:
   using: "composite"
   steps:
     - name: Start client combo
       run: ./ethd up
       shell: bash
-    - name: Pause for 30 seconds
-      run: sleep 30
+    - name: Pause for 15 seconds
+      run: sleep 15
       shell: bash
     - name: Test CL
+      if: ${{ inputs.test_cl == 'true' }}
       run: ./.github/check-service.sh consensus
       shell: bash
     - name: Test VC
+      if: ${{ inputs.test_vc == 'true' }}
       run: ./.github/check-service.sh validator
       shell: bash
     - name: Test EL
+      if: ${{ inputs.test_el == 'true' }}
       run: ./.github/check-service.sh execution
       shell: bash

--- a/.github/workflows/test-caplin-erigon.yml
+++ b/.github/workflows/test-caplin-erigon.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-caplin-erigon:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-caplin') ||
       contains(github.event.pull_request.labels.*.name, 'test-all') ||
@@ -30,20 +30,30 @@ jobs:
           COMPOSE_FILE=caplin.yml:erigon.yml:lodestar-vc-only.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
           CL_NODE=http://execution:5052
           var=CL_NODE
           set_value_in_env
-      - name: Start Caplin/Erigon w/ Lodestar VC
-        run: ./ethd up
-      - name: Pause for 30 seconds
-        run: sleep 30
-      - name: Test Caplin/Erigon
-        run: ./.github/check-service.sh execution
-      - name: Test VC
-        run: ./.github/check-service.sh validator
+          EL_EXTRAS="--torrent.download.rate 1mb"
+          var=EL_EXTRAS
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: false
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}
+    with:
+      test_cl: false

--- a/.github/workflows/test-env-variations.yml
+++ b/.github/workflows/test-env-variations.yml
@@ -1,0 +1,92 @@
+on:
+  workflow_call:
+    inputs:
+      test_cl:
+        type: string
+        default: "true"
+      test_vc:
+        type: string
+        default: "true"
+      test_el:
+        type: string
+        default: "true"
+
+jobs:
+  test-env-variations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Fetch .env file
+        uses: actions/download-artifact@v6
+        with:
+          name: env-file
+          path: .
+      - name: Set MEV Boost
+        run: |
+          source ./.github/helper.sh
+          MEV_BOOST=true
+          var=MEV_BOOST
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ inputs.test_cl }}
+          test_vc: ${{ inputs.test_vc }}
+          test_el: ${{ inputs.test_el }}
+      - name: Set MEV Factor 90
+        run: |
+          source ./.github/helper.sh
+          MEV_BUILD_FACTOR=90
+          var=MEV_BUILD_FACTOR
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ inputs.test_cl }}
+          test_vc: ${{ inputs.test_vc }}
+          test_el: ${{ inputs.test_el }}
+      - name: Set MEV Factor 100
+        run: |
+          source ./.github/helper.sh
+          MEV_BUILD_FACTOR=100
+          var=MEV_BUILD_FACTOR
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ inputs.test_cl }}
+          test_vc: ${{ inputs.test_vc }}
+          test_el: ${{ inputs.test_el }}
+      - name: Set MEV Factor 0
+        run: |
+          source ./.github/helper.sh
+          MEV_BUILD_FACTOR=0
+          var=MEV_BUILD_FACTOR
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ inputs.test_cl }}
+          test_vc: ${{ inputs.test_vc }}
+          test_el: ${{ inputs.test_el }}
+      - name: Set CL and EL MAX and MIN peers
+        run: |
+          source ./.github/helper.sh
+          CL_MAX_PEER_COUNT=100
+          var=CL_MAX_PEER_COUNT
+          set_value_in_env
+          CL_MIN_PEER_COUNT=20
+          var=CL_MIN_PEER_COUNT
+          set_value_in_env
+          EL_MAX_PEER_COUNT=10
+          var=EL_MAX_PEER_COUNT
+          set_value_in_env
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ inputs.test_cl }}
+          test_vc: ${{ inputs.test_vc }}
+          test_el: ${{ inputs.test_el }}

--- a/.github/workflows/test-grandine-nimbus.yml
+++ b/.github/workflows/test-grandine-nimbus.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-grandine-nimbus:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-grandine') ||
       contains(github.event.pull_request.labels.*.name, 'test-nimbus-el') ||
@@ -28,22 +28,13 @@ jobs:
           COMPOSE_FILE=grandine-allin1.yml:nimbus-el.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
-      - name: Start Grandine/Nimbus EL
-        run: ./ethd up
-      - name: Pause for 30 seconds
-        run: sleep 30
-      - name: Test Nimbus EL
-        run: ./.github/check-service.sh execution
-      - name: Test Grandine CL
-        run: ./.github/check-service.sh consensus
-      # - name: Test Grandine VC
-      #   run: ./.github/check-service.sh validator
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_vc: false
       - name: Set Grandine/Nimbus EL w/ Lighthouse VC
         run: |
           source ./.github/helper.sh
@@ -52,3 +43,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-lighthouse-ethrex.yml
+++ b/.github/workflows/test-lighthouse-ethrex.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-lighthouse-ethrex:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-ethrex') ||
       contains(github.event.pull_request.labels.*.name, 'test-all') ||
@@ -30,9 +30,6 @@ jobs:
           COMPOSE_FILE=lighthouse.yml:ethrex.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -46,3 +43,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-lighthouse-reth.yml
+++ b/.github/workflows/test-lighthouse-reth.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-lighthouse-reth:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-lighthouse') ||
       contains(github.event.pull_request.labels.*.name, 'test-reth') ||
@@ -31,9 +31,6 @@ jobs:
           COMPOSE_FILE=lighthouse.yml:reth.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -47,3 +44,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-lodestar-erigon.yml
+++ b/.github/workflows/test-lodestar-erigon.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-lodestar-erigon:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-lodestar') ||
       contains(github.event.pull_request.labels.*.name, 'test-erigon') ||
@@ -31,9 +31,6 @@ jobs:
           COMPOSE_FILE=lodestar.yml:erigon.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -47,3 +44,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-nimbus-nethermind.yml
+++ b/.github/workflows/test-nimbus-nethermind.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-nimbus-nethermind:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-nimbus') ||
       contains(github.event.pull_request.labels.*.name, 'test-nethermind') ||
@@ -31,9 +31,6 @@ jobs:
           COMPOSE_FILE=nimbus.yml:nethermind.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -47,3 +44,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-prysm-geth.yml
+++ b/.github/workflows/test-prysm-geth.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-prysm-geth:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-prysm') ||
       contains(github.event.pull_request.labels.*.name, 'test-geth') ||
@@ -31,9 +31,6 @@ jobs:
           COMPOSE_FILE=prysm.yml:geth.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -50,3 +47,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/.github/workflows/test-teku-besu.yml
+++ b/.github/workflows/test-teku-besu.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 jobs:
-  test-teku-besu:
+  test-client-combo:
     if: |
       contains(github.event.pull_request.labels.*.name, 'test-teku') ||
       contains(github.event.pull_request.labels.*.name, 'test-besu') ||
@@ -31,9 +31,6 @@ jobs:
           COMPOSE_FILE=teku.yml:besu.yml:mev-boost.yml
           var=COMPOSE_FILE
           set_value_in_env
-          MEV_BOOST=true
-          var=MEV_BOOST
-          set_value_in_env
           FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
           var=FEE_RECIPIENT
           set_value_in_env
@@ -47,3 +44,15 @@ jobs:
           set_value_in_env
       - name: Test the stack
         uses: ./.github/actions/test_client_stack
+      - name: Upload .env file
+        uses: actions/upload-artifact@v5
+        with:
+          name: env-file
+          path: .env
+          include-hidden-files: true
+          overwrite: true
+
+  test-env-variations:
+    uses: ./.github/workflows/test-env-variations.yml
+    needs: test-client-combo
+    if: ${{ needs.test-client-combo.result == 'success' }}

--- a/besu.yml
+++ b/besu.yml
@@ -62,8 +62,8 @@ services:
       - 0.0.0.0
       - --rpc-ws-port
       - ${EL_WS_PORT:-8546}
-      - --max-peers
-      - ${EL_MAX_PEER_COUNT:-25}
+      - ${EL_MAX_PEER_COUNT:+--max-peers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
       - --host-allowlist=*
       - --engine-host-allowlist=*
       - --engine-jwt-secret=/var/lib/besu/ee-secret/jwtsecret

--- a/erigon.yml
+++ b/erigon.yml
@@ -99,8 +99,8 @@ services:
       - --authrpc.vhosts=*
       - --authrpc.jwtsecret
       - /var/lib/erigon/ee-secret/jwtsecret
-      - --maxpeers
-      - ${EL_MAX_PEER_COUNT:-100}
+      - ${EL_MAX_PEER_COUNT:+--maxpeers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
     labels:
       - metrics.scrape=true
       - metrics.path=/debug/metrics/prometheus

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R erigon:erigon /var/lib/erigon
   exec gosu erigon "${BASH_SOURCE[0]}" "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/erigon/ee-secret/jwtsecret
@@ -109,6 +122,9 @@ if [ "${IPV6}" = "true" ]; then
 else
   __ipv6=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/ethrex.yml
+++ b/ethrex.yml
@@ -52,8 +52,8 @@ services:
       - ${EL_P2P_PORT:-30303}
       - --discovery.port
       - ${EL_P2P_PORT:-30303}
-      - --target.peers
-      - ${EL_MAX_PEER_COUNT:-100}
+      - ${EL_MAX_PEER_COUNT:+--target.peers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
       - --http.addr
       - 0.0.0.0
       - --http.port

--- a/ethrex/docker-entrypoint.sh
+++ b/ethrex/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R ethrex:ethrex /var/lib/ethrex
   exec gosu ethrex "${BASH_SOURCE[0]}" "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/ethrex/ee-secret/jwtsecret
@@ -69,6 +82,9 @@ else
       ;;
   esac
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/geth.yml
+++ b/geth.yml
@@ -75,8 +75,8 @@ services:
       - --authrpc.port
       - ${EE_PORT:-8551}
       - --authrpc.vhosts=*
-      - --maxpeers
-      - ${EL_MAX_PEER_COUNT:-50}
+      - ${EL_MAX_PEER_COUNT:+--maxpeers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
     labels:
       - metrics.scrape=true
       - metrics.path=/debug/metrics/prometheus

--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R geth:geth /var/lib/geth
   exec su-exec geth docker-entrypoint.sh "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/geth/ee-secret/jwtsecret
@@ -117,6 +130,9 @@ else
   echo "Geth full node without history expiry"
   __prune=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -82,8 +82,8 @@ services:
       - ${CL_P2P_PORT:-9000}
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
-      - --target-peers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--target-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --eth1-rpc-urls
       - ${EL_NODE}
       - --jwt-secret

--- a/grandine-cl-only.yml
+++ b/grandine-cl-only.yml
@@ -79,8 +79,8 @@ services:
       - ${CL_P2P_PORT:-9000}
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
-      - --target-peers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--target-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --eth1-rpc-urls
       - ${EL_NODE}
       - --jwt-secret

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R gdconsensus:gdconsensus /var/lib/grandine
   exec gosu gdconsensus docker-entrypoint.sh "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 __normalize_int() {
     local v=$1
@@ -159,6 +172,9 @@ if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
 else
   __w3s_url=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters

--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -71,8 +71,8 @@ services:
       - ${CL_P2P_PORT:-9000}
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
-      - --target-peers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--target-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --execution-endpoint
       - ${EL_NODE}
       - --execution-jwt

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -72,8 +72,8 @@ services:
       - ${CL_P2P_PORT:-9000}
       - --quic-port
       - ${CL_QUIC_PORT:-9001}
-      - --target-peers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--target-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --execution-endpoint
       - ${EL_NODE}
       - --execution-jwt

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R lhconsensus:lhconsensus /var/lib/lighthouse
   exec gosu lhconsensus docker-entrypoint.sh "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/lighthouse/beacon/ee-secret/jwtsecret
@@ -88,6 +101,9 @@ if [ "${IPV6}" = "true" ]; then
 else
   __ipv6=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 if [ -f /var/lib/lighthouse/beacon/prune-marker ]; then
   rm -f /var/lib/lighthouse/beacon/prune-marker

--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -76,8 +76,8 @@ services:
       - ${EL_NODE}
       - --jwtSecret
       - /var/lib/lodestar/consensus/ee-secret/jwtsecret
-      - --targetPeers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--targetPeers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --logLevel
       - ${LOG_LEVEL}
       - --suggestedFeeRecipient

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -76,8 +76,8 @@ services:
       - ${EL_NODE}
       - --jwtSecret
       - /var/lib/lodestar/consensus/ee-secret/jwtsecret
-      - --targetPeers
-      - ${CL_MAX_PEER_COUNT:-200}
+      - ${CL_MAX_PEER_COUNT:+--targetPeers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --logLevel
       - ${LOG_LEVEL}
       - --suggestedFeeRecipient

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -55,8 +55,8 @@ services:
       - ${EL_P2P_PORT:-30303}
       - --Network.P2PPort
       - ${EL_P2P_PORT:-30303}
-      - --Network.MaxActivePeers
-      - ${EL_MAX_PEER_COUNT:-50}
+      - ${EL_MAX_PEER_COUNT:+--Network.MaxActivePeers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
       - --HealthChecks.Enabled
       - "true"
       - --HealthChecks.UIEnabled

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R nethermind:nethermind /var/lib/nethermind
   exec gosu nethermind "${BASH_SOURCE[0]}" "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 # Move legacy xdai dir to gnosis
 if [ -d "/var/lib/nethermind/nethermind_db/xdai" ]; then
@@ -106,6 +119,9 @@ if [ -d /var/lib/nethermind-og/nethermind_db ]; then
 else
   __datadir="--data-dir /var/lib/nethermind"
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -68,7 +68,7 @@ services:
       - --status-bar=false
       - --tcp-port=${CL_P2P_PORT:-9000}
       - --udp-port=${CL_P2P_PORT:-9000}
-      - --max-peers=${CL_MAX_PEER_COUNT:-160}
+      - ${CL_MAX_PEER_COUNT:+--max-peers=${CL_MAX_PEER_COUNT}}
       - --el=${EL_NODE}
       - --jwt-secret=/var/lib/nimbus/ee-secret/jwtsecret
       - --rest

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -65,7 +65,7 @@ services:
       - --status-bar=false
       - --tcp-port=${CL_P2P_PORT:-9000}
       - --udp-port=${CL_P2P_PORT:-9000}
-      - --max-peers=${CL_MAX_PEER_COUNT:-160}
+      - ${CL_MAX_PEER_COUNT:+--max-peers=${CL_MAX_PEER_COUNT}}
       - --el=${EL_NODE}
       - --jwt-secret=/var/lib/nimbus/ee-secret/jwtsecret
       - --rest

--- a/nimbus-el.yml
+++ b/nimbus-el.yml
@@ -62,7 +62,7 @@ services:
       - --engine-api-port=${EE_PORT:-8551}
       - --engine-api-address=0.0.0.0
       - --engine-api-ws
-      - --max-peers=${EL_MAX_PEER_COUNT:-25}
+      - ${EL_MAX_PEER_COUNT:+--max-peers=${EL_MAX_PEER_COUNT}}
       - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -65,7 +65,7 @@ services:
       - --status-bar=false
       - --tcp-port=${CL_P2P_PORT:-9000}
       - --udp-port=${CL_P2P_PORT:-9000}
-      - --max-peers=${CL_MAX_PEER_COUNT:-160}
+      - ${CL_MAX_PEER_COUNT:+--max-peers=${CL_MAX_PEER_COUNT}}
       - --el=${EL_NODE}
       - --jwt-secret=/var/lib/nimbus/ee-secret/jwtsecret
       - --rest

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R user:user /var/lib/nimbus
   exec gosu user docker-entrypoint.sh "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 __normalize_int() {
     local v=$1
@@ -12,6 +25,7 @@ __normalize_int() {
     fi
     printf '%s' "$v"
 }
+
 
 # Remove old low-entropy token, related to Sigma Prime security audit
 # This detection isn't perfect - a user could recreate the token without ./ethd update
@@ -145,6 +159,9 @@ if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
 else
   __w3s_url=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 if [ "${DEFAULT_GRAFFITI}" = "true" ]; then
 # Word splitting is desired for the command line parameters

--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -77,8 +77,8 @@ services:
       - ${PRYSM_UDP_PORT}
       - --p2p-quic-port
       - ${CL_QUIC_PORT}
-      - --p2p-max-peers
-      - ${CL_MAX_PEER_COUNT:-70}
+      - ${CL_MAX_PEER_COUNT:+--p2p-max-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --verbosity
       - ${LOG_LEVEL}
       - --accept-terms-of-use

--- a/prysm.yml
+++ b/prysm.yml
@@ -78,8 +78,8 @@ services:
       - ${PRYSM_UDP_PORT}
       - --p2p-quic-port
       - ${CL_QUIC_PORT}
-      - --p2p-max-peers
-      - ${CL_MAX_PEER_COUNT:-70}
+      - ${CL_MAX_PEER_COUNT:+--p2p-max-peers}
+      - ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}
       - --verbosity
       - ${LOG_LEVEL}
       - --accept-terms-of-use

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$(id -u)" = '0' ]; then
+if [[ "$(id -u)" -eq 0 ]]; then
   chown -R prysmconsensus:prysmconsensus /var/lib/prysm
   exec gosu prysmconsensus docker-entrypoint.sh "$@"
 fi
+
+
+# Because we're oh-so-clever with + substitution and maxpeers, we may have empty args. Remove them
+__strip_empty_args() {
+  local __arg
+  __args=()
+  for __arg in "$@"; do
+    if [[ -n "$__arg" ]]; then
+      __args+=("$__arg")
+    fi
+  done
+}
+
 
 if [ -n "${JWT_SECRET}" ]; then
   echo -n "${JWT_SECRET}" > /var/lib/prysm/ee-secret/jwtsecret
@@ -72,6 +85,9 @@ else
   echo "Prysm node without beacon DB pruning"
   __prune=""
 fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 if [[ "${NETWORK}" = "sepolia" ]]; then
   GENESIS=/var/lib/prysm/genesis.ssz

--- a/reth.yml
+++ b/reth.yml
@@ -85,8 +85,8 @@ services:
       - ${EE_PORT:-8551}
       - --authrpc.jwtsecret
       - /var/lib/reth/ee-secret/jwtsecret
-      - --max-outbound-peers
-      - ${EL_MAX_PEER_COUNT:-100}
+      - ${EL_MAX_PEER_COUNT:+--max-outbound-peers}
+      - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -73,8 +73,8 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
-      - --p2p-peer-upper-bound=${CL_MAX_PEER_COUNT:-100}
-      - --p2p-peer-lower-bound=${CL_MIN_PEER_COUNT:-64}
+      - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
+      - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --validator-keys=/var/lib/teku/validator-keys:/var/lib/teku/validator-passwords
       - --logging=${LOG_LEVEL}
       - --rest-api-host-allowlist=*

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -70,8 +70,8 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
-      - --p2p-peer-upper-bound=${CL_MAX_PEER_COUNT:-100}
-      - --p2p-peer-lower-bound=${CL_MIN_PEER_COUNT:-64}
+      - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
+      - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --logging=${LOG_LEVEL}
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true

--- a/teku.yml
+++ b/teku.yml
@@ -70,8 +70,8 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
-      - --p2p-peer-upper-bound=${CL_MAX_PEER_COUNT:-100}
-      - --p2p-peer-lower-bound=${CL_MIN_PEER_COUNT:-64}
+      - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
+      - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --logging=${LOG_LEVEL}
       - --rest-api-host-allowlist=*
       - --rest-api-enabled=true


### PR DESCRIPTION
**What I did**

Do not hard-code max peer defaults: Only set max peer if the env variable is not empty

Add a generic `test-env-variations` workflow to CI, so that MAX peers as well as MEV Boost and MEV build factor can be tested. Further tests in a separate PR.

Restrict Erigon to 1mb torrent during CI: We're running out of space otherwise
