### PR TITLE
Add command to reduce security of web3signer keys

### DIFF
--- a/web3signer.yml
+++ b/web3signer.yml
@@ -107,6 +107,22 @@ services:
     labels:
       - logs.collect=true
 
+  reduce-key-security:
+    profiles: ["tools"]
+    restart: "no"
+    build:
+      context: ./web3signer
+      dockerfile: Dockerfile.convert
+    image: w3s-converter:local
+    pull_policy: never
+    user: 10000:10000
+    volumes:
+      - web3signer-keys:/var/lib/web3signer
+    environment:
+      - NETWORK=${NETWORK}
+    entrypoint:
+      - convert-keys.sh
+
 volumes:
   web3signer-keys:
   web3signer-slashing-data:

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -110,6 +110,22 @@ services:
     labels:
       - logs.collect=true
 
+  reduce-key-security:
+    profiles: ["tools"]
+    restart: "no"
+    build:
+      context: ./web3signer
+      dockerfile: Dockerfile.convert
+    image: w3s-converter:local
+    pull_policy: never
+    user: 10000:10000
+    volumes:
+      - web3signer-keys:/var/lib/web3signer
+    environment:
+      - NETWORK=${NETWORK}
+    entrypoint:
+      - convert-keys.sh
+
 volumes:
   web3signer-keys:
   web3signer-slashing-data:

--- a/web3signer/Dockerfile.convert
+++ b/web3signer/Dockerfile.convert
@@ -1,0 +1,31 @@
+# hadolint global ignore=DL3008
+FROM eclipse-temurin:25-jdk-noble AS builder
+
+#ARG BUILD_TARGET=main
+ARG BUILD_TARGET=d32d6faf156b42985d6287a99e379b91d86fdb44
+ARG SRC_REPO=https://github.com/usmansaleem/v4keystore_converter
+ARG SRC_DIR=converter
+WORKDIR /usr/src
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git
+
+RUN bash -eo pipefail <<'EOF'
+  git clone "$SRC_REPO" "$SRC_DIR"
+  cd "$SRC_DIR"
+  git config advice.detachedHead false
+  git fetch --all --tags
+  CLEANED=$(echo "$BUILD_TARGET" | sed 's/\$\$(/$(/g')
+  TARGET=$(eval echo "$CLEANED")
+  git checkout "$TARGET"
+  git submodule update --init --recursive --jobs $(nproc)
+  ./gradlew installDist
+EOF
+
+FROM eclipse-temurin:25-jre-noble
+
+COPY --from=builder /usr/src/converter/converter/build/install/converter/ /opt/converter/
+COPY ./convert-keys.sh /usr/local/bin/
+
+USER 10000:10000
+
+ENTRYPOINT ["/opt/converter/bin/converter"]

--- a/web3signer/Dockerfile.convert
+++ b/web3signer/Dockerfile.convert
@@ -1,0 +1,30 @@
+# hadolint global ignore=DL3008
+FROM eclipse-temurin:25-jdk-noble AS builder
+
+ARG BUILD_TARGET=main
+ARG SRC_REPO=https://github.com/usmansaleem/v4keystore_converter
+ARG SRC_DIR=converter
+WORKDIR /usr/src
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git
+
+RUN bash -eo pipefail <<'EOF'
+  git clone "$SRC_REPO" "$SRC_DIR"
+  cd "$SRC_DIR"
+  git config advice.detachedHead false
+  git fetch --all --tags
+  CLEANED=$(echo "$BUILD_TARGET" | sed 's/\$\$(/$(/g')
+  TARGET=$(eval echo "$CLEANED")
+  git checkout "$TARGET"
+  git submodule update --init --recursive --jobs $(nproc)
+  ./gradlew installDist
+EOF
+
+FROM eclipse-temurin:25-jre-noble
+
+COPY --from=builder /usr/src/converter/converter/build/install/converter/ /opt/converter/
+COPY ./convert-keys.sh /usr/local/bin/
+
+USER 10000:10000
+
+ENTRYPOINT ["/opt/converter/bin/converter"]

