### PR TITLE
Enable getProof for Erigon full node

### DIFF
--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -86,7 +86,7 @@ elif [[ "${MINIMAL_NODE}" = "true" ]]; then
   esac
 else
   echo "Erigon full node without history expiry"
-  __prune="--prune.mode=blocks"
+  __prune="--prune.mode=blocks --prune.include-commitment-history"
 fi
 
 __caplin=""


### PR DESCRIPTION
**What I did**

Enable `eth_getProof` for Erigon full node by default

Eth Docker will assume full nodes are for RPC, and expired nodes for staking, for the most part. 