### PR TITLE
Support Ethrex max blobs

### DIFF
--- a/ethrex.yml
+++ b/ethrex.yml
@@ -52,6 +52,8 @@ services:
       - ${EL_P2P_PORT:-30303}
       - ${EL_MAX_PEER_COUNT:+--p2p.target-peers}
       - ${EL_MAX_PEER_COUNT:+${EL_MAX_PEER_COUNT}}
+      - ${MAX_BLOBS:+--builder.max-blobs}
+      - ${MAX_BLOBS:+${MAX_BLOBS}}
       - --http.addr
       - 0.0.0.0
       - --http.port


### PR DESCRIPTION
**What I did**

Add `--builder.max-blobs` option. Requires Ethrex v10.

Take out of draft when Ethrex v10 has been released
