### PR TITLE
CI matrix skips steps again

### DIFF
--- a/.github/workflows/test-client-combos.yml
+++ b/.github/workflows/test-client-combos.yml
@@ -6,6 +6,7 @@ defaults:
 
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
     branches: [main]


### PR DESCRIPTION
**What I did**

Use a more direct if clause to skip. Skipped jobs still show as succeeded, but do not show any succeeded steps.
