### PR TITLE
Update to latest tagged release instead of tracking main

### DIFF
--- a/ethd
+++ b/ethd
@@ -2149,11 +2149,14 @@ update() {
     __get_value_from_env "${var}" "${__env_file}" "__value"
     if [[ -z "${__value}" || "${__value}" = "latest" ]]; then
       export ETHDPINNED=""
-      branch=$(git rev-parse --abbrev-ref HEAD)
-      if [[ "${branch}" =~ ^tag-* ]]; then
-        git checkout main
+      ${__as_owner} git fetch origin --tags
+      __value=$(git tag --sort=-v:refname | head -1)
+      if [[ -z "${__value}" ]]; then
+        echo "No tags found, falling back to main branch"
+        ${__as_owner} git pull origin main
+      else
+        ${__as_owner} git checkout -B "tag-${__value}" "tags/${__value}"
       fi
-      ${__as_owner} git pull origin main
     else
       export ETHDPINNED="${__value}"
       ${__as_owner} git fetch --tags

--- a/ethd
+++ b/ethd
@@ -2150,9 +2150,10 @@ update() {
     if [[ -z "${__value}" || "${__value}" = "latest" ]]; then
       export ETHDPINNED=""
       ${__as_owner} git fetch origin --tags
-      __value=$(git tag --sort=-v:refname | head -1)
+      __value=$(${__as_owner} git tag --sort=-v:refname | head -1)
       if [[ -z "${__value}" ]]; then
         echo "No tags found, falling back to main branch"
+        ${__as_owner} git checkout main || ${__as_owner} git checkout -B main origin/main
         ${__as_owner} git pull origin main
       else
         ${__as_owner} git checkout -B "tag-${__value}" "tags/${__value}"


### PR DESCRIPTION
## Summary

- Default updates (`ETH_DOCKER_TAG` empty or `latest`) now fetch tags and check out the most recent release instead of `git pull origin main`
- Pinned updates (`ETH_DOCKER_TAG` set to a specific version) are unchanged
- Falls back to pulling `main` if no tags exist

## Motivation

Production staking systems benefit from running tested, tagged releases rather than tracking `main`. Currently, `ethd update` pulls whatever is on `main` at the time, which may include untested or in-progress changes. By defaulting to the latest tagged release, operators get stable versions that have been explicitly cut as releases.

The existing `ETH_DOCKER_TAG` pinning mechanism already uses this exact pattern (fetch tags, checkout on a local `tag-*` branch) — this change simply applies it to the default path as well, automatically selecting the latest tag via `git tag --sort=-v:refname`.

## Test plan

- [ ] `ethd update` with `ETH_DOCKER_TAG=` (default): should fetch tags and check out the latest one (currently `v26.4.1`)
- [ ] `ethd update` with `ETH_DOCKER_TAG=v26.3.0`: should still pin to that specific tag (unchanged behavior)
- [ ] Edge case: repo with no tags falls back to `git pull origin main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)