### PR TITLE
Support reth download for snapshot

### DIFF
--- a/default.env
+++ b/default.env
@@ -230,6 +230,12 @@ CL_NODE_TYPE=pruned
 # "aggressive-expiry" is supported with Reth, Erigon and Besu
 # "aggressive-expiry" is experimental in Besu as of Jan 27th 2026
 EL_NODE_TYPE=pre-merge-expiry
+# Whether to get a snapshot from the Reth servers, if using Reth. This breaks eth_getLogs,
+# do not use with RocketPool, SSV or NodeSet
+# "true" will use a (likely) correct snapshot for EL_NODE_TYPE,
+# empty or "false" disables it, and any other string is assumed to be
+# exact parameters for Reth's "download" function
+RETH_SNAPSHOT=
 # EraE URL, see https://github.com/eth-clients/e2store-format-specs/ and https://ethpandaops.io/data/history/
 # If this URL is provided, an EL that supports EraE import will use it when fresh syncing
 ERA_URL=
@@ -475,4 +481,4 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 DOCKER_ROOT=/var/lib/docker
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=52
+ENV_VERSION=53

--- a/ethd
+++ b/ethd
@@ -4380,6 +4380,13 @@ __query_4444() {  # Call with with --defaultno for RPC
 }
 
 
+__query_reth_snapshot() {
+  if (whiptail --title "Reth snapshot" --yesno "Do you want to speed up Reth sync by using a database snapshot? This breaks eth_getLogs RPC calls, do not use with RocketPool, SSV or NodeSet" 10 65) then
+    RETH_SNAPSHOT=true
+  fi
+}
+
+
 __query_grafana() {
   if (whiptail --title "Grafana" --yesno "Do you want to use Grafana dashboards?" 10 65) then
       if [[ "$OSTYPE" = "darwin"* ]]; then
@@ -5212,11 +5219,16 @@ config() {
       __query_execution_client
     fi
 
+#shellcheck disable=SC2034
+    RETH_SNAPSHOT=""
     if [[ -n "${EXECUTION_CLIENT+x}" && "${NETWORK}" =~ (mainnet|sepolia) ]]; then
       if [[ "${__deployment}" = "rpc" ]]; then
         __query_4444 --defaultno
       else
         __query_4444 ""
+      fi
+      if [[ "${EXECUTION_CLIENT:-}" = "reth.yml" && "${NETWORK}" = "mainnet" && ! "${EL_NODE_TYPE}" = "full" ]]; then
+        __query_reth_snapshot
       fi
     else  # On all other networks, disable
 #shellcheck disable=SC2034
@@ -5470,7 +5482,9 @@ config() {
   var=MEV_RELAYS
   __update_value_in_env "${var}" "${!var-}" "${__env_file}"
   var=EL_NODE_TYPE
-  __update_value_in_env "${var}" "${!var-false}" "${__env_file}"
+  __update_value_in_env "${var}" "${!var-full}" "${__env_file}"
+  var=RETH_SNAPSHOT
+  __update_value_in_env "${var}" "${!var-}" "${__env_file}"
   var=DOCKER_EXT_NETWORK
   __update_value_in_env "${var}" "${!var:-"rocketpool_net"}" "${__env_file}"
   if [[ "${__deployment}" = "lido_obol" ]]; then

--- a/reth.yml
+++ b/reth.yml
@@ -32,6 +32,7 @@ services:
       - COMPOSE_FILE=${COMPOSE_FILE}
       - IPV6=${IPV6:-false}
       - EL_P2P_PORT_2=${EL_P2P_PORT_2:-30304}
+      - RETH_SNAPSHOT=${RETH_SNAPSHOT:-}
       # Make this RUST_LOG=${LOG_LEVEL:-info},engine=trace when requiring deep debug
       # RPC debug can be done with jsonrpsee=trace or jsonrpsee::target=trace for a specific target
       # - RUST_LOG=${LOG_LEVEL:-info},engine=trace

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -98,13 +98,20 @@ case "${NODE_TYPE}" in
   archive)
     echo "Reth archive node without pruning"
     __prune=""
+    __snap="--archive"
     ;;
   full)
     echo "Reth full node without history expiry"
     __prune+=" --prune.receipts.before 0"
+    __snap=""
+    # Reth 2.1.0
+    # __snap="--full --receipts-all --with-txs"
     ;;
   pre-merge-expiry)
     __prune+=" --prune.transactionlookup.distance 10064"
