### PR TITLE
Add a prune-marker service to ethrex.yml

### DIFF
--- a/ethrex.yml
+++ b/ethrex.yml
@@ -83,6 +83,16 @@ services:
       - metrics.instance=execution
       - metrics.network=${NETWORK}
 
+  set-prune-marker:
+    profiles: ["tools"]
+    image: alpine:3
+    user: "10001:10001"
+    restart: "no"
+    volumes:
+      - ethrex-el-data:/var/lib/ethrex
+    entrypoint: ["/bin/sh", "-c"]
+    command: /bin/sh
+
 volumes:
   ethrex-el-data:
   jwtsecret:


### PR DESCRIPTION
**What I did**

This fixes `./ethd prune-history` when using Ethrex. Note that Ethrex always prunes pre-merge history, and so this command is currently a NOP
