### PR TITLE
Always lint before running tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,12 @@ name: Lint sources
 run-name: Lint sources
 
 on:
-  push:
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/test-client-combos.yml
+++ b/.github/workflows/test-client-combos.yml
@@ -11,9 +11,40 @@ on:
     types: [opened, synchronize, labeled, unlabeled]
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    name: Lint sources
+    if: |
+      (
+        contains(join(github.event.pull_request.labels.*.name, ','), 'test-') &&
+        !contains(github.event.pull_request.labels.*.name, 'test-ethd') &&
+        !contains(github.event.pull_request.labels.*.name, 'test-grafana') &&
+        !contains(github.event.pull_request.labels.*.name, 'test-nimbus-proxy') &&
+        !contains(github.event.pull_request.labels.*.name, 'test-web3signer')
+      )
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+          cache: 'pip'
+      - name: Lint sources
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure
+
   test-client-combo:
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       matrix:
         combo:

--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -6,9 +6,14 @@ defaults:
 
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-ethd:

--- a/.github/workflows/test-grafana.yml
+++ b/.github/workflows/test-grafana.yml
@@ -6,9 +6,14 @@ defaults:
 
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-grafana:

--- a/.github/workflows/test-nimbus-proxy.yml
+++ b/.github/workflows/test-nimbus-proxy.yml
@@ -6,9 +6,14 @@ defaults:
 
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-nimbus-proxy:


### PR DESCRIPTION
**What I did**

Add a copy of `lint.yml` to `test-client-combos.yml` and have the client tests rely on it. Lint errors will not consume Github runners.

lint in the test combo only runs if a `test-` label has been set, and it's not one of the other three workflows. No more "let's start 188 runners and cancel them right away", *unless* there's a `test-` label. Then, they still all get started.

Concurrency added: If we're starting a test over, say because of a force push, kill the old test.

While this lints twice, it also means client combination runners aren't started if lint fails.

Grafana, ethd, nimbus-proxy and web3signer tests start even with a failing lint. Those are one runner each. I'm comfortable with having them run even if there's a linting error.
