### PR TITLE
Introduce builder service to avoid building multiple times

### DIFF
--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -43,6 +43,8 @@ jobs:
         run: cp default.env .env
       - name: Test ethd update
         run: ./ethd update --debug --non-interactive
+      - name: Remove .env
+        run: rm .env
       - name: Test ethd config defaults
         run: expect ./.github/test-ethd-config.exp all-defaults
         env:

--- a/deposit-cli.yml
+++ b/deposit-cli.yml
@@ -1,6 +1,5 @@
 services:
-  deposit-cli-new:
-    profiles: ["tools"]
+  deposit-cli-builder:
     restart: "no"
     build:
       context: ./ethstaker-deposit-cli
@@ -12,6 +11,16 @@ services:
         - DOCKER_REPO=${DEPCLI_DOCKER_REPO:-ghcr.io/ethstaker/ethstaker-deposit-cli}
     image: ethstaker-deposit-cli:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  deposit-cli-new:
+    profiles: ["tools"]
+    restart: "no"
+    image: ethstaker-deposit-cli:local
+    pull_policy: never
+    depends_on:
+      deposit-cli-builder:
+        condition: service_completed_successfully
     volumes:
       - ./.eth:/app/.eth/
     entrypoint:
@@ -22,19 +31,15 @@ services:
       - new-mnemonic
       - --chain
       - ${NETWORK}
+
   deposit-cli-existing:
     profiles: ["tools"]
     restart: "no"
