### PR TITLE
Switch to new cadvisor repo

### DIFF
--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -118,7 +118,7 @@ services:
 
   cadvisor:
     restart: "unless-stopped"
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    image: ghcr.io/google/cadvisor:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/rootfs:ro,rslave

--- a/grafana.yml
+++ b/grafana.yml
@@ -111,7 +111,7 @@ services:
 
   cadvisor:
     restart: "unless-stopped"
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    image: ghcr.io/google/cadvisor:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/rootfs:ro,rslave


### PR DESCRIPTION
**What I did**

Google changed the repo to ghcr.io. cadvisor 0.54.0 can handle the new `overlayfs` storage driver in Docker 29.x. Use `latest` for cadvisor, it may actually work when on ghcr.io
