### PR TITLE
Support Web3signer distroless

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -23,6 +23,12 @@ jobs:
             test_el: false
             test_vc: false
           - env: |-
+              CORE_FILES=web3signer.yml
+              W3S_DOCKERFILE=Dockerfile.source
+            test_cl: false
+            test_el: false
+            test_vc: false
+          - env: |-
               COMPOSE_FILE=nimbus-vp.yml
               NIMVP_DOCKERFILE=Dockerfile.source
             test_cl: false

--- a/.github/workflows/test-web3signer.yml
+++ b/.github/workflows/test-web3signer.yml
@@ -1,0 +1,80 @@
+name: Test Web3signer
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-web3signer:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'test-web3signer') ||
+      contains(github.event.pull_request.labels.*.name, 'test-all') ||
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Create .env file
+        run: cp default.env .env
+      - name: Set Lighthouse/Geth/Web3signer
+        run: |
+          source ./.github/helper.sh
+          CORE_FILES=lighthouse.yml:geth.yml:web3signer.yml
+          var=CORE_FILES
+          set_value_in_env
+          FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+          var=FEE_RECIPIENT
+          set_value_in_env
+          WEB3SIGNER=true
+          var=WEB3SIGNER
+          set_value_in_env
+          W3S_DOCKER_TAG=latest
+          var=W3S_DOCKER_TAG
+          set_value_in_env
+          W3S_READ_ONLY=false
+          var=W3S_READ_ONLY
+          set_value_in_env
+      - name: Start Lighthouse/Geth/Web3signer
+        run: ./ethd up
+      - name: Pause for 30 seconds
+        run: sleep 30
+      - name: Test Web3signer
+        run: ./.github/check-service.sh web3signer
+      - name: Test PostgreSQL
+        run: ./.github/check-service.sh postgres
+      - name: Test version
+        run: ./ethd version
+      - name: Set distroless
+        run: |
+          source ./.github/helper.sh
+          W3S_DOCKER_TAG=latest-distroless
+          var=W3S_DOCKER_TAG
+          set_value_in_env
+          W3S_READ_ONLY=true
+          var=W3S_READ_ONLY
+          set_value_in_env
+      - name: Rebuild Web3signer image
+        run: ./ethd cmd build --pull
+      - name: Start Lighthouse/Geth/Web3signer
+        run: ./ethd up
+      - name: Pause for 30 seconds
+        run: sleep 30
+      - name: Test Web3signer
+        run: ./.github/check-service.sh web3signer
+      - name: Test PostgreSQL
+        run: ./.github/check-service.sh postgres
+      - name: Test version
+        run: ./ethd version

--- a/default.env
+++ b/default.env
@@ -404,8 +404,15 @@ VERO_DOCKER_REPO=ghcr.io/serenita-org/vero
 VERO_DOCKERFILE=Dockerfile.binary
 
 # Web3Signer
+# SRC build target can be a tag, a branch, or a pr as "pr-ID"
+W3S_SRC_BUILD_TARGET=master
+W3S_SRC_REPO=https://github.com/Consensys/web3signer
+# Use latest-distroless or <vx.y>-distroless for a distroless setup
 W3S_DOCKER_TAG=latest
+# Set to "true" for distroless and read-only Docker
+W3S_READ_ONLY=false
 W3S_DOCKER_REPO=consensys/web3signer
+W3S_DOCKERFILE=Dockerfile.binary
 PG_DOCKER_TAG=18-trixie
 
 # Besu
@@ -494,4 +501,4 @@ DOCKER_ROOT=/var/lib/docker
 DOCKER_SOCK=/var/run/docker.sock
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=55
+ENV_VERSION=56

--- a/ethd
+++ b/ethd
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 __project_name="Eth Docker"
 __app_name="Ethereum node"
 __sample_service="consensus"
-__min_env_version=55
+__min_env_version=56
 __docker_exe="docker"
 __old_docker=0
 __docker_sudo=""
