### PR TITLE
Do not default Grandine to aggressive pruning

### DIFF
--- a/default.env
+++ b/default.env
@@ -199,6 +199,7 @@ LODESTAR_HEAP=
 # "archive" may also keep all blobs, depending on client
 # Switching node type typically requires a resync
 # "pruned-with-zkproofs" is experimental and will not work with the standard client builds
+# Grandine has an additional "aggressive-pruned" mode, which keeps minimal data
 # For a more granular way to handle it, please use CL_EXTRAS in combination with "full"
 CL_NODE_TYPE=pruned
 # EL_NODE_TYPE can be "archive", "full", "pre-merge-expiry", "aggressive-expiry" or "rolling-expiry"

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -73,13 +73,16 @@ fi
 case "${NODE_TYPE}" in
   archive)
     echo "Grandine archive node without pruning"
-    __prune="--back-sync"
+    __prune="--back-sync --archive-storage"
     ;;
   pruned)
+    __prune=""
+    ;;
+  aggressive-pruned)
     __prune="--prune-storage"
     ;;
   full)
-    __prune=""
+    __prune="--back-sync"
     ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Grandine implementation."


### PR DESCRIPTION
**What I did**

Introduce `aggressive-pruned` for Grandine; by default even when `pruned` do not prune at all

**Related issue**

Addresses #2415 
