### PR TITLE
Update Vero Dockerfile - remove multiprocessing metrics dir

### DIFF
--- a/vero/Dockerfile.binary
+++ b/vero/Dockerfile.binary
@@ -23,7 +23,6 @@ RUN set -eux; \
 
 # Create data mount point with permissions
 RUN mkdir -p /var/lib/vero && chown -R ${USER}:${USER} /var/lib/vero && chmod -R 700 /var/lib/vero
-RUN chown -R ${USER}:${USER} /tmp/multiprocessing
 
 # Cannot assume buildkit, hence no chmod
 COPY --chown=${USER}:${USER} ./docker-entrypoint.sh /usr/local/bin/

--- a/vero/Dockerfile.source
+++ b/vero/Dockerfile.source
@@ -61,10 +61,6 @@ RUN groupadd -g ${UID} ${USER} && \
 RUN mkdir -p /vero && chown -R ${USER}:${USER} /vero
 WORKDIR /vero
 
-# Create directory for prometheus in multiprocess mode
-RUN mkdir /tmp/multiprocessing && chown -R ${USER}:${USER} /tmp/multiprocessing
-ENV PROMETHEUS_MULTIPROC_DIR=/tmp/multiprocessing
-
 COPY --chown=${USER}:${USER} --from=builder /build/vero/src .
 
 # Create data mount point with permissions


### PR DESCRIPTION
**What I did**

Synced the Dockerfile with the one upstream - the multiprocessing metrics mode was removed from Vero.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
