### PR TITLE
Initial support for Grandine plugin in Nethermind

### DIFF
--- a/.github/workflows/test-client-combos.yml
+++ b/.github/workflows/test-client-combos.yml
@@ -52,6 +52,26 @@ jobs:
             test_cl: true
             test_el: true
             test_vc: true
+          - label1: test-grandine-plugin
+            label2: na
+            env: |-
+              COMPOSE_FILE=grandine-plugin.yml:lighthouse-vc-only.yml:nethermind.yml:mev-boost.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+              NM_DOCKER_REPO=sifrai/grandine
+              NM_DOCKER_TAG=unstable-nethermind-1.35.8
+            test_cl: false
+            test_el: true
+            test_vc: true
+          - label1: test-grandine-plugin
+            label2: na
+            env: |-
+              COMPOSE_FILE=grandine-plugin-allin1.yml:nethermind.yml:mev-boost.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+              NM_DOCKER_REPO=sifrai/grandine
+              NM_DOCKER_TAG=unstable-nethermind-1.35.8
+            test_cl: false
+            test_el: true
+            test_vc: false
           - label1: test-ethrex
             label2: na
             env: |-

--- a/caplin.yml
+++ b/caplin.yml
@@ -1,4 +1,4 @@
-# To be used with erigon.yml when its built-in Caplin CL is in use
+# caplin.yml to be used with erigon.yml when its built-in Caplin CL is in use
 services:
   execution:
     ports:

--- a/ethd
+++ b/ethd
@@ -2298,6 +2298,7 @@ resync-consensus() {
     *nimbus.yml*|*nimbus-cl-only.yml*) cl_volume='nimbus-consensus-data'; cl_client="nimbus";;
     *lodestar.yml*|*lodestar-cl-only.yml*) cl_volume='lsconsensus-data'; cl_client="lodestar";;
     *prysm.yml*|*prysm-cl-only.yml*) cl_volume='prysmconsensus-data'; cl_client="prysm";;
+    *grandine-plugin.yml*|*grandine-plugin-allin1.yml*) cl_volume='wipe-db'; cl_client="grandine-plugin";;
     *grandine-allin1.yml*) cl_volume='wipe-db'; cl_client="grandine";;
     *grandine.yml*|*grandine-cl-only.yml*) cl_volume='grandineconsensus-data'; cl_client="grandine";;
     *erigon.yml*) cl_volume='wipe-db'; cl_client="caplin";;
