### PR TITLE
Switch Besu build to Java 25

### DIFF
--- a/besu/Dockerfile.source
+++ b/besu/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Besu in a stock Ubuntu container
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # This is here to avoid build-time complaints
 ARG DOCKER_TAG


### PR DESCRIPTION
**What I did**

Besu can now build on Java 25, and a future version will require it. Make the switch now
