### PR TITLE
Re-enable QUIC for Lodestar 1.42.0

### DIFF
--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -66,11 +66,8 @@ services:
       - ${CL_REST_PORT:-5052}
       - --port
       - ${CL_P2P_PORT:-9000}
-# BUGBUG
-# Library is bugged; re-enable with Lodestar 1.42.0
-#      - --quicPort
-#      - ${CL_QUIC_PORT:-9001}
-#      - --quic
+      - --quicPort
+      - ${CL_QUIC_PORT:-9001}
       - --nat
       - --metrics
       - "true"

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -75,11 +75,8 @@ services:
       - ${CL_REST_PORT:-5052}
       - --port
       - ${CL_P2P_PORT:-9000}
-# BUGBUG
-# Library is bugged; re-enable with Lodestar 1.42.0
-#      - --quicPort
-#      - ${CL_QUIC_PORT:-9001}
-#      - --quic
+      - --quicPort
+      - ${CL_QUIC_PORT:-9001}
       - --nat
       - --metrics
       - "true"

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -113,9 +113,6 @@ if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Lodestar to listen on IPv6 ports"
   echo "IPv6 ENR will be auto-discovered. Please make sure the v6 P2P ports are reachable \"from Internet\""
   __ipv6="--listenAddress 0.0.0.0 --listenAddress6 :: --port6 ${CL_P2P_PORT:-9000} --quicPort6 ${CL_QUIC_PORT:-9001}"
-# BUGBUG
-# Remove with Lodestar 1.42.0; here because library is buggy
-  __ipv6+=" --quicPort ${CL_QUIC_PORT:-9001} --quic"
 else
   __ipv6="--listenAddress 0.0.0.0"
 fi


### PR DESCRIPTION
**What I did**

Lodestar 1.42.0 fixes the QUIC bug with IPv4-only machines and enables QUIC by default. Always set the QUIC port.