@@ -2325,7 +2326,7 @@ resync-consensus() {
   esac
 
   echo "Stopping ${cl_client} container"
-  if [[ "${cl_client}" = "caplin" ]]; then
+  if [[ "${cl_client}" =~ (caplin|grandine-plugin) ]]; then
     __docompose stop execution && __docompose rm -f execution
   else
     __docompose stop consensus && __docompose rm -f consensus

--- a/grandine-plugin-allin1.yml
+++ b/grandine-plugin-allin1.yml
@@ -1,0 +1,82 @@
+# grandine-plugin-allin1.yml to be used with nethermind.yml for Nethermind with Grandine plugin and Grandine VC
+services:
+  execution:
+    ports:
+      # Grandine consensus P2P ports
+      - "${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp"
+      - "${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp"
+    environment:
+      - CL_NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - CL_EXTRAS=${CL_EXTRAS:-}
+      - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
+      - JWT_SECRET=${JWT_SECRET}
+      - MEV_BOOST=${MEV_BOOST}
+      - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
+      - MEV_NODE=${MEV_NODE}
+      - BEACON_STATS_API=${BEACON_STATS_API}
+      - BEACON_STATS_MACHINE=${BEACON_STATS_MACHINE}
+      - VC_EXTRAS=${VC_EXTRAS:-}
+      - GRAFFITI=${GRAFFITI:-}
+      - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
+      - DOPPELGANGER=${DOPPELGANGER:-false}
+      - IPV6=${IPV6:-false}
+      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
+      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
+      - CL_REST_PORT=${CL_REST_PORT:-5052}
+      - CL_MAX_PEER_COUNT=${CL_MAX_PEER_COUNT:-}
+      - FEE_RECIPIENT=${FEE_RECIPIENT:-}
+      - KEY_API_PORT=${KEY_API_PORT:-}
+      - EMBEDDED_VC=true
+      - RUST_LOG=${LOG_LEVEL:-info}
+    volumes:
+      - grandineconsensus-data:/var/lib/grandine
+# No metrics scrape at present via labels.
+# Create an extra scrape target for execution:8008 in prometheus/conf.d
+
+  wipe-db:
+    profiles: ["tools"]
+    restart: "no"
+    image: alpine:3
+    user: "10002"
+    volumes:
+      - grandineconsensus-data:/var/lib/grandine
+      - /etc/localtime:/etc/localtime:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        rm -rf /var/lib/grandine/${NETWORK}/beacon/*
+
+  validator-keys:
+    profiles: ["tools"]
+    restart: "no"
+    build:
+      context: ./vc-utils
+    image: vc-utils:local
+    pull_policy: never
+    # The API token has 640 permissions. Root copies it,
+    # then switches to the local user's UID or if not provided,
+    # 1000. The UID has to be able to write .eth/validator_keys
+    # for the "keys delete" command.
+    user: root
+    volumes:
+      - grandineconsensus-data:/var/lib/grandine
+      - ./.eth/validator_keys:/validator_keys
+      - ./.eth/exit_messages:/exit_messages
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-}
+      - KEY_API_PORT=${KEY_API_PORT:-7500}
+      - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
+      - CL_NODE=${CL_NODE}
+    depends_on:
+      - execution
+    entrypoint:
+      - keymanager.sh
+      - /var/lib/grandine/${NETWORK}/validator/api-token.txt
+      - execution
+
+volumes:
+  grandineconsensus-data:

--- a/grandine-plugin.yml
+++ b/grandine-plugin.yml
@@ -1,0 +1,52 @@
+# grandine-plugin.yml to be used with nethermind.yml for Nethermind with Grandine plugin
+services:
+  execution:
+    ports:
+      # Grandine consensus P2P ports
+      - "${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp"
+      - "${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp"
+    environment:
+      - CL_NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - CL_EXTRAS=${CL_EXTRAS:-}
+      - WEB3SIGNER=${WEB3SIGNER:-false}
+      - W3S_NODE=${W3S_NODE}
+      - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
+      - JWT_SECRET=${JWT_SECRET}
+      - MEV_BOOST=${MEV_BOOST}
+      - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
+      - MEV_NODE=${MEV_NODE}
+      - BEACON_STATS_API=${BEACON_STATS_API}
+      - BEACON_STATS_MACHINE=${BEACON_STATS_MACHINE}
+      - VC_EXTRAS=${VC_EXTRAS:-}
+      - GRAFFITI=${GRAFFITI:-}
+      - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
+      - DOPPELGANGER=${DOPPELGANGER:-false}
+      - IPV6=${IPV6:-false}
+      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
+      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
+      - CL_REST_PORT=${CL_REST_PORT:-5052}
+      - CL_MAX_PEER_COUNT=${CL_MAX_PEER_COUNT:-}
+      - FEE_RECIPIENT=${FEE_RECIPIENT:-}
+      - KEY_API_PORT=${KEY_API_PORT:-}
+      - EMBEDDED_VC=false
+      - RUST_LOG=${LOG_LEVEL:-info}
+    volumes:
+      - grandineconsensus-data:/var/lib/grandine
+# No metrics scrape at present via labels.
+# Create an extra scrape target for execution:8008 in prometheus/conf.d
+
+  wipe-db:
+    profiles: ["tools"]
+    restart: "no"
+    image: alpine:3
+    user: "10002"
+    volumes:
+      - grandineconsensus-data:/var/lib/grandine
+      - /etc/localtime:/etc/localtime:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        rm -rf /var/lib/grandine/${NETWORK}/beacon/*
+
+volumes:
+  grandineconsensus-data:

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -30,6 +30,8 @@ services:
       - NODE_TYPE=${EL_NODE_TYPE:-pre-merge-expiry}
       - AUTOPRUNE_NM=${AUTOPRUNE_NM:-true}
       - NETWORK=${NETWORK}
+      # For Grandine plugin
+      - COMPOSE_FILE=${COMPOSE_FILE}
     volumes:
       - nethermind-el-data:/var/lib/nethermind
       - nm-eth1-data:/var/lib/nethermind-og

--- a/nethermind/Dockerfile.binary
+++ b/nethermind/Dockerfile.binary
@@ -15,7 +15,7 @@ ARG GID=10002
 
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends ca-certificates gosu tzdata wget git git-lfs adduser; \
+	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends ca-certificates gosu tzdata wget git git-lfs adduser curl; \
 	rm -rf /var/lib/apt/lists/*; \
 # verify that the binary works
         gosu nobody true
@@ -35,12 +35,12 @@ RUN adduser \
     --ingroup "${USER}" \
     "${USER}"
 
-# This only goes so far. keystore, logs and nethermind_db are volumes and need to be chown'd in the entrypoint
 RUN chown -R ${USER}:${USER} /nethermind
 RUN mkdir -p /var/lib/nethermind-og && chown -R ${USER}:${USER} /var/lib/nethermind-og \
 && chmod -R 700 /var/lib/nethermind-og
 RUN mkdir -p /var/lib/nethermind/ee-secret && chown -R ${USER}:${USER} /var/lib/nethermind \
 && chmod -R 700 /var/lib/nethermind && chmod 777 /var/lib/nethermind/ee-secret
+RUN mkdir -p /var/lib/grandine && chown -R ${USER}:${USER} /var/lib/grandine && chmod 700 /var/lib/grandine
 
 # Cannot assume buildkit, hence no chmod
 COPY --chown=${USER}:${USER} ./docker-entrypoint.sh /usr/local/bin/

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -19,6 +19,15 @@ __strip_empty_args() {
 }
 
 
+__normalize_int() {
+  local v=$1
+  if [[ "${v}" =~ ^[0-9]+$ ]]; then
+    v=$((10#${v}))
+  fi
+  printf '%s' "${v}"
+}
+
+
 if [[ -n "${JWT_SECRET}" ]]; then
   echo -n "${JWT_SECRET}" > /var/lib/nethermind/ee-secret/jwtsecret
   echo "JWT secret was supplied in .env"
@@ -147,9 +156,154 @@ else
   __datadir="--data-dir /var/lib/nethermind"
 fi
 
+if [[ "${COMPOSE_FILE}" =~ grandine-plugin(-allin1)?\.yml ]]; then
+  if [[ ! -f /var/lib/grandine/wallet-password.txt ]]; then
+    echo "Creating password for Grandine key wallet"
+    head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /var/lib/grandine/wallet-password.txt
+  fi
+  __grandine="--grandine-disableupnp --grandine-datadir /var/lib/grandine --grandine-httpaddress 0.0.0.0 --grandine-httpport ${CL_REST_PORT:-5052}"
+  __grandine+=" --grandine-httpallowedorigins=* --grandine-listenaddress 0.0.0.0 --grandine-libp2pport ${CL_P2P_PORT:-9000} --grandine-discoveryport ${CL_P2P_PORT:-9000}"
+  __grandine+=" --grandine-quicport ${CL_QUIC_PORT:-9001} ${CL_MAX_PEER_COUNT:+--grandine-targetpeers} ${CL_MAX_PEER_COUNT:+${CL_MAX_PEER_COUNT}}"
+  __grandine+=" --grandine-metrics --grandine-metricsaddress 0.0.0.0 --grandine-metricsport 8008 --grandine-suggestedfeerecipient ${FEE_RECIPIENT}"
+  __grandine+=" --grandine-trackliveness"
+
+  if [[ "${EMBEDDED_VC}" = "true" ]]; then
+    __grandine+=" --grandine-keystorestoragepasswordfile /var/lib/grandine/wallet-password.txt  --grandine-enablevalidatorapi"
+    __grandine+=" --grandine-validatorapiaddress 0.0.0.0 --grandine-validatorapiport ${KEY_API_PORT:-7500} --grandine-validatorapiallowedorigins=*"
+  fi
+
+  if [[ "${NETWORK}" =~ ^https?:// ]]; then
+    echo "Custom testnet at ${NETWORK}"
+    repo=$(awk -F'/tree/' '{print $1}' <<< "${NETWORK}")
+    branch=$(awk -F'/tree/' '{print $2}' <<< "${NETWORK}" | cut -d'/' -f1)
+    config_dir=$(awk -F'/tree/' '{print $2}' <<< "${NETWORK}" | cut -d'/' -f2-)
+    echo "This appears to be the ${repo} repo, branch ${branch} and config directory ${config_dir}."
+    # For want of something more amazing, let's just fail if git fails to pull this
+    set -e
+    if [[ ! -d "/var/lib/grandine/testnet/${config_dir}" ]]; then
+      mkdir -p /var/lib/grandine/testnet
+      cd /var/lib/grandine/testnet
+      git init --initial-branch="${branch}"
+      git remote add origin "${repo}"
+      git config core.sparseCheckout true
+      echo "${config_dir}" > .git/info/sparse-checkout
+      git pull origin "${branch}"
+    fi
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 {print $2}' "/var/lib/grandine/testnet/${config_dir}/bootstrap_nodes.yaml" | paste -sd ",")"
+    set +e
+    __grandine+=" --grandine-configurationdirectory=/var/lib/grandine/testnet/${config_dir} --grandine-bootnodes=${bootnodes}"
+  else
+    __grandine+=" --grandine-network=${NETWORK}"
+  fi
+
+  case "${CL_NODE_TYPE}" in
+    archive)
+      echo "Grandine archive node without pruning"
+      __grandine+=" --grandine-backsync --grandine-archivestorage"
+      ;;
+    pruned)
+      ;;
+    aggressive-pruned)
+      __grandine+=" --grandine-prunestorage"
+      ;;
+    full)
+      __grandine+=" --grandine-backsync"
+      ;;
+    *)
+      echo "ERROR: The node type ${CL_NODE_TYPE} is not known to Eth Docker's Grandine implementation."
+      sleep 30
+      exit 1
+      ;;
+  esac
+
+# Check whether we should rapid sync
+  if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
+    __grandine+=" --grandine-checkpointsyncurl=${CHECKPOINT_SYNC_URL}"
+    echo "Grandine checkpoint sync enabled"
+  fi
+
+# Check whether we should send stats to beaconcha.in
+  if [[ -n "${BEACON_STATS_API}" ]]; then
+    __grandine+=" --grandine-remotemetricsurl https://beaconcha.in/api/v1/client/metrics?apikey=${BEACON_STATS_API}&machine=${BEACON_STATS_MACHINE}"
+    echo "Grandine beacon stats API enabled"
+  fi
+
+# Check whether we should use MEV Boost
+  if [[ "${MEV_BOOST}" = "true" ]]; then
+    __mev_boost=" --grandine-builderurl ${MEV_NODE:-http://mev-boost:18550}"
+    echo "Grandine MEV Boost enabled"
+    if [[ "${EMBEDDED_VC}" = "true" ]]; then
+      build_factor="$(__normalize_int "${MEV_BUILD_FACTOR}")"
+      case "${build_factor}" in
+        0)
+          __mev_boost=""
+          __mev_factor=""
+          echo "Disabled MEV Boost because MEV_BUILD_FACTOR is 0."
+          echo "WARNING: This conflicts with MEV_BOOST true. Set factor in a range of 1 to 100"
+          ;;
+        [1-9]|[1-9][0-9])
+          #__mev_factor="--default-builder-boost-factor ${build_factor}"
+          #echo "Enabled MEV Build Factor of ${build_factor}"
+          __mev_factor=""
+          echo "WARNING: Embedded Grandine does not support --builder-boost-factor. MEV build factor ${build_factor} not applied."
+          ;;
+        100)
+          #__mev_factor="--default-builder-boost-factor 18446744073709551615"
+          #echo "Always prefer MEV builder blocks, MEV_BUILD_FACTOR 100"
+          __mev_factor=""
+          echo "WARNING: Embedded Grandine does not support --builder-boost-factor. MEV build factor ${build_factor} not applied."
+          ;;
+        "")
+          __mev_factor=""
+          #echo "Use default --grandine-defaultbuilderboostfactor"
+          ;;
+        *)
+          __mev_factor=""
+          echo "WARNING: MEV_BUILD_FACTOR has an invalid value of \"${build_factor}\""
+          ;;
+      esac
+      __mev_boost+="${__mev_factor}"
+    fi
+    __grandine+="${__mev_boost}"
+  fi
+
+  if [[ "${IPV6}" = "true" ]]; then
+    echo "Configuring Grandine to listen on IPv6 ports"
+    __grandine+=" --grandine-listenaddressipv6 :: --grandine-libp2pportipv6 ${CL_P2P_PORT:-9000} --grandine-discoveryportipv6 ${CL_P2P_PORT:-9000} \
+  --grandine-quicportipv6 ${CL_QUIC_PORT:-9001}"
+  # ENR discovery on v6 is not yet working, likely too few peers. Manual for now
+    ipv6_pattern="^[0-9A-Fa-f]{1,4}:"  # Sufficient to check the start
+    set +e
+    public_v6=$(curl -s -6 ifconfig.me)
+    set -e
+    if [[ "${public_v6}" =~ ${ipv6_pattern} ]]; then
+      __grandine+=" --grandine-enraddressipv6 ${public_v6} --grandine-enrtcpportipv6 ${CL_P2P_PORT:-9000} --grandine-enrudpportipv6 ${CL_P2P_PORT:-9000}"
+    fi
+  fi
+
+# Check whether we should enable doppelganger protection
+  if [[ "${EMBEDDED_VC}" = "true" && "${DOPPELGANGER}" = "true" ]]; then
+    __grandine+=" --grandine-detectdoppelgangers"
+    echo "Grandine Doppelganger protection enabled"
+  fi
+
+# Web3signer URL
+  if [[ "${EMBEDDED_VC}" = "true" && "${WEB3SIGNER}" = "true" ]]; then
+    __grandine+=" --web3signer-urls ${W3S_NODE}"
+  fi
+
+  if [[ ! "${DEFAULT_GRAFFITI}" = "true" ]]; then
+      __grandine+=" --grandine-graffiti ${GRAFFITI}"
+  fi
+
+  __grandine+=" ${CL_EXTRAS} ${VC_EXTRAS}"
+else
+  __grandine=""
+fi
+
 __strip_empty_args "$@"
 set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__datadir} ${__network} ${__prune} ${EL_EXTRAS}
+exec "$@" ${__datadir} ${__network} ${__prune} ${__grandine} ${EL_EXTRAS}


### PR DESCRIPTION
**What I did**

Support Grandine plugin, with Nethermind binary build only, and for users that explicitly seek it. This requires adjustments in `.env`:

```
COMPOSE_FILE=grandine-plugin.yml:nethermind.yml
# Could also be grandine-plugin-allin1.yml; plus add whatever else the user runs such as commit-boost-pbs, grafana, &c
CL_NODE=http://execution:5052
NM_DOCKER_REPO=sifrai/grandine
NM_DOCKER_TAG=unstable-nethermind-1.35.8
```

**Related issue**
Implements #2373
