### PR TITLE
Docker install with deb822

### DIFF
--- a/ethd
+++ b/ethd
@@ -342,13 +342,17 @@ __upgrade_compose() {
       echo "${__project_name} cannot update Docker Compose on Debian ${__os_major_version}."
       exit 1
     fi
-    ${__auto_sudo} mkdir -p /etc/apt/keyrings
-    ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg | ${__auto_sudo} gpg --dearmor --yes \
-    -o /etc/apt/keyrings/docker.gpg
-    ${__auto_sudo} echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-        https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-        | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
+    ${__auto_sudo} install -m 0755 -d /etc/apt/keyrings
+    ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    ${__auto_sudo} chmod a+r /etc/apt/keyrings/docker.asc
+    ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/debian
+Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
     ${__auto_sudo} apt-get update
     ${__auto_sudo} apt-get install -y docker-compose-plugin docker-buildx-plugin
     echo "Installed docker-compose-plugin"
@@ -745,13 +749,17 @@ __install_docker() {
   fi
 
   if [[ -z "$(command -v docker)" ]]; then
-    ${__auto_sudo} mkdir -p /etc/apt/keyrings
-    curl -fsSL "https://download.docker.com/linux/${repo}/gpg" | ${__auto_sudo} gpg --dearmor \
-      --yes -o /etc/apt/keyrings/docker.gpg
-    echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-      https://download.docker.com/linux/${repo} $(lsb_release -cs) stable" \
-      | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
+    ${__auto_sudo} install -m 0755 -d /etc/apt/keyrings
+    ${__auto_sudo} curl -fsSL https://download.docker.com/linux/${repo}/gpg -o /etc/apt/keyrings/docker.asc
+    ${__auto_sudo} chmod a+r /etc/apt/keyrings/docker.asc
+    ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/${repo}
+Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
     ${__auto_sudo} apt-get update
     ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
       docker-buildx-plugin


### PR DESCRIPTION
**What I did**

When installing the docker-ce repo, use the deb822 `.sources` format instead of the old `.list`
