### PR TITLE
Use UBUNTU_CODENAME if defined

### DIFF
--- a/ethd
+++ b/ethd
@@ -836,7 +836,7 @@ __install_docker() {
     ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb
 URIs: https://download.docker.com/linux/${repo}
-Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")
 Components: stable
 Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/docker.asc

--- a/ethd
+++ b/ethd
@@ -787,7 +787,7 @@ __install_docker() {
     ${__auto_sudo} tee /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb
 URIs: https://download.docker.com/linux/${repo}
-Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-VERSION_CODENAME}")
 Components: stable
 Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
**What I did**

When installing docker-ce, use `${UBUNTU_CODENAME:-VERSION_CODENAME}` for the `Suites:`. `UBUNTU_CODENAME` if defined, `VERSION_CODENAME` otherwise. Works well on Ubuntu and Debian.
