### PR TITLE
Document Web3signer default heap

### DIFF
--- a/default.env
+++ b/default.env
@@ -228,7 +228,7 @@ PROXY_EXTRAS=
 # to 12g. If left empty, the defaults in besu.yml and teku.yml are used
 BESU_HEAP=
 TEKU_HEAP=
-# Heap for Web3signer. Defaults to -Xmx4g; -Xmx2g should also work in many setups
+# Heap for Web3signer. Defaults to -Xmx6g.
 W3S_HEAP=
 # Heap for Lodestar. Sets NODE_OPTIONS to this value, for example --max-old-space-size=16384
 # If left empty, the default in lodestar.yml will be used


### PR DESCRIPTION
**What I did**

`26.4.1` fixes a memory leak on startup

This needs to be thoroughly tested. In draft until I can do so. Ethstaker has 15k Hoodi keys, that would be a good test.

After testing, no. With `-Xmx6g` and 32 keys, Web3signer uses no more than 1.5 GiB during key load. With 15,000 keys, it uses up to 6.4 GiB during key load in 500-key batches, then drops down.

High Xmx does not hurt users with few keys, and protects users with many keys.

Changed PR to merely correctly document the default
