### PR TITLE
Fix source build for Nethermind and Caplin CI

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -48,7 +48,7 @@ jobs:
               COMPOSE_FILE=caplin.yml:erigon.yml:lighthouse-vc-only.yml
               ERIGON_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
-            test_cl: true
+            test_cl: false
             test_el: true
             test_vc: true
           - env: |-

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -35,7 +35,7 @@ EOF
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y --no-install-recommends install ca-certificates gosu tzdata wget git git-lfs \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y --no-install-recommends install ca-certificates gosu tzdata wget git git-lfs adduser \
   && gosu nobody true \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**What I did**

Nethermind source needs `adduser`; Caplin Source CI should not test for `consensus`
