### PR TITLE
Remove p2p.enabled from ethrex

### DIFF
--- a/ethrex.yml
+++ b/ethrex.yml
@@ -47,7 +47,6 @@ services:
       - ethrex
       - --datadir
       - /var/lib/ethrex
-      - --p2p.enabled
       - --p2p.port
       - ${EL_P2P_PORT:-30303}
       - --discovery.port


### PR DESCRIPTION
**What I did**

Ethrex v7 removes `--p2p.enabled` and replaces it with `--p2p.disabled`. Remove `--p2p.enabled` from `ethrex.yml`

