### PR TITLE
Use node 24 in lodestar source build

### DIFF
--- a/lodestar/Dockerfile.source
+++ b/lodestar/Dockerfile.source
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3007,DL3008,DL3059,DL4006
-FROM node:22-slim AS builder
+FROM node:24-slim AS builder
 
 # Here only to avoid build-time errors
 ARG DOCKER_TAG
@@ -33,7 +33,7 @@ RUN bash -eo pipefail <<'EOF'
 EOF
 
 
-FROM node:22-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata bash gosu git git-lfs wget \
     && gosu nobody true && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We use node 24 as default since [v1.38.0](https://github.com/ChainSafe/lodestar/releases/tag/v1.38.0)