-    build:
-      context: ./ethstaker-deposit-cli
-      dockerfile: ${DEPCLI_DOCKERFILE}
-      args:
-        - BUILD_TARGET=${DEPCLI_SRC_BUILD_TARGET:-'$(git describe --tags $(git rev-list --tags --max-count=1))'}
-        - SRC_REPO=${DEPCLI_SRC_REPO:-https://github.com/ethstaker/ethstaker-deposit-cli}
-        - DOCKER_TAG=${DEPCLI_DOCKER_TAG:-latest}
-        - DOCKER_REPO=${DEPCLI_DOCKER_REPO:-ghcr.io/ethstaker/ethstaker-deposit-cli}
     image: ethstaker-deposit-cli:local
     pull_policy: never
+    depends_on:
+      deposit-cli-builder:
+        condition: service_completed_successfully
     volumes:
       - ./.eth:/app/.eth/
     entrypoint:
@@ -45,19 +50,15 @@ services:
       - existing-mnemonic
       - --chain
       - ${NETWORK}
+
   deposit-cli-change:
     profiles: ["tools"]
-    build:
-      context: ./ethstaker-deposit-cli
-      dockerfile: ${DEPCLI_DOCKERFILE}
-      args:
-        - BUILD_TARGET=${DEPCLI_SRC_BUILD_TARGET:-'$(git describe --tags $(git rev-list --tags --max-count=1))'}
-        - SRC_REPO=${DEPCLI_SRC_REPO:-https://github.com/ethstaker/ethstaker-deposit-cli}
-        - DOCKER_TAG=${DEPCLI_DOCKER_TAG:-latest}
-        - DOCKER_REPO=${DEPCLI_DOCKER_REPO:-ghcr.io/ethstaker/ethstaker-deposit-cli}
     restart: "no"
     image: ethstaker-deposit-cli:local
     pull_policy: never
+    depends_on:
+      deposit-cli-builder:
+        condition: service_completed_successfully
     volumes:
       - ./.eth:/app/.eth
     entrypoint:

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -16,13 +16,22 @@ x-build: &lh-build
     - DOCKER_REPO=${LH_DOCKER_REPO:-sigp/lighthouse}
 
 services:
-  validator:
-    restart: "unless-stopped"
+  lighthouse-builder:
+    restart: "no"
     build:
       <<: *lh-build
     image: lighthouse:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  validator:
+    restart: "unless-stopped"
+    image: lighthouse:local
+    pull_policy: never
     user: lhvalidator
+    depends_on:
+      lighthouse-builder:
+        condition: service_completed_successfully
     environment:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
@@ -83,11 +92,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *lh-build
     image: lighthouse:local
     pull_policy: never
     user: root
+    depends_on:
+      lighthouse-builder:
+        condition: service_completed_successfully
     volumes:
       - lhvalidator-data:/var/lib/lighthouse
       - ./.eth/validator_keys:/validator_keys
@@ -115,6 +125,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - lhvalidator-data:/var/lib/lighthouse
       - ./.eth/validator_keys:/validator_keys
@@ -126,8 +138,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/lighthouse/validators/api-token.txt

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -17,14 +17,23 @@ x-build: &lh-build
     - DOCKER_REPO=${LH_DOCKER_REPO:-sigp/lighthouse}
 
 services:
-  consensus:
-    restart: "unless-stopped"
+  lighthouse-builder:
+    restart: "no"
     build:
       <<: *lh-build
     image: lighthouse:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  consensus:
+    restart: "unless-stopped"
+    image: lighthouse:local
+    pull_policy: never
     user: lhconsensus
     stop_grace_period: 1m
+    depends_on:
+      lighthouse-builder:
+        condition: service_completed_successfully
     volumes:
       - lhconsensus-data:/var/lib/lighthouse
       - /etc/localtime:/etc/localtime:ro
@@ -95,11 +104,17 @@ services:
 
   validator:
     restart: "unless-stopped"
-    build:
-      <<: *lh-build
     image: lighthouse:local
     pull_policy: never
     user: lhvalidator
+    depends_on:
+      consensus:
+        condition: service_started
+      lighthouse-builder:
+        condition: service_completed_successfully
+    volumes:
+      - lhvalidator-data:/var/lib/lighthouse
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
@@ -111,9 +126,6 @@ services:
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
-    volumes:
-      - lhvalidator-data:/var/lib/lighthouse
-      - /etc/localtime:/etc/localtime:ro
     networks:
       default:
         aliases:
@@ -144,8 +156,6 @@ services:
       - --unencrypted-http-transport
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
-    depends_on:
-      - consensus
     labels:
       - traefik.enable=true
       - traefik.http.routers.${VC_HOST:-vc}.service=${VC_HOST:-vc}
@@ -162,13 +172,16 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *lh-build
     image: lighthouse:local
     pull_policy: never
     # Keys have 440 permissions. Root copies and chowns them,
     # then switches to user lhvalidator
     user: root
+    depends_on:
+      consensus:
+        condition: service_started
+      lighthouse-builder:
+        condition: service_completed_successfully
     volumes:
       - lhvalidator-data:/var/lib/lighthouse
       - ./.eth/validator_keys:/validator_keys
@@ -187,8 +200,6 @@ services:
       - ${NETWORK}
       - --debug-level=${LOG_LEVEL}
       - --keystore
-    depends_on:
-      - consensus
 
   validator-keys:
     profiles: ["tools"]
@@ -202,6 +213,8 @@ services:
     # 1000. The UID has to be able to write .eth/validator_keys
     # for the "keys delete" command.
     user: root
+    depends_on:
+      - validator
     volumes:
       - lhvalidator-data:/var/lib/lighthouse
       - ./.eth/validator_keys:/validator_keys
@@ -213,8 +226,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/lighthouse/validators/api-token.txt

--- a/lodestar-vc-only.yml
+++ b/lodestar-vc-only.yml
@@ -16,13 +16,25 @@ x-build: &ls-build
     - DOCKER_REPO=${LS_DOCKER_REPO:-chainsafe/lodestar}
 
 services:
-  validator:
-    restart: "unless-stopped"
+  lodestar-builder:
+    restart: "no"
     build:
       <<: *ls-build
     image: lodestar:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  validator:
+    restart: "unless-stopped"
+    image: lodestar:local
+    pull_policy: never
     user: lsvalidator
+    depends_on:
+      lodestar-builder:
+        condition: service_completed_successfully
+    volumes:
+      - lsvalidator-data:/var/lib/lodestar/validators
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
@@ -36,9 +48,6 @@ services:
       - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
-    volumes:
-      - lsvalidator-data:/var/lib/lodestar/validators
-      - /etc/localtime:/etc/localtime:ro
     networks:
       default:
         aliases:
@@ -79,11 +88,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *ls-build
     image: lodestar:local
     pull_policy: never
     user: lsvalidator
+    depends_on:
+      lodestar-builder:
+        condition: service_completed_successfully
     volumes:
       - lsvalidator-data:/var/lib/lodestar/validators
       - /etc/localtime:/etc/localtime:ro
@@ -110,6 +120,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - lsvalidator-data:/var/lib/lodestar/validators
       - ./.eth/validator_keys:/validator_keys
@@ -121,8 +133,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/lodestar/validators/validator-db/api-token.txt

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -16,14 +16,23 @@ x-build: &ls-build
     - DOCKER_REPO=${LS_DOCKER_REPO:-chainsafe/lodestar}
 
 services:
-  consensus:
-    restart: "unless-stopped"
+  lodestar-builder:
+    restart: "no"
     build:
       <<: *ls-build
     image: lodestar:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  consensus:
+    restart: "unless-stopped"
+    image: lodestar:local
+    pull_policy: never
     user: lsconsensus
     stop_grace_period: 1m
+    depends_on:
+      lodestar-builder:
+        condition: service_completed_successfully
     volumes:
       - lsconsensus-data:/var/lib/lodestar/consensus
       - /etc/localtime:/etc/localtime:ro
@@ -96,6 +105,14 @@ services:
     image: lodestar:local
     pull_policy: never
     user: lsvalidator
+    depends_on:
+      consensus:
+        condition: service_started
+      lodestar-builder:
+        condition: service_completed_successfully
+    volumes:
+      - lsvalidator-data:/var/lib/lodestar/validators
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
@@ -109,11 +126,6 @@ services:
       - W3S_NODE=${W3S_NODE}
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
-    volumes:
-      - lsvalidator-data:/var/lib/lodestar/validators
-      - /etc/localtime:/etc/localtime:ro
-    depends_on:
-      - consensus
     networks:
       default:
         aliases:
@@ -156,11 +168,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *ls-build
     image: lodestar:local
     pull_policy: never
     user: lsvalidator
+    depends_on:
+      lodestar-builder:
+        condition: service_completed_successfully
     volumes:
       - lsvalidator-data:/var/lib/lodestar/validators
       - /etc/localtime:/etc/localtime:ro
@@ -187,6 +200,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - lsvalidator-data:/var/lib/lodestar/validators
       - ./.eth/validator_keys:/validator_keys
@@ -198,8 +213,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/lodestar/validators/validator-db/api-token.txt

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -19,15 +19,24 @@ x-build: &nimbus-build
     - DOCKER_VC_REPO=${NIM_DOCKER_VC_REPO:-statusim/nimbus-validator-client}
 
 services:
-  consensus:
-    restart: "unless-stopped"
+  nimbus-builder:
+    restart: "no"
     build:
       target: consensus
       <<: *nimbus-build
     image: nimbus:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  consensus:
+    restart: "unless-stopped"
+    image: nimbus:local
+    pull_policy: never
     user: user
     stop_grace_period: 1m
+    depends_on:
+      nimbus-builder:
+        condition: service_completed_successfully
     volumes:
       - nimbus-data:/var/lib/nimbus
       - /etc/localtime:/etc/localtime:ro
@@ -108,12 +117,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      target: consensus
-      <<: *nimbus-build
     image: nimbus:local
     pull_policy: never
     user: root
+    depends_on:
+      nimbus-builder:
+        condition: service_completed_successfully
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./.eth/validator_keys:/validator_keys

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -88,6 +88,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - nimbus-vc-data:/var/lib/nimbus
       - ./.eth/validator_keys:/validator_keys
@@ -99,8 +101,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/nimbus/api-token.txt

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -154,6 +154,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - nimbus-vc-data:/var/lib/nimbus
       - ./.eth/validator_keys:/validator_keys
@@ -165,8 +167,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/nimbus/api-token.txt

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -18,14 +18,23 @@ x-build: &prysm-build
     - DOCKER_VC_REPO=${PRYSM_DOCKER_VC_REPO:-gcr.io/offchainlabs/prysm/validator}
 
 services:
-  validator:
-    restart: "unless-stopped"
+  prysm-validator-builder:
+    restart: "no"
     build:
       target: validator
       <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  validator:
+    restart: "unless-stopped"
+    image: prysm-validator:local
+    pull_policy: never
     user: prysmvalidator
+    depends_on:
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
@@ -87,18 +96,18 @@ services:
   create-wallet:
     profiles: ["tools"]
     restart: "no"
-    build:
-      target: validator
-      <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
     user: prysmvalidator
-    environment:
-      - NETWORK=${NETWORK}
-      - WEB3SIGNER=${WEB3SIGNER:-false}
+    depends_on:
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
+    environment:
+      - NETWORK=${NETWORK}
+      - WEB3SIGNER=${WEB3SIGNER:-false}
     entrypoint: create-wallet.sh
 
   validator-exit:
@@ -120,12 +129,12 @@ services:
   validator-backup:
     profiles: ["tools"]
     restart: "no"
-    build:
-      target: validator
-      <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
     user: root
+    depends_on:
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - ./.eth/validator_keys:/validator_keys
@@ -152,6 +161,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - ./.eth/validator_keys:/validator_keys
@@ -164,8 +175,6 @@ services:
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
       - PRYSM=true
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/prysm/auth-token

--- a/prysm.yml
+++ b/prysm.yml
@@ -18,6 +18,15 @@ x-build: &prysm-build
     - DOCKER_VC_REPO=${PRYSM_DOCKER_VC_REPO:-gcr.io/offchainlabs/prysm/validator}
 
 services:
+  prysm-validator-builder:
+    restart: "no"
+    build:
+      target: validator
+      <<: *prysm-build
+    image: prysm-validator:local
+    pull_policy: never
+    entrypoint: ["true"]
+
   consensus:
     restart: "unless-stopped"
     build:
@@ -98,12 +107,14 @@ services:
 
   validator:
     restart: "unless-stopped"
-    build:
-      target: validator
-      <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
     user: prysmvalidator
+    depends_on:
+      consensus:
+        condition: service_started
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
@@ -152,8 +163,6 @@ services:
       - ${FEE_RECIPIENT}
       - --wallet-password-file
       - /var/lib/prysm/password.txt
-    depends_on:
-      - consensus
     labels:
       - traefik.enable=true
       - traefik.http.routers.prysm.entrypoints=web,websecure
@@ -169,24 +178,26 @@ services:
   create-wallet:
     profiles: ["tools"]
     restart: "no"
-    build:
-      target: validator
-      <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
     user: prysmvalidator
-    environment:
-      - NETWORK=${NETWORK}
-      - WEB3SIGNER=${WEB3SIGNER:-false}
+    depends_on:
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
+    environment:
+      - NETWORK=${NETWORK}
+      - WEB3SIGNER=${WEB3SIGNER:-false}
     entrypoint: create-wallet.sh
 
   validator-exit:
     profiles: ["tools"]
     restart: "no"
     image: ${PRYSM_DOCKER_CTL_REPO}:${PRYSM_DOCKER_CTL_TAG}
+    depends_on:
+      - consensus
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - /etc/localtime:/etc/localtime:ro
@@ -198,18 +209,18 @@ services:
       - --beacon-rpc-provider=consensus:4000
       - --wallet-password-file=/var/lib/prysm/password.txt
       - --${NETWORK}
-    depends_on:
-      - consensus
 
   validator-backup:
     profiles: ["tools"]
     restart: "no"
-    build:
-      target: validator
-      <<: *prysm-build
     image: prysm-validator:local
     pull_policy: never
     user: root
+    depends_on:
+      consensus:
+        condition: service_started
+      prysm-validator-builder:
+        condition: service_completed_successfully
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - ./.eth/validator_keys:/validator_keys
@@ -227,8 +238,6 @@ services:
       - --${NETWORK}
       - --backup-dir=/validator_keys
       - --backup-password-file=/var/lib/prysm/password.txt
-    depends_on:
-      - consensus
 
   validator-keys:
     profiles: ["tools"]
@@ -238,6 +247,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - prysmvalidator-data:/var/lib/prysm
       - ./.eth/validator_keys:/validator_keys
@@ -250,8 +261,6 @@ services:
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
       - PRYSM=true
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/prysm/auth-token

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -17,14 +17,23 @@ x-build: &teku-build
     - DOCKER_REPO=${TEKU_DOCKER_REPO:-consensys/teku}
 
 services:
-  consensus:
-    restart: "unless-stopped"
+  teku-builder:
+    restart: "no"
     build:
       <<: *teku-build
     image: teku:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  consensus:
+    restart: "unless-stopped"
+    image: teku:local
+    pull_policy: never
     user: teku
     stop_grace_period: 1m
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -118,11 +127,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *teku-build
     image: teku:local
     pull_policy: never
     user: teku
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -142,6 +152,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - consensus
     volumes:
       - teku-data:/var/lib/teku
       - ./.eth/validator_keys:/validator_keys
@@ -154,8 +166,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - consensus
     entrypoint:
       - keymanager.sh
       - /var/lib/teku/validator/key-manager/validator-api-bearer

--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -16,13 +16,22 @@ x-build: &teku-build
     - DOCKER_REPO=${TEKU_DOCKER_REPO:-consensys/teku}
 
 services:
-  validator:
-    restart: "unless-stopped"
+  teku-builder:
+    restart: "no"
     build:
       <<: *teku-build
     image: teku:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  validator:
+    restart: "unless-stopped"
+    image: teku:local
+    pull_policy: never
     user: teku
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -75,11 +84,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *teku-build
     image: teku:local
     pull_policy: never
     user: teku
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro

--- a/teku.yml
+++ b/teku.yml
@@ -16,14 +16,23 @@ x-build: &teku-build
     - DOCKER_REPO=${TEKU_DOCKER_REPO:-consensys/teku}
 
 services:
-  consensus:
-    restart: "unless-stopped"
+  teku-builder:
+    restart: "no"
     build:
       <<: *teku-build
     image: teku:local
     pull_policy: never
+    entrypoint: ["true"]
+
+  consensus:
+    restart: "unless-stopped"
+    image: teku:local
+    pull_policy: never
     user: teku
     stop_grace_period: 1m
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - tekuconsensus-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -92,11 +101,14 @@ services:
 
   validator:
     restart: "unless-stopped"
-    build:
-      <<: *teku-build
     image: teku:local
     pull_policy: never
     user: teku
+    depends_on:
+      consensus:
+        condition: service_started
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-vc-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -150,11 +162,12 @@ services:
   validator-exit:
     profiles: ["tools"]
     restart: "no"
-    build:
-      <<: *teku-build
     image: teku:local
     pull_policy: never
     user: teku
+    depends_on:
+      teku-builder:
+        condition: service_completed_successfully
     volumes:
       - teku-vc-data:/var/lib/teku
       - /etc/localtime:/etc/localtime:ro
@@ -173,6 +186,8 @@ services:
     image: vc-utils:local
     pull_policy: never
     user: root
+    depends_on:
+      - validator
     volumes:
       - teku-vc-data:/var/lib/teku
       - ./.eth/validator_keys:/validator_keys
@@ -185,8 +200,6 @@ services:
       - WEB3SIGNER=${WEB3SIGNER:-false}
       - W3S_NODE=${W3S_NODE}
       - CL_NODE=${CL_NODE}
-    depends_on:
-      - validator
     entrypoint:
       - keymanager.sh
       - /var/lib/teku/validator/key-manager/validator-api-bearer


### PR DESCRIPTION
**What I did**

Where multiple services use the same image and build it locally, introduce a builder service they depend on.

This avoids multiple builds, which can also fail on slow systems due to a race condition: Surfaced by the macOS CI

```
=> [validator] exporting to image 0.6s
=> => exporting layers 0.6s
=> => writing image sha256:0943fbc60676fa872d511f6114c58bbe6faecc8dcea6b59f36339cc2b231446a 0.0s
=> => naming to docker.io/library/teku:local 0.0s
=> [consensus] exporting to image 0.6s
=> => exporting layers 0.6s 
=> => writing image sha256:116c8b56440232ecaab9a560abff9188c84af9c7cdfd20c465b5fb58a70ba98e 0.0s 
=> => naming to docker.io/library/teku:local
```

`pull_policy: never` so the current behavior of Eth Docker is preserved: Users can restart the stack without the image changing on them, even if they use a `stable` or `latest` tag for upstream. They need to seek updates with `./ethd update` or `./ethd cmd build`
