### PR TITLE
Teku heap to 8g default

### DIFF
--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -39,7 +39,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
-      - JAVA_OPTS=${TEKU_HEAP:--Xmx6g}
+      - JAVA_OPTS=${TEKU_HEAP:--Xmx8g}
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -29,7 +29,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
-      - JAVA_OPTS=${TEKU_HEAP:--Xmx7g}
+      - JAVA_OPTS=${TEKU_HEAP:--Xmx8g}
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}

--- a/teku.yml
+++ b/teku.yml
@@ -38,7 +38,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - jwtsecret:/var/lib/teku/ee-secret
     environment:
-      - JAVA_OPTS=${TEKU_HEAP:--Xmx7g}
+      - JAVA_OPTS=${TEKU_HEAP:--Xmx8g}
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}


### PR DESCRIPTION
**What I did**

Bump Teku default heap to 8g, based on this comment: https://discord.com/channels/694822223575384095/782670046736285697/1435791435386458122

"8g should be OK for now", and I am wondering whether we've had some users who see OOM at 7g already