--- a/web3signer/convert-keys.sh
+++ b/web3signer/convert-keys.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2174
+set -Eeuo pipefail
+
+ts=$(date +%s)
+base_dir=/var/lib/web3signer
+mkdir -p -m 700 "${base_dir}"/converted-keys
+
+if ! find "${base_dir}"/keys -type f -name '*.password' -print -quit 2>/dev/null | grep -q .; then
+  echo "No key files found in ${base_dir}/keys. Aborting."
+  exit 1
+fi
+
+if [[ "${NETWORK}" =~ ^(mainnet|gnosis)$ ]]; then
+  echo "Reducing key security on ${NETWORK} is not recommended. If you need to do so, please do so manually."
+  echo "Aborting"
+  exit 1
+fi
+
+if find "${base_dir}"/converted-keys -type f -name '*.json' -print -quit | grep -q .; then
+  while true; do
+    echo "Keys have previously been converted."
+    read -rp "Do you want to run conversion again, maybe because you added keys? (N/y) " yn
+    case "${yn}" in
+      [Yy]) echo; rm -f "${base_dir}"/converted-keys/*; break;;
+      *) echo "Aborting, no changes made"; exit 0;;
+    esac
+  done
+fi
+
+while true; do
+  echo "WARNING: This function will reduce the security of validator keys loaded into Web3signer."
+  echo "Web3signer startup time for thousands of keys will reduce to seconds."
+  echo "Conversion can take 30 minutes for 15,000 keys. Running in screen or tmux is recommended."
+  read -rp "Are you sure you want to convert keystores to lower security? (No/yes) " yn
+  case "${yn}" in
+    [Yy][Ee][Ss]) echo; break;;
+    *) echo "Aborting, no changes made"; exit 0;;
+  esac
+done
+
+mkdir -p -m 700 "${base_dir}"/keys-backup."${ts}"
+cp -rp "${base_dir}"/keys/* "${base_dir}"/keys-backup."${ts}"/
+
+for file in "${base_dir}"/keys-backup."${ts}"/*.password; do
+  [ -e "$file" ] || continue
+  cp -- "$file" "${file%.password}.txt"
+done
+
+/opt/converter/bin/converter --src="${base_dir}"/keys-backup."${ts}" --password-src="${base_dir}"/keys-backup."${ts}" --dest="${base_dir}"/converted-keys
+cp "${base_dir}"/converted-keys/*.json "${base_dir}"/keys/
+
+echo
+echo "Original keys have been backed up to keys-backup.${ts}, inside the \"web3signer-keys\" Docker volume"
+echo "Converted keys have been copied to the Web3signer key store"
+echo "Restart web3signer to use the converted keys"

--- a/web3signer/convert-keys.sh
+++ b/web3signer/convert-keys.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ts=$(date +%s)
+base_dir=/var/lib/web3signer
+mkdir -p "${base_dir}"/converted-keys
+
+if ! find "${base_dir}"/keys -type f -name '*.password' -print -quit | grep -q .; then
+  echo "No key files found in ${base_dir}/keys. Aborting."
+  exit 0
+fi
+
+if [[ "${NETWORK}" =~ ^(mainnet|gnosis)$ ]]; then
+  echo "Reducing key security on ${NETWORK} is not recommended. If you need to do so, please do so manually."
+  echo "Aborting"
+  exit 0
+fi
+
+if find "${base_dir}"/converted-keys -type f -name '*.json' -print -quit | grep -q .; then
+  while true; do
+    echo "Keys have previously been converted."
+    read -rp "Do you want to run conversion again, maybe because you added keys? (N/y) " yn
+    case "${yn}" in
+      [Yy]) echo; break;;
+      *) echo "Aborting, no changes made"; exit 0;;
+    esac
+  done
+fi
+
+while true; do
+  echo "WARNING: This function will reduce the security of validator keys loaded into Web3signer."
+  echo "Web3signer startup time for thousands of keys will reduce to seconds."
+  echo "Conversion can take 30 minutes for 15,000 keys. Running in screen or tmux is recommended."
+  read -rp "Are you sure you want to convert keystores to lower security? (No/yes) " yn
+  case "${yn}" in
+    [Yy][Ee][Ss]) echo; break;;
+    *) echo "Aborting, no changes made"; exit 0;;
+  esac
+done
+
+mkdir -p "${base_dir}"/keys-backup."${ts}"
+cp -p "${base_dir}"/keys/* "${base_dir}"/keys-backup."${ts}"/
+
+for file in "${base_dir}"/keys-backup."${ts}"/*.password; do
+  [ -e "$file" ] || continue
+  cp -- "$file" "${file%.password}.txt"
+done
+
+/opt/converter/bin/converter --src="${base_dir}"/keys-backup."${ts}" --password-src="${base_dir}"/keys-backup."${ts}" --dest="${base_dir}"/converted-keys
+cp "${base_dir}"/converted-keys/*.json "${base_dir}"/keys/
+
+echo
+echo "Original keys have been backed up to keys-backup.${ts}, inside the \"web3signer-keys\" Docker volume"
+echo "Converted keys have been copied to the Web3signer key store"
+echo "Restart web3signer to use the converted keys"


### PR DESCRIPTION
**What I did**

Add a command to reduce the security of validator key files in Web3signer, to load in seconds, not 30 minutes.

This comes in handy when running genesis validator keys on  Hoodi. I've done it manually one too many times, and wanted a command.

Uses https://github.com/usmansaleem/v4keystore_converter

Will refuse to run on `mainnet` or `gnosis`
