### PR TITLE
Improve Reth snapshot download for Reth 2.1.0

### DIFF
--- a/default.env
+++ b/default.env
@@ -253,8 +253,7 @@ CL_NODE_TYPE=pruned
 # "aggressive-expiry" is supported with Reth, Erigon and Besu
 # "aggressive-expiry" is experimental in Besu as of Jan 27th 2026
 EL_NODE_TYPE=pre-merge-expiry
-# Whether to get a snapshot from the Reth servers, if using Reth. This breaks eth_getLogs,
-# do not use with RocketPool, SSV or NodeSet
+# Whether to get a snapshot from the Reth servers, if using Reth.
 # "true" will use a (likely) correct snapshot for EL_NODE_TYPE,
 # empty or "false" disables it, and any other string is assumed to be
 # exact parameters for Reth's "download" function

--- a/ethd
+++ b/ethd
@@ -4466,14 +4466,13 @@ __query_4444() {  # Call with with --defaultno for RPC
 
 
 __query_reth_snapshot() {
-  # Reth 2.1.0, remove the test for full
-  if [[ "${EXECUTION_CLIENT}" != "reth.yml" || "${NETWORK}" != "mainnet" || "${EL_NODE_TYPE}" = "full" ]]; then
+  if [[ "${EXECUTION_CLIENT}" != "reth.yml" || "${NETWORK}" != "mainnet" ]]; then
     return
   fi
 
   __write_vars+=("RETH_SNAPSHOT")
 
-  if whiptail --title "Reth snapshot" --yesno "Do you want to speed up Reth sync by using a database snapshot? This breaks eth_getLogs RPC calls, do not use with RocketPool, SSV or NodeSet" 10 65; then
+  if whiptail --title "Reth snapshot" --yesno "Do you want to speed up Reth sync by using a database snapshot?" 10 65; then
     RETH_SNAPSHOT=true
   else
     RETH_SNAPSHOT=""

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -103,15 +103,11 @@ case "${NODE_TYPE}" in
   full)
     echo "Reth full node without history expiry"
     __prune+=" --prune.receipts.before 0"
-    __snap=""
-    # Reth 2.1.0
-    # __snap="--full --receipts-all --with-txs"
+    __snap="--with-txs-since 0 --with-receipts-since 0 --with-state-history-distance 10064"
     ;;
   pre-merge-expiry)
     __prune+=" --prune.transactionlookup.distance 10064"
-    __snap="--full"
-    # Reth 2.1.0
-    # __snap="--full --receipts-pre-merge"
+    __snap="--with-txs-since 15537394 --with-receipts-since 15537394 --with-state-history-distance 10064"
     case ${NETWORK} in
       mainnet|sepolia)
         echo "Reth minimal node with pre-merge history expiry"
@@ -125,9 +121,7 @@ case "${NODE_TYPE}" in
     ;;
   pre-prague-expiry)
     __prune+=" --prune.transactionlookup.distance 10064"
-    __snap="--full"
-    # Reth 2.1.0
-    # __snap="--full --receipts-pre-merge"
+    __snap="--with-txs-since 22431084 --with-receipts-since 22431084 --with-state-history-distance 10064"
     case "${NETWORK}" in
       mainnet)
         echo "Reth minimal node with pre-Prague history expiry"
@@ -151,9 +145,7 @@ case "${NODE_TYPE}" in
     echo "Reth minimal node with rolling history expiry, keeps 1 year."
     # 365 days = 82125 epochs = 2628000 slots / blocks
     __prune+=" --prune.transactionlookup.distance 10064 --prune.bodies.distance 2628000 --prune.receipts.distance 2628000"
-    __snap="--full"
-    # Reth 2.1.0
-    # __snap="--full --receipts-pre-merge"
+    __snap="--with-txs-distance 2628000 --with-receipts-distance 2628000 --with-state-history-distance 10064"
     ;;
   aggressive-expiry)
     echo "Reth minimal node with aggressive expiry"
@@ -214,14 +206,7 @@ if [[ -n "${__snap}" && ! -d /var/lib/reth/db ]]; then
   echo "Downloading Reth snapshot with parameters: ${__snap}"
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap} --resumable
-# Reth 2.1.0
-#  reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap}
-# Reth 2.0.0 does not take into account --datadir.static, resolve manually
-# Remove with Reth 2.1.0
-  if [[ -n "${__static}" && -d /var/lib/reth/static_files ]]; then
-    mv -v -t /var/lib/static /var/lib/reth/static_files/*
-  fi
+  exec reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap}
 fi
 
 __strip_empty_args "$@"


### PR DESCRIPTION
**What I did**

`--resumable` is now default, receipts and bodies download can be specified on CLI

Keep in draft until Reth 2.1.0 is out
