### PR TITLE
Make it easier to run eth-docker with an app user

### DIFF
--- a/ethd
+++ b/ethd
@@ -194,14 +194,25 @@ __handle_docker() {
 
 
 __handle_root() {
-  if [[ "${EUID}" -eq 0 ]]; then
+  local g
+  local found=0
+
+  if [[ "${EUID}" != $(id -u "${__owner}") ]]; then
     __as_owner="sudo -u ${__owner}"
-  else
-    if groups | grep -q '\bsudo\b' || groups | grep -q '\badmin\b'; then
-      __auto_sudo="sudo"
-    else
-      __cannot_sudo=1
-    fi
+  fi
+
+  if [[ "${EUID}" -ne 0 ]]; then
+    for g in $(id -nG); do
+      if [[ "${g}" =~ ^(sudo|admin)$ ]]; then
+        __auto_sudo="sudo"
+        found=1
+        break
+      fi
+    done
+  fi
+
+  if [[ "${EUID}" -ne 0 && "${found}" -eq 0 ]]; then
+    __cannot_sudo=1
   fi
 }
 
@@ -6002,7 +6013,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Use this to make sure root doesn't end up owning files
 # shellcheck disable=SC2012
 __owner=$(ls -ld . | awk '{print $3}')
-__owner_group=$(id -gn "${__owner}")
+# shellcheck disable=SC2012
+__owner_group=$(ls -ld . | awk '{print $4}')
 
 if [[ "${__owner}" = "root" ]]; then
   echo "Please install ${__project_name} as a non-root user."


### PR DESCRIPTION
**What I did**

Assume a setup with a `node` user that has eth-docker installed, and a `node-admins` group. `node` and whoever administers the node are in `node-admins`. The `eth-docker` directory has 775 or 770 permissions, and the `node-admins` group has ownership, plus setgid is set on directories. `chown -R node:node-admins ~/eth-docker && find ~/eth-docker -type d -exec chmod g+s {} +`

With `__as_owner` being set when the effective UID of `ethd` doesn't match the owner, user `alice` can cd to `/home/node/eth-docker` and execute `./ethd <whatever>`, and any file manipulation or creation activity will be prefixed with `sudo -u node`.

This makes it easy to have multiple admins on a server without a shared login.
