### PR TITLE
Better ETHDSECUNDO and Compose version check

### DIFF
--- a/ethd
+++ b/ethd
@@ -13,6 +13,9 @@ __docker_major_version=""
 __docker_minor_version=""
 __docker_patch_version=""
 __compose_exe="docker compose"
+__compose_version=""
+__compose_major=""
+__compose_minor=""
 __old_compose=0
 __compose_upgraded=0
 __distro=""
@@ -226,38 +229,41 @@ __upgrade_docker() {
   local runc_fixed_version
   local yn
 
+  if [[ -z "${ETHDSECUNDO:-}" && "${__command}" = "update" ]]; then  # Run this after getting the new ethd
+    return
+  fi
+
 # A vulnerable runc may be found in Debian <= 13 or Ubuntu <= 24.04
 # The Debian code can be removed when Debian 13 goes EOL in 2030.
 # The Ubuntu code can be removed when Ubuntu 24.04 goes EOL in 2029.
-  if [[ -n "${ETHDSECUNDO-}" || ! "${__command}" = "update" ]]; then  # Don't run this twice
-    if (( __docker_major_version < 28 )) ||
-       (( __docker_major_version == 28 && __docker_minor_version < 5 )) ||
-       (( __docker_major_version == 28 && __docker_minor_version == 5 && __docker_patch_version < 2 )); then
-      runc_version=$(runc --version | awk '{ gsub(/[-\+~]/, " ", $3); $0=$0; print $3 }')
-      runc_major_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[1]; }')
-      runc_minor_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[2]; }')
-      runc_patch_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[3]; }')
+  if (( __docker_major_version < 28 )) ||
+      (( __docker_major_version == 28 && __docker_minor_version < 5 )) ||
+      (( __docker_major_version == 28 && __docker_minor_version == 5 && __docker_patch_version < 2 )); then
+    runc_version=$(runc --version | awk '{ gsub(/[-\+~]/, " ", $3); $0=$0; print $3 }')
+    runc_major_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[1]; }')
+    runc_minor_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[2]; }')
+    runc_patch_version=$(echo "${runc_version}" | awk '{ split($1, version, "."); print version[3]; }')
 
-      if [[ "${__distro}" =~ (ubuntu|debian) ]]; then
-        if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
-          if [[ "${__distro}" =~ debian ]]; then
-            if [[ "${__os_major_version}" -gt 13 ]]; then  # Assume Debian 14 and up are fine
-              return
-            fi
-            runc_dpkg_version=$(dpkg-query -W -f='${Version}\n' runc)
-            case ${__os_major_version} in
+    if [[ "${__distro}" =~ (ubuntu|debian) ]]; then
+      if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
+        if [[ "${__distro}" =~ debian ]]; then
+          if [[ "${__os_major_version}" -gt 13 ]]; then  # Assume Debian 14 and up are fine
+            return
+          fi
+          runc_dpkg_version=$(dpkg-query -W -f='${Version}\n' runc)
+          case ${__os_major_version} in
 # These fixed versions are a guess and have not been released
-              13) runc_fixed_version="1.1.15+ds1-2+deb13u1";;
-              12) runc_fixed_version="1.1.5+ds1-1+deb12u2";;  # I don't expect to hit this, because docker.io is old
-              11) runc_fixed_version="1.0.0~rc93+ds1-5+deb11u6";;  # I don't expect to hit this, because docker.io is old
-              *) echo "Cannot check runc on Debian ${__os_major_version}. Please update to ${__min_debian} or later"; return;;
-            esac
-            if dpkg --compare-versions "${runc_dpkg_version}" lt "${runc_fixed_version}"; then
-              echo
-              echo "Docker ${__docker_version} with runc ${runc_version} detected"
-              echo "This version of runc is vulnerable"
-              echo "If an updated version of runc is available, please install it"
-              echo "Alternatively, consider uninstalling runc and replacing it with crun"
+            13) runc_fixed_version="1.1.15+ds1-2+deb13u1";;
+            12) runc_fixed_version="1.1.5+ds1-1+deb12u2";;  # I don't expect to hit this, because docker.io is old
+            11) runc_fixed_version="1.0.0~rc93+ds1-5+deb11u6";;  # I don't expect to hit this, because docker.io is old
+            *) echo "Cannot check runc on Debian ${__os_major_version}. Please update to ${__min_debian} or later"; return;;
+          esac
+          if dpkg --compare-versions "${runc_dpkg_version}" lt "${runc_fixed_version}"; then
+            echo
+            echo "Docker ${__docker_version} with runc ${runc_version} detected"
+            echo "This version of runc is vulnerable"
+            echo "If an updated version of runc is available, please install it"
+            echo "Alternatively, consider uninstalling runc and replacing it with crun"
 # Commented out until fixed versions have actually been released
 #              if [ "${__non_interactive}" -eq 0 ]; then
 #                while true; do
