### PR TITLE
Change default traefik tag to 3.6

### DIFF
--- a/default.env
+++ b/default.env
@@ -433,7 +433,7 @@ DEPCLI_DOCKER_REPO=ghcr.io/ethstaker/ethstaker-deposit-cli
 DEPCLI_DOCKERFILE=Dockerfile.binary
 
 # traefik and ddns-updater
-TRAEFIK_TAG=v3.5
+TRAEFIK_TAG=v3.6
 DDNS_TAG=v2
 
 # Path to mount to node-exporter if needed for --collector.textfile.directory


### PR DESCRIPTION
**What I did**

Traefik `3.6.1` fixes the incompatibility with Docker `29.0.0` and up.  Switch the default tag to `3.6`. Existing users would need to seek this themselves. Given that users of traefik are advanced, that is acceptable
