### PR TITLE
Fix __owner_group for non-setgid setups

### DIFF
--- a/ethd
+++ b/ethd
@@ -6061,8 +6061,14 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Use this to make sure root doesn't end up owning files
 # shellcheck disable=SC2012
 __owner=$(ls -ld . | awk '{print $3}')
-# shellcheck disable=SC2012
-__owner_group=$(ls -ld . | awk '{print $4}')
+if [[ -g . ]]; then
+  # setgid: new files inherit directory group
+  # shellcheck disable=SC2012
+  __owner_group=$(ls -ld . | awk '{print $4}')
+else
+  # no setgid: new files inherit owner's primary group
+  __owner_group=$(id -gn "${__owner}")
+fi
 
 if [[ "${__owner}" = "root" ]]; then
   echo "Please install ${__project_name} as a non-root user."

--- a/ethd
+++ b/ethd
@@ -6060,11 +6060,11 @@ fi
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Use this to make sure root doesn't end up owning files
 # shellcheck disable=SC2012
-__owner=$(ls -ld . | awk '{print $3}')
+__dir_listing=$(ls -ld .)
+__owner=$(awk '{print $3}' <<< "${__dir_listing}")
 if [[ -g . ]]; then
   # setgid: new files inherit directory group
-  # shellcheck disable=SC2012
-  __owner_group=$(ls -ld . | awk '{print $4}')
+  __owner_group=$(awk '{print $4}' <<< "${__dir_listing}")
 else
   # no setgid: new files inherit owner's primary group
   __owner_group=$(id -gn "${__owner}")


### PR DESCRIPTION
## Summary

- Fix regression from commit 7c07d3a (PR #2545) where `__owner_group` always uses the directory's group, causing spurious "Fixing ownership" messages on every start when the directory group differs from the owner's primary group
- Check the setgid bit on the directory: use directory group when set (multi-admin setup), owner's primary group otherwise (standard single-user setup)

## Test plan

- [ ] On a system **without** setgid on the eth-docker dir (the common case): verify `__owner_group` equals the owner's primary group and no spurious "Fixing ownership" messages appear
- [ ] On a system **with** setgid (app-user setup from PR #2545): verify `__owner_group` equals the directory's group, preserving multi-admin behavior

Fixes #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)