@@ -271,64 +277,63 @@ __upgrade_docker() {
 #                  esac
 #                done
 #              fi
-            fi
-          else  # This is Ubuntu and they fixed it with runc 1.3.3
-            if (( runc_major_version == 1 &&  runc_minor_version < 3 )) ||
-               (( runc_major_version == 1 && runc_minor_version == 3 && runc_patch_version < 3 )); then
-              echo
-              echo "Docker ${__docker_version} with runc ${runc_version} detected"
-              echo "This version of runc is vulnerable"
-              __nag_os_version
-              if [[ "${__eol_os}" -eq 1 ]]; then
-                echo "${__project_name} cannot update runc on Ubuntu ${__os_major_version}."
-                return
-              fi
-              echo "It is recommended that you update runc"
-              if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
-                while true; do
-                  read -rp "Do you want to update runc (yes/no) " yn
-                  case "${yn}" in
-                    [Nn]*) echo "Please be sure to update runc yourself!"; return;;
-                    *)
-                      ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install --only-upgrade runc
-                      break
-                      ;;
-                  esac
-                done
-              fi
-            fi
           fi
-        elif dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
-          echo
-          echo "Docker ${__docker_version} detected"
-          echo "This version of Docker has a vulnerable runc binary"
-          __nag_os_version
-          if [[ "${__eol_os}" -eq 1 ]]; then
-            echo "${__project_name} cannot update Docker-CE on ${__distro} ${__os_major_version}."
-            return
-          fi
-          echo "It is recommended that you update Docker-CE"
-          if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
-            while true; do
-              read -rp "Do you want to update Docker-CE? (yes/no) " yn
-              case "${yn}" in
-                [Nn]*) echo "Please be sure to update Docker CE yourself!"; return;;
-                *)
-                  ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install --only-upgrade docker-ce containerd.io
-                  break
-                  ;;
-              esac
-            done
+        else  # This is Ubuntu and they fixed it with runc 1.3.3
+          if (( runc_major_version == 1 &&  runc_minor_version < 3 )) ||
+              (( runc_major_version == 1 && runc_minor_version == 3 && runc_patch_version < 3 )); then
+            echo
+            echo "Docker ${__docker_version} with runc ${runc_version} detected"
+            echo "This version of runc is vulnerable"
+            __nag_os_version
+            if [ "${__eol_os}" -eq 1 ]; then
+              echo "${__project_name} cannot update runc on Ubuntu ${__os_major_version}."
+              return
+            fi
+            echo "It is recommended that you update runc"
+            if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
+              while true; do
+                read -rp "Do you want to update runc (yes/no) " yn
+                case "${yn}" in
+                  [Nn]*) echo "Please be sure to update runc yourself!"; return;;
+                  *)
+                    ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install --only-upgrade runc
+                    break
+                    ;;
+                esac
+              done
+            fi
           fi
         fi
-      else
-        if (( runc_major_version == 1 && runc_minor_version < 2 )) ||
-           (( runc_major_version == 1 && runc_minor_version == 2 && runc_patch_version < 8 )) ||
-           (( runc_major_version == 1 && runc_minor_version == 3 && runc_patch_version < 3 )); then
-          echo
-          echo "Docker ${__docker_version} with runc ${runc_version} detected"
-          echo "This version of runc may be vulnerable, but ${__project_name} cannot update it on ${__distro}"
+      elif dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
+        echo
+        echo "Docker ${__docker_version} detected"
+        echo "This version of Docker has a vulnerable runc binary"
+        __nag_os_version
+        if [[ "${__eol_os}" -eq 1 ]]; then
+          echo "${__project_name} cannot update Docker-CE on ${__distro} ${__os_major_version}."
+          return
         fi
+        echo "It is recommended that you update Docker-CE"
+        if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
+          while true; do
+            read -rp "Do you want to update Docker-CE? (yes/no) " yn
+            case "${yn}" in
+              [Nn]*) echo "Please be sure to update Docker CE yourself!"; return;;
+              *)
+                ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install --only-upgrade docker-ce containerd.io
+                break
+                ;;
+            esac
+          done
+        fi
+      fi
+    else
+      if (( runc_major_version == 1 && runc_minor_version < 2 )) ||
+          (( runc_major_version == 1 && runc_minor_version == 2 && runc_patch_version < 8 )) ||
+          (( runc_major_version == 1 && runc_minor_version == 3 && runc_patch_version < 3 )); then
+        echo
+        echo "Docker ${__docker_version} with runc ${runc_version} detected"
+        echo "This version of runc may be vulnerable, but ${__project_name} cannot update it on ${__distro}"
       fi
     fi
   fi
@@ -401,7 +406,7 @@ __check_compose_version() {
 # Compose V1 is in Debian 11 and Debian 12. The Debian-specific code can be removed when Debian 12 goes EOL in 2028.
 # Compose V1 is in Ubuntu 22.04 and 24.04. The Compose version check can be removed when Ubuntu 24.04 goes EOL in 2029.
 
-# Check for Compose V2 (docker compose) vs Compose V1 (docker-compose)
+# Check for Compose V2+ (docker compose) vs Compose V1 (docker-compose)
   if docker compose version >/dev/null 2>&1; then
     __compose_version=$(${__docker_sudo} docker compose version | sed -n -E -e "s/.*version [v]?([0-9.-]*).*/\1/ip")
     __compose_major=${__compose_version%%.*}
@@ -409,10 +414,8 @@ __check_compose_version() {
     __compose_minor=${__compose_minor%%.*}
    if [[ "${__compose_major}" -eq 1 ]]; then
      __old_compose=1
-   elif [[ "${__compose_minor}" -lt 18 ]]; then
+   elif [[ "${__compose_major}" -eq 2 && "${__compose_minor}" -lt 18 ]]; then
      __old_compose=1
-   else
-     __old_compose=0
    fi
   else
     __old_compose=1
@@ -421,54 +424,50 @@ __check_compose_version() {
     __compose_minor=${__compose_version#*.}
     __compose_minor=${__compose_minor%%.*}
   fi
-  if [ "${__old_compose}" -eq 1 ]; then
-    if [[ "${__compose_major}" -eq 1 ]]; then
-      # This runs before the actual update command, in the main section. ethd exits if it can't upgrade, therefore
-      # no check for ${ETHDSECUNDO} or command update, here
-      echo
-      echo "You are using docker-compose ${__compose_version}, which is unsupported by Docker, Inc."
-      echo "${__project_name} only supports Compose V2."
-      echo
-      if [[ "${__distro}" = "ubuntu" ]]; then
-        echo "It is recommended that you replace Compose V1 with Compose V2."
-        if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
-          while true; do
-            read -rp "Do you want to update Docker Compose to V2? (yes/no) " yn
-            case "${yn}" in
-              [Nn]*)
-                echo "Please be sure to update Docker Compose yourself!"
-                echo "You can install it with \"sudo apt update && sudo apt install docker-compose-v2\"."
-                echo "You can remove the old docker-compose:"
-                echo "\"sudo apt-mark manual docker.io && sudo apt --autoremove remove docker-compose\""
-                break
-                ;;
-              *) __upgrade_compose; break;;
-            esac
-          done
-        fi
-      elif [[ "${__distro}" =~ debian ]]; then
-        if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
-          if [[ "${__os_major_version}" -lt 13 ]]; then
-            echo "Debian ${__os_major_version}'s docker.io does not ship with Compose V2. Please replace docker.io with docker-ce"
-            echo "See https://ethdocker.com/Usage/Prerequisites#switching-from-dockerio-to-docker-ce"
-          else
-            echo "Debian ${__os_major_version} ships with Compose V2."
-            echo "This is very unexpected, and ${__project_name} is not sure what to recommend."
-            echo "Please come to ethstaker Discord: http://discord.gg/ethstaker"
-          fi
-        else
-          echo "You appear to be using Docker CE, which ships with Compose V2."
-          echo "This is very unexpected, and ${__project_name} is not sure what to recommend."
-          echo "Please come to ethstaker Discord: http://discord.gg/ethstaker"
-        fi
-      else
-        echo "${__project_name} does not know how to update Docker Compose on ${__distro}"
-      fi
-    else  # Old Compose V2
-      if [[ -n "${ETHDSECUNDO-}" || ! "${__command}" = "update" ]]; then  # Don't run this twice
-        true  # Nothing now for old V2; maybe in future we'll do the update for the user
-      fi
+  if [[ "${__compose_major}" -gt 1 ]]; then
+    return
+  fi
+
+  # This runs before the actual update command, in the main section. ethd exits if it can't upgrade, therefore
+  # no check for ${ETHDSECUNDO} or command update, here
+  echo
+  echo "You are using docker-compose ${__compose_version}, which is unsupported by Docker, Inc."
+  echo "${__project_name} only supports Compose V2."
+  echo
+  if [[ "${__distro}" = "ubuntu" ]]; then
+    echo "It is recommended that you replace Compose V1 with Compose V2."
+    if [[ "${__non_interactive}" -eq 0 && "${__cannot_sudo}" -eq 0 ]]; then
+      while true; do
+        read -rp "Do you want to update Docker Compose to V2? (yes/no) " yn
+        case "${yn}" in
+          [Nn]*)
+            echo "Please be sure to update Docker Compose yourself!"
+            echo "You can install it with \"sudo apt update && sudo apt install docker-compose-v2\"."
+            echo "You can remove the old docker-compose:"
+            echo "\"sudo apt-mark manual docker.io && sudo apt --autoremove remove docker-compose\""
+            break
+            ;;
+          *) __upgrade_compose; break;;
+        esac
+      done
     fi