@@ -1121,6 +1121,16 @@ __source_build() {
 # shellcheck disable=SC2154
       if [[ "${__value}" = "Dockerfile.source" ]]; then
         __docompose --profile tools build --pull --no-cache deposit-cli-new
+      fi
+      ;;
+  esac
+  case "${COMPOSE_FILE}" in
+    *web3signer.yml*)
+      var="W3S_DOCKERFILE"
+      __get_value_from_env "${var}" "${__env_file}" "__value"
+# shellcheck disable=SC2154
+      if [[ "${__value}" = "Dockerfile.source" ]]; then
+        __docompose build --pull --no-cache web3signer
       fi
       ;;
   esac
@@ -5816,6 +5826,7 @@ config() {
 
 version() {
   local var
+  local w3s_exec=""
 
   grep "^This is" README.md
   echo
@@ -5939,7 +5950,17 @@ version() {
   # Web3signer version
   case "${__value}" in
     *web3signer.yml*)
-      __docompose exec web3signer /opt/web3signer/bin/web3signer --version
+      var=W3S_DOCKER_TAG
+      __get_value_from_env "${var}" "${__env_file}" "${var}"
+      var=W3S_DOCKERFILE
+      __get_value_from_env "${var}" "${__env_file}" "${var}"
+      if [[ "${W3S_DOCKERFILE}" = "Dockerfile.binary" && "${W3S_DOCKER_TAG}" =~ distroless ]]; then
+        w3s_exec="java -cp /opt/web3signer/lib/* tech.pegasys.web3signer.Web3SignerApp"
+      else
+        w3s_exec="/opt/web3signer/bin/web3signer"
+      fi
+  # shellcheck disable=SC2086
+      __docompose exec web3signer ${w3s_exec} --version
       echo
       __docompose exec postgres pg_config --version
       echo

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -19,6 +19,7 @@ services:
     pull_policy: never
     volumes:
       - web3signer-slashing-data:/var/lib/postgres-data:ro
+      - web3signer-keys:/var/lib/web3signer
     environment:
       - PG_DOCKER_TAG=${PG_DOCKER_TAG}
       - PG_ALIAS=${PG_ALIAS}
@@ -40,17 +41,20 @@ services:
     build:
       context: ./web3signer
       args:
+        - BUILD_TARGET=${W3S_SRC_BUILD_TARGET:-$$(git describe --tags $$(git rev-list --tags --max-count=1))}
+        - SRC_REPO=${W3S_SRC_REPO:-https://github.com/Consensys/web3signer}
         - DOCKER_TAG=${W3S_DOCKER_TAG:-latest}
         - DOCKER_REPO=${W3S_DOCKER_REPO:-consensys/web3signer}
-      dockerfile: Dockerfile.binary
+      dockerfile: ${W3S_DOCKERFILE}
     image: web3signer:local
     pull_policy: never
-    user: web3signer
+    user: 10000:10000
     volumes:
       - web3signer-keys:/var/lib/web3signer
       - /etc/localtime:/etc/localtime:ro
+    read_only: ${W3S_READ_ONLY:-false}
     environment:
-      - JAVA_OPTS=${W3S_HEAP:--Xmx6g}
+      - JAVA_TOOL_OPTIONS=${W3S_HEAP:--Xmx6g}
       - NETWORK=${NETWORK}
       - PG_ALIAS=${PG_ALIAS:-${NETWORK}-postgres}
     networks:
@@ -62,15 +66,14 @@ services:
       w3s-init:
         condition: service_completed_successfully
     <<: *logging
-    entrypoint:
-      - docker-entrypoint.sh
-      - /opt/web3signer/bin/web3signer
+    command:
       - --key-store-path=/var/lib/web3signer/keys
       - --metrics-enabled
       - --metrics-host-allowlist=*
       - --http-host-allowlist=*
       - --logging=${LOG_LEVEL:-info}
       - eth2
+      - --network=${NETWORK}
       - --enable-key-manager-api=true
       - --slashing-protection-db-url=jdbc:postgresql://${PG_ALIAS:-${NETWORK}-postgres}/web3signer
       - --slashing-protection-db-username=postgres

--- a/web3signer/Dockerfile.binary
+++ b/web3signer/Dockerfile.binary
@@ -1,30 +1,6 @@
-# hadolint global ignore=DL3007,DL3008,DL3059
 ARG DOCKER_TAG=latest
 ARG DOCKER_REPO=consensys/web3signer
 
 FROM ${DOCKER_REPO}:${DOCKER_TAG}
 
-ARG USER=web3signer
-ARG UID=10000
-
-USER root
-
-RUN groupmod -g "${UID}" ${USER} && usermod -u "${UID}" -g "${UID}" ${USER}
-
-RUN set -eux; \
-  apt-get update; \
-  DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends gosu ca-certificates tzdata git git-lfs; \
-  rm -rf /var/lib/apt/lists/*; \
-# verify that the binary works
-  gosu nobody true
-
-# Create data mount point with permissions
-RUN mkdir -p /var/lib/web3signer/keys && chown -R ${USER}:${USER} /var/lib/web3signer && chmod -R 700 /var/lib/web3signer
-# Cannot assume buildkit, hence no chmod
-COPY --chown=${USER}:${USER} ./docker-entrypoint.sh /usr/local/bin/
-# Belt and suspenders
-RUN chmod -R 755 /usr/local/bin/*
-
-USER ${USER}
-
-ENTRYPOINT ["/opt/web3signer/bin/web3signer"]
+USER 10000:10000

--- a/web3signer/Dockerfile.source
+++ b/web3signer/Dockerfile.source
@@ -1,0 +1,72 @@
+# hadolint global ignore=DL3007,DL3008,DL3059
+# Build Web3signer in a stock Ubuntu container
+FROM eclipse-temurin:25-jdk-noble AS builder
+
+# This is here to avoid build-time complaints
+ARG DOCKER_TAG
+ARG DOCKER_REPO
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git
+
+ARG BUILD_TARGET
+ARG SRC_REPO
+
+WORKDIR /usr/src
+
+ARG SRC_DIR=web3signer
+RUN bash -eo pipefail <<'EOF'
+  git clone "$SRC_REPO" "$SRC_DIR"
+  cd "$SRC_DIR"
+  git config advice.detachedHead false
+  git fetch --all --tags
+  CLEANED=$(echo "$BUILD_TARGET" | sed 's/\$\$(/$(/g')
+  TARGET=$(eval echo "$CLEANED")
+  echo "Build $TARGET from $SRC_REPO"
+  if [[ "$TARGET" =~ ^pr-[1-9][0-9]*$ ]]; then
+    git fetch origin pull/$(echo "$TARGET" | cut -d '-' -f 2)/head:build-pr
+    git checkout build-pr
+  else
+    git checkout "$TARGET"
+  fi
+  git submodule update --init --recursive --jobs $(nproc)
+  ./gradlew installDist
+EOF
+
+
+# Pull all binaries into a second stage deploy Ubuntu container
+FROM eclipse-temurin:25-jre-noble
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
+  ca-certificates \
+  tzdata \
+  git \
+  git-lfs \
+  adduser \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG USER=web3signer
+ARG UID=10000
+
+# See https://stackoverflow.com/a/55757473/12429735RUN
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/usr/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+# Create data mount point with permissions
+RUN mkdir -p /var/lib/web3signer/keys && chown -R ${USER}:${USER} /var/lib/web3signer && chmod -R 700 /var/lib/web3signer
+
+# Cannot assume buildkit, hence no chmod
+COPY --from=builder --chown=${USER}:${USER} /usr/src/web3signer/build/install/web3signer/. /opt/web3signer/
+COPY --chown=${USER}:${USER} ./docker-entrypoint.sh /usr/local/bin/
+# Belt and suspenders
+RUN chmod -R 755 /usr/local/bin/*
+
+USER ${USER}
+
+ENTRYPOINT ["docker-entrypoint.sh", "/opt/web3signer/bin/web3signer"]

--- a/web3signer/docker-entrypoint-flyway.sh
+++ b/web3signer/docker-entrypoint-flyway.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -Eeu
 
+# Permissions
+mkdir -p /var/lib/web3signer/keys && chown -R 10000:10000 /var/lib/web3signer
+
 # Configuration
 db_url="postgresql://postgres:postgres@${PG_ALIAS}:5432/web3signer"
 check_query="SELECT 1 FROM pg_database WHERE datname = current_database() AND datcollversion <> (SELECT collversion FROM pg_collation WHERE collname = 'en_US.utf8' LIMIT 1);"
@@ -47,6 +50,28 @@ if [[ -f "${data_dir}/PG_VERSION" ]]; then
     sleep 30
     exit 1
   fi
+fi
+
+if [[ -f /var/lib/web3signer/.migration_fatal_error ]]; then
+    echo "An error occurred during \"ethd update\" and slashing protection database migration, that makes it unsafe to start Web3signer."
+    echo "Until this is manually remedied, Web3signer will refuse to start up."
+    echo "Aborting."
+    echo
+    echo "If this issue has since been resolved, you can remove the \".migration_fatal_error\" marker file in Web3signer's"
+    echo "Docker volume."
+    echo
+    echo "ONLY remove the marker file if the issue has been resolved. You risk slashing otherwise."
+    sleep 30
+    exit 1
+fi
+
+if [[ -f /var/lib/web3signer/.migration_error ]]; then
+    echo "An error occurred during \"ethd update\", while switching to a new version of PostgreSQL."
+    echo "Web3signer will start, but won't work until PostgreSQL's version matches the slashing protection database"
+    echo "version."
+    echo
+    echo "If this issue has since been resolved, you can remove the \".migration_error\" marker file in Web3signer's"
+    echo "Docker volume."
 fi
 
 exec "$@"

--- a/web3signer/docker-entrypoint.sh
+++ b/web3signer/docker-entrypoint.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [[ "$(id -u)" -eq 0 ]]; then
-  chown -R web3signer /var/lib/web3signer
-  exec gosu web3signer docker-entrypoint.sh "$@"
-fi
+# Because we're oh-so-clever with custom NETWORK, we may need to remove what's already passed in.
+__strip_network_args() {
+  local arg
+  __args=()
+  for arg in "$@"; do
+    if [[ ! "${arg}" = "--network=${NETWORK}" ]]; then
+      __args+=("${arg}")
+    fi
+  done
+}
 
-if [[ "${NETWORK}" =~ ^https?:// ]]; then
+
+if [[ "${NETWORK:-}" =~ ^https?:// ]]; then
   echo "Custom testnet at ${NETWORK}"
   repo=$(awk -F'/tree/' '{print $1}' <<< "${NETWORK}")
   branch=$(awk -F'/tree/' '{print $2}' <<< "${NETWORK}" | cut -d'/' -f1)
@@ -25,31 +32,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
   fi
   set +e
   __network="--network=/var/lib/web3signer/testnet/${config_dir}/config.yaml"
+
+  __strip_network_args "$@"
+  set -- "${__args[@]}"
 else
-  __network="--network=${NETWORK}"
+  __network=""
 fi
 
-if [[ -f /var/lib/web3signer/.migration_fatal_error ]]; then
-    echo "An error occurred during \"ethd update\" and slashing protection database migration, that makes it unsafe to start Web3signer."
-    echo "Until this is manually remedied, Web3signer will refuse to start up."
-    echo "Aborting."
-    echo
-    echo "If this issue has since been resolved, you can remove the \".migration_fatal_error\" marker file in Web3signer's"
-    echo "Docker volume."
-    echo
-    echo "ONLY remove the marker file if the issue has been resolved. You risk slashing otherwise."
-    sleep 30
-    exit 1
-fi
-
-if [[ -f /var/lib/web3signer/.migration_error ]]; then
-    echo "An error occurred during \"ethd update\", while switching to a new version of PostgreSQL."
-    echo "Web3signer will start, but won't work until PostgreSQL's version matches the slashing protection database"
-    echo "version."
-    echo
-    echo "If this issue has since been resolved, you can remove the \".migration_error\" marker file in Web3signer's"
-    echo "Docker volume."
-fi
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
 exec "$@" ${__network}


### PR DESCRIPTION
**What I did**

Consensys introduced a `latest-distroless` tag. This supports it.

Requires Web3signer 26.4.2 or later

The migration warnings and failures have migrated into `w3s-init`

`Dockerfile.binary` is the default and will just run the entrypoint of whatever image the user chooses

`Dockerfile.source` still supports custom network processing

Add Web3signer CI
