### PR TITLE
Provisioned alerts don't fire on No Data

### DIFF
--- a/grafana/default-alerts/cpu.yml
+++ b/grafana/default-alerts/cpu.yml
@@ -81,11 +81,12 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        noDataState: NoData
-        execErrState: Error
+        noDataState: OK
+        execErrState: OK
         for: 10m
         annotations:
           summary: CPU usage high, above 90%
         labels:
           severity: medium
+          origin: provisioned
         isPaused: false

--- a/grafana/default-alerts/crit_disk_space.yml
+++ b/grafana/default-alerts/crit_disk_space.yml
@@ -79,11 +79,12 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        noDataState: NoData
-        execErrState: Error
+        noDataState: OK
+        execErrState: OK
         for: 10m
         annotations:
           summary: Disk space critically low on {{ $labels.mountpoint }}, {{ $values.B }} percent free
         labels:
           severity: critical
+          origin: provisioned
         isPaused: false

--- a/grafana/default-alerts/disk_space.yml
+++ b/grafana/default-alerts/disk_space.yml
@@ -79,11 +79,12 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        noDataState: NoData
-        execErrState: Error
+        noDataState: OK
+        execErrState: OK
         for: 10m
         annotations:
           summary: Disk space low on {{ $labels.mountpoint }}, {{ $values.B }} percent free
         labels:
           severity: medium
+          origin: provisioned
         isPaused: false

--- a/grafana/default-alerts/memory.yml
+++ b/grafana/default-alerts/memory.yml
@@ -82,11 +82,12 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        noDataState: NoData
-        execErrState: Error
+        noDataState: OK
+        execErrState: OK
         for: 5m
         annotations:
           summary: memory usage is dangerously high at {{ humanizePercentage $values.B.Value }}.
         labels:
           severity: critical
+          origin: provisioned
         isPaused: false

--- a/grafana/default-alerts/oom.yml
+++ b/grafana/default-alerts/oom.yml
@@ -89,4 +89,5 @@ groups:
           summary: A container ran out of memory and was killed by Linux
         labels:
           severity: critical
+          origin: provisioned
         isPaused: false


### PR DESCRIPTION
**What I did**

Provisioned alerts don't fire when there's an issue with node exporter or cadvisor

Add an `origin` label so they can be ignored or routed elsewhere by the user easily