+  elif [[ "${__distro}" =~ debian ]]; then
+    if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
+      if [[ "${__os_major_version}" -lt 13 ]]; then
+        echo "Debian ${__os_major_version}'s docker.io does not ship with Compose V2. Please replace docker.io with docker-ce"
+        echo "See https://ethdocker.com/Usage/Prerequisites#switching-from-dockerio-to-docker-ce"
+      else
+        echo "Debian ${__os_major_version} ships with Compose V2."
+        echo "This is very unexpected, and ${__project_name} is not sure what to recommend."
+        echo "Please come to ethstaker Discord: http://discord.gg/ethstaker"
+      fi
+    else
+      echo "You appear to be using Docker CE, which ships with Compose V2."
+      echo "This is very unexpected, and ${__project_name} is not sure what to recommend."
+      echo "Please come to ethstaker Discord: http://discord.gg/ethstaker"
+    fi
+  else
+    echo "${__project_name} does not know how to update Docker Compose on ${__distro}"
   fi
 }
 
@@ -2115,7 +2114,7 @@ update() {
     fi
   fi
 
-  if [[ -z "${ETHDSECUNDO-}" ]]; then
+  if [[ -z "${ETHDSECUNDO:-}" ]]; then
     set +e
     ${__as_owner} git config pull.rebase false
     var="ETH_DOCKER_TAG"
@@ -6160,7 +6159,7 @@ fi
 
 if [[ "${__old_compose}" -eq 1 && "${__compose_major}" -eq 2 ]]; then
   echo "You are using Docker Compose ${__compose_version}, which has been shown to cause issues with new features"
-  echo "${__project_name} may require Compose v2.18.1 or later in future"
+  echo "${__project_name} requires Compose v2.18 or later"
   echo
   echo "It is recommended that you update Compose."
   if [[ "${__distro}" =~ (debian|ubuntu) ]]; then


### PR DESCRIPTION
**What I did**

Use `${ETHDSECUNDO:-}` for better readability

Use
```
  if [[ -z "${ETHDSECUNDO:-}" && "${__command}" = "update" ]]; then  # Run this after getting the new ethd
    return
  fi
  <body of the work>
```
instead of
```
  if [[ -n "${ETHDSECUNDO-}" || ! "${__command}" = "update" ]]; then  # Don't run this twice
      <body of the work>
  fi
```

When checking for old Docker Compose, explicitly check for 2.18, not x.18, and do not take action for Compose V2+, other than a nag

Define `__compose_version`, `__compose_major` and `__compose_minor` in the globals section