+    __snap="--full"
+    # Reth 2.1.0
+    # __snap="--full --receipts-pre-merge"
     case ${NETWORK} in
       mainnet|sepolia)
         echo "Reth minimal node with pre-merge history expiry"
@@ -118,6 +125,9 @@ case "${NODE_TYPE}" in
     ;;
   pre-prague-expiry)
     __prune+=" --prune.transactionlookup.distance 10064"
+    __snap="--full"
+    # Reth 2.1.0
+    # __snap="--full --receipts-pre-merge"
     case "${NETWORK}" in
       mainnet)
         echo "Reth minimal node with pre-Prague history expiry"
@@ -141,10 +151,14 @@ case "${NODE_TYPE}" in
     echo "Reth minimal node with rolling history expiry, keeps 1 year."
     # 365 days = 82125 epochs = 2628000 slots / blocks
     __prune+=" --prune.transactionlookup.distance 10064 --prune.bodies.distance 2628000 --prune.receipts.distance 2628000"
+    __snap="--full"
+    # Reth 2.1.0
+    # __snap="--full --receipts-pre-merge"
     ;;
   aggressive-expiry)
     echo "Reth minimal node with aggressive expiry"
     __prune="--minimal"
+    __snap="--minimal"
     ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Reth implementation."
@@ -169,9 +183,6 @@ if [[ -f /var/lib/reth/repair-trie ]]; then
   fi
 fi
 
-__strip_empty_args "$@"
-set -- "${__args[@]}"
-
 # Traces
 if [[ "${COMPOSE_FILE}" =~ (grafana\.yml|grafana-rootless\.yml) ]]; then
   __trace="--tracing-otlp=http://tempo:4318/v1/traces"
@@ -188,6 +199,30 @@ if [[ "${IPV6:-false}" = "true" ]]; then
 else
   __ipv6=""
 fi
+
+# Snapshot
+# Reth 2.1.0
+# if [[ ! -d /var/lib/reth/db && "${NETWORK}" = "mainnet" && -n "${RETH_SNAPSHOT}" && ! "${RETH_SNAPSHOT}" = "false" ]]; then
+if [[ ! -d /var/lib/reth/db && ! "${NODE_TYPE}" = "full" && "${NETWORK}" = "mainnet" && -n "${RETH_SNAPSHOT}" \
+      && ! "${RETH_SNAPSHOT}" = "false" ]]; then
+  if [[ ! "${RETH_SNAPSHOT}" = "true" ]]; then
+    __snap="${RETH_SNAPSHOT}"
+  fi
+  echo "Downloading Reth snapshot with parameters: ${__snap}"
+# Word splitting is desired for the command line parameters
+# shellcheck disable=SC2086
+  reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap} --resumable
+# Reth 2.1.0
+#  reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap}
+# Reth 2.0.0 does not take into account --datadir.static, resolve manually
+# Remove with Reth 2.1.0
+  if [[ -n "${__static}" && -d /var/lib/reth/static_files ]]; then
+    mv -v -t /var/lib/static /var/lib/reth/static_files/*
+  fi
+fi
+
+__strip_empty_args "$@"
+set -- "${__args[@]}"
 
 if [[ -f /var/lib/reth/prune-marker ]]; then
   rm -f /var/lib/reth/prune-marker


### PR DESCRIPTION
**What I did**

Support `reth download` and resolve `static_files` issue, see [Reth issue](https://github.com/paradigmxyz/reth/issues/23436). Requires Reth 2.0.0. This speeds up initial sync dramatically.

Do not offer this for "full" nodes, as Reth has only post-merge, minimal and archive. Use post-merge for post-prague and rolling: This prunes the static files when Reth first runs.

Reth 2.1.0 improves upon this in multiple ways, and the code has comments to show how it should behave after release of 2.1.0