### PR TITLE
Move Ethrex jwtsecret into /var/lib/ee-secret

### DIFF
--- a/ethrex.yml
+++ b/ethrex.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - ethrex-el-data:/var/lib/ethrex
       - /etc/localtime:/etc/localtime:ro
-      - jwtsecret:/var/lib/ethrex/ee-secret
+      - jwtsecret:/var/lib/ee-secret
     ports:
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/tcp
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/udp
@@ -67,7 +67,7 @@ services:
       - --metrics.port
       - "6060"
       - --authrpc.jwtsecret
-      - /var/lib/ethrex/ee-secret/jwtsecret
+      - /var/lib/ee-secret/jwtsecret
       - --authrpc.addr
       - 0.0.0.0
       - --authrpc.port

--- a/ethrex/Dockerfile.binary
+++ b/ethrex/Dockerfile.binary
@@ -31,7 +31,8 @@ RUN adduser \
   --uid "${UID}" \
   "${USER}"
 
-RUN mkdir -p /var/lib/ethrex/ee-secret && chown -R ${USER}:${USER} /var/lib/ethrex && chmod -R 700 /var/lib/ethrex && chmod 777 /var/lib/ethrex/ee-secret
+RUN mkdir -p /var/lib/ee-secret && chown -R ${USER}:${USER} /var/lib/ee-secret && chmod 777 /var/lib/ee-secret
+RUN mkdir -p /var/lib/ethrex && chown -R ${USER}:${USER} /var/lib/ethrex && chmod -R 700 /var/lib/ethrex
 
 # Cannot assume buildkit, hence no chmod
 COPY --chown=${USER}:${USER} ./docker-entrypoint.sh /usr/local/bin/

--- a/ethrex/Dockerfile.source
+++ b/ethrex/Dockerfile.source
@@ -120,7 +120,8 @@ RUN adduser \
   --uid "${UID}" \
   "${USER}"
 
-RUN mkdir -p /var/lib/ethrex/ee-secret && chown -R ${USER}:${USER} /var/lib/ethrex && chmod -R 700 /var/lib/ethrex && chmod 777 /var/lib/ethrex/ee-secret
+RUN mkdir -p /var/lib/ee-secret && chown -R ${USER}:${USER} /var/lib/ee-secret && chmod 777 /var/lib/ee-secret
+RUN mkdir -p /var/lib/ethrex && chown -R ${USER}:${USER} /var/lib/ethrex && chmod -R 700 /var/lib/ethrex
 
 WORKDIR /usr/local/bin
 

--- a/ethrex/docker-entrypoint.sh
+++ b/ethrex/docker-entrypoint.sh
@@ -19,24 +19,28 @@ __strip_empty_args() {
 }
 
 
+if [[ -d /var/lib/ethrex/ee-secret ]]; then
+  rm -rf /var/lib/ethrex/ee-secret/  # Remove legacy dir
+fi
+
 if [[ -n "${JWT_SECRET}" ]]; then
-  echo -n "${JWT_SECRET}" > /var/lib/ethrex/ee-secret/jwtsecret
+  echo -n "${JWT_SECRET}" > /var/lib/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"
 fi
 
-if [[ ! -f /var/lib/ethrex/ee-secret/jwtsecret ]]; then
+if [[ ! -f /var/lib/ee-secret/jwtsecret ]]; then
   echo "Generating JWT secret"
   secret1=$(head -c 8 /dev/urandom | od -A n -t u8 | tr -d '[:space:]' | sha256sum | head -c 32)
   secret2=$(head -c 8 /dev/urandom | od -A n -t u8 | tr -d '[:space:]' | sha256sum | head -c 32)
-  echo -n "${secret1}""${secret2}" > /var/lib/ethrex/ee-secret/jwtsecret
+  echo -n "${secret1}""${secret2}" > /var/lib/ee-secret/jwtsecret
 fi
 
-if [[ -O /var/lib/ethrex/ee-secret ]]; then
+if [[ -O /var/lib/ee-secret ]]; then
   # In case someone specifies JWT_SECRET but it's not a distributed setup
-  chmod 777 /var/lib/ethrex/ee-secret
+  chmod 777 /var/lib/ee-secret
 fi
-if [[ -O /var/lib/ethrex/ee-secret/jwtsecret ]]; then
-  chmod 666 /var/lib/ethrex/ee-secret/jwtsecret
+if [[ -O /var/lib/ee-secret/jwtsecret ]]; then
+  chmod 666 /var/lib/ee-secret/jwtsecret
 fi
 
 if [[ "${NETWORK}" =~ ^https?:// ]]; then


### PR DESCRIPTION
**What I did**

Ethrex v8 won't initialize its database if there is anything at all in its `--datadir`. Move the `jwtsecret` into `/var/lib/ee-secret` to work around this
