### PR TITLE
Teku entrypoint doesn't stall

### DIFF
--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -196,8 +196,8 @@ if [[ "${IPV6}" = "true" ]]; then
   ipv4_pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
   ipv6_pattern="^[0-9A-Fa-f]{1,4}:"  # Sufficient to check the start
   set +e
-  public_v4=$(curl -s -4 ifconfig.me)
-  public_v6=$(curl -s -6 ifconfig.me)
+  public_v4=$(curl -s -m5 -4 ifconfig.me)
+  public_v6=$(curl -s -m5 -6 ifconfig.me)
   set -e
   valid_v4=0
   if [[ "${public_v4}" =~ ${ipv4_pattern} ]]; then

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -203,7 +203,7 @@ if [[ "${IPV6}" = "true" ]]; then
   if [[ "${public_v4}" =~ ${ipv4_pattern} ]]; then
     valid_v4=1
   fi
-  if [[ "a{$public_v6}" =~ ${ipv6_pattern} ]]; then
+  if [[ "${public_v6}" =~ ${ipv6_pattern} ]]; then
     if [[ "${valid_v4}" -eq 1 ]]; then
       __ipv6+=" --p2p-advertised-ips ${public_v4},${public_v6}"
     else


### PR DESCRIPTION
**What I did**

The Teku entrypoint can "stall" when `IPV6=true` but the curl for v6 connectivity can't connect. Add a 5-second timeout to make this faster.