### PR TITLE
Check for keys service before calling it

### DIFF
--- a/ethd
+++ b/ethd
@@ -3516,11 +3516,7 @@ __i_haz_web3signer() {
 
 
 __i_haz_keys_service() {
-# This caused issues and is currently not being called
   if ! __docompose --profile tools config --services | grep -q validator-keys; then
-    if [[ "${1:-}" = "silent" ]]; then
-      return 1
-    fi
     echo "The validator-keys service is not defined. Are you running only a consensus layer client?"
     echo "Key management happens on the validator client / web3signer, not the consensus layer client."
     echo "You can however do things like send an exit message, prep a withdrawal credentials change,"
@@ -3658,7 +3654,7 @@ keys() {
 
   owner_uid=$(id -u "${__owner}")
   if [[ "${1:-}" = "import" ]]; then
-    #__i_haz_keys_service
+    __i_haz_keys_service
     shift
     __prep-keyimport "$@"
     __docompose run --rm -e OWNER_UID="${owner_uid}" validator-keys import "${__keys_args}"
@@ -3822,7 +3818,6 @@ keys() {
     if [[ "${failed}" -gt 0 ]]; then
       echo "Failed for ${failed} validators"
     fi
-  #elif [[ "${1:-}" = "send-exit" ]] && ! __i_haz_keys_service silent; then
   elif [[ "${1:-}" = "send-exit" ]]; then
     var="CL_NODE"
     __get_value_from_env "${var}" "${__env_file}" "CL_NODE"
@@ -3865,7 +3860,7 @@ keys() {
       --entrypoint "keymanager.sh" \
       vc-utils:local /var/lib/lighthouse/nonesuch.txt eth2 send-exit
   else
-    #__i_haz_keys_service
+    __i_haz_keys_service
     __docompose run --rm -e OWNER_UID="${owner_uid}" validator-keys "$@"
   fi
 }


### PR DESCRIPTION
**What I did**

Start using `__i_haz_keys_service` again

Works in my testing, and I am not sure why it may have failed previously. It checks for the existence of the service in the config.