### PR TITLE
Disable Prysm beacon DB pruning for now

### DIFF
--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -79,8 +79,10 @@ if [ "${ARCHIVE_NODE}" = "true" ]; then
   echo "Prysm archive node without pruning"
   __prune="--slots-per-archive-point=32 --blob-retention-epochs=4294967295"
 elif [ "${MINIMAL_NODE}" = "true" ]; then
-  echo "Prysm node with beacon DB pruning"
-  __prune="--beacon-db-pruning"
+#  echo "Prysm node with beacon DB pruning"
+#  __prune="--beacon-db-pruning"
+  echo "Prysm node's beacon DB pruning is buggy, not using it. New release expected late Nov 2025"
+  __prune=""
 else
   echo "Prysm node without beacon DB pruning"
   __prune=""


### PR DESCRIPTION
**What I did**

As per Prysm devs:

"My hunch is the pruner is deleting the origin block (the block used to checkpoint sync), which it should treat as a special case and not delete. If that block is being deleted it should be a simple fix to stop deleting it. We’ve already merged a bug fix to check for this error and avoid the sigsev which will be in the next release in any case. I do think disabling the pruning flag until the next release (there will be one before December for sure) is a good move."
