### PR TITLE
Fix Nimbus VC boost factor

### DIFF
--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -47,11 +47,11 @@ if [[ "${MEV_BOOST}" = "true" ]]; then
       echo "WARNING: This conflicts with MEV_BOOST true. Set factor in a range of 1 to 100"
       ;;
     [1-9]|[1-9][0-9])
-      __mev_factor="--builder-boost-factor ${build_factor}"
+      __mev_factor="--builder-boost-factor=${build_factor}"
       echo "Enabled MEV Build Factor of ${build_factor}"
       ;;
     100)
-      __mev_factor="--builder-boost-factor 18446744073709551615"
+      __mev_factor="--builder-boost-factor=18446744073709551615"
       echo "Always prefer MEV builder blocks, MEV_BUILD_FACTOR 100"
       ;;
     "")


### PR DESCRIPTION
**What I did**

Add a missing `=` so Nimbus VC still works with MEV_BUILD_FACTOR
