### PR TITLE
Change default checkpoint sync URL to https://hoodi.checkpoint.sigp.io

### DIFF
--- a/default.env
+++ b/default.env
@@ -26,7 +26,7 @@ DEFAULT_GRAFFITI=true
 NETWORK=hoodi
 # CL rapid sync via initial state/checkpoint. Please use one from https://eth-clients.github.io/checkpoint-sync-endpoints/
 # Alternatively, use an already synced CL that you trust. No trailing / for Teku, please.
-CHECKPOINT_SYNC_URL=https://hoodi.beaconstate.info
+CHECKPOINT_SYNC_URL=https://hoodi.checkpoint.sigp.io
 # Doppelganger protection - set to "true" to enable. This will intentionally skip two epochs on client start, and attempt to
 # detect duplicates of the validator(s) already running. Note this is NOT foolproof, though it can be useful when moving a node
 DOPPELGANGER=false

--- a/ethd
+++ b/ethd
@@ -4086,7 +4086,7 @@ __query_checkpoint_beacon() {
         CHECKPOINT_SYNC_URL="https://sepolia.beaconstate.info"
         ;;
       "hoodi")
-        CHECKPOINT_SYNC_URL="https://hoodi.beaconstate.info"
+        CHECKPOINT_SYNC_URL="https://hoodi.checkpoint.sigp.io"
         ;;
       "ephemery")
         CHECKPOINT_SYNC_URL="https://ephemery.beaconstate.ethstaker.cc/"


### PR DESCRIPTION
**What I did**

Changed default checkpoint to `https://hoodi.checkpoint.sigp.io`. `hoodi.beaconstate.info` caused too many errors in CI
