### PR TITLE
Remove Lima pin for test-ethd

### DIFF
--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Set up Docker on macOS
         if: ${{ startsWith(matrix.os, 'macos-') }}
         uses: douglascamata/setup-docker-macos-action@5643cfd7e434881308f89f2f3ae8852da11df909
-        with:
-          lima: v1.2.2
       - name: Install Expect
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: sudo apt-get install -y expect whiptail


### PR DESCRIPTION
**What I did**

The new macOS Docker runner supports Lima 2.x
