### PR TITLE
Contributoor extras

### DIFF
--- a/contributoor.yml
+++ b/contributoor.yml
@@ -15,8 +15,12 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
     <<: *logging
-    command:
+    entrypoint:
+      - sentry
       - --network=${NETWORK}
       - --beacon-node-address=${CL_NODE}
       - --username=${CONTRIBUTOOR_USERNAME}
       - --password=${CONTRIBUTOOR_PASSWORD}
+      - --attestation-subnet-check-enabled
+      - --log-level=${LOG_LEVEL}
+    command: ${CONTRIBUTOOR_EXTRAS}

--- a/default.env
+++ b/default.env
@@ -46,6 +46,8 @@ SIREN_PASSWORD=
 CONTRIBUTOOR_USERNAME=
 # EthPandaOps Contributoor Password
 CONTRIBUTOOR_PASSWORD=
+# EthPandaOps Contributoor additional parameters
+CONTRIBUTOOR_EXTRAS=
 
 # Promtail logs label, something unique like the server name
 LOGS_LABEL=eth-docker
@@ -450,4 +452,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=46
+ENV_VERSION=47


### PR DESCRIPTION
**What I did**

Contributoor sends subnet data by default, as requested at https://discord.com/channels/694822223575384095/748687253307392101/1443733127179665549

Also, users can add additional parameters to contributoor via `CONTRIBUTOOR_EXTRAS`, same request
