### PR TITLE
Clean up node exporter configuration

### DIFF
--- a/default.env
+++ b/default.env
@@ -200,8 +200,8 @@ EE_PORT=8551
 CL_REST_PORT=5052
 # Node exporter is direct on host, make sure it doesn't conflict
 # If ufw is "in front of" Docker, make sure to allow this traffic
-# sudo ufw allow from 172.16.0.0/12 to any port 9199 comment "node-exporter from docker"
-# sudo ufw allow from 192.168.0.0/16 to any port 9199 comment "node-exporter from docker"
+# sudo ufw allow proto tcp from 172.16.0.0/12 to any port 9199 comment "node-exporter from Docker"
+# sudo ufw allow proto tcp from 192.168.0.0/16 to any port 9199 comment "node-exporter from Docker"
 NODE_EXPORTER_PORT=9199
 
 
@@ -485,7 +485,7 @@ TRAEFIK_TAG=v3.6
 DDNS_TAG=v2
 
 # Path to mount to node-exporter if needed for --collector.textfile.directory
-NODE_EXPORTER_COLLECTOR_MOUNT_PATH=/dev/null
+NODE_EXPORTER_COLLECTOR_MOUNT_PATH=
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.
 NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker.+)($|/)'
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd

--- a/default.env
+++ b/default.env
@@ -200,8 +200,8 @@ EE_PORT=8551
 CL_REST_PORT=5052
 # Node exporter is direct on host, make sure it doesn't conflict
 # If ufw is "in front of" Docker, make sure to allow this traffic
-# sudo ufw allow from 172.16.0.0/12 to any port 9199 comment "node-exporter from docker"
-# sudo ufw allow from 192.168.0.0/16 to any port 9199 comment "node-exporter from docker"
+# sudo ufw allow proto tcp from 172.16.0.0/12 to any port 9199 comment "node-exporter from Docker"
+# sudo ufw allow proto tcp from 192.168.0.0/16 to any port 9199 comment "node-exporter from Docker"
 NODE_EXPORTER_PORT=9199
 
 
@@ -492,7 +492,7 @@ TRAEFIK_TAG=v3.6
 DDNS_TAG=v2
 
 # Path to mount to node-exporter if needed for --collector.textfile.directory
-NODE_EXPORTER_COLLECTOR_MOUNT_PATH=/dev/null
+NODE_EXPORTER_COLLECTOR_MOUNT_PATH=
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.
 NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker.+)($|/)'
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd

--- a/ethd
+++ b/ethd
@@ -1798,6 +1798,11 @@ __env_migrate() {
 # shellcheck disable=SC2016
         __value='${CORE_FILES}${CUSTOM_FILES:+:${CUSTOM_FILES}}'
       fi
+      # Remove after Glamsterdam
+      if [[ "${var}" = "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" && "${__value}" = "/dev/null" ]]; then
+        __value=""
+      fi
+
       if [[ "${var}" = "CL_QUIC_PORT" ]]; then
         __get_value_from_env "CL_P2P_PORT" "${__env_file}.source" "CL_P2P_PORT"
         if [[ -n "${CL_P2P_PORT}" && "${CL_P2P_PORT}" = "${__value}" ]]; then

--- a/ethd
+++ b/ethd
@@ -1832,6 +1832,11 @@ __env_migrate() {
 # shellcheck disable=SC2016
         __value='${CORE_FILES}${CUSTOM_FILES:+:${CUSTOM_FILES}}'
       fi
+      # Remove after Glamsterdam
+      if [[ "${var}" = "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" && "${__value}" = "/dev/null" ]]; then
+        __value=""
+      fi
+
       if [[ "${var}" = "CL_QUIC_PORT" ]]; then
         __get_value_from_env "CL_P2P_PORT" "${__env_file}.source" "CL_P2P_PORT"
         if [[ -n "${CL_P2P_PORT}" && "${CL_P2P_PORT}" = "${__value}" ]]; then

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -33,26 +33,26 @@ services:
   node-exporter:
     image: prom/node-exporter:latest
     command:
-      - '--path.rootfs=/host'
-      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
+      - '--path.udev.data=/rootfs/run/udev/data'
       - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
-      - '--no-collector.ipvs'
-      - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}'
+      - '--collector.textfile.directory=/tmp/text-collector'
       - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
       - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
+      - '--no-collector.ipvs'
+      - '--no-collector.cpufreq'
     pid: host
     network_mode: host  # See all network interfaces
     restart: unless-stopped
     environment:
       - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
     volumes:
-      - /:/host:ro,rslave
-      - /etc/hostname:/etc/nodename:ro
-      - /proc:/host/proc:ro,rslave
+      - /:/rootfs:ro,rslave
       - /sys:/host/sys:ro,rslave
+      - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
     <<: *logging
     labels:
       - metrics.scrape=true

--- a/grafana.yml
+++ b/grafana.yml
@@ -66,26 +66,26 @@ services:
   node-exporter:
     image: prom/node-exporter:latest
     command:
-      - '--path.rootfs=/host'
-      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
+      - '--path.udev.data=/rootfs/run/udev/data'
       - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
-      - '--no-collector.ipvs'
-      - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}'
+      - '--collector.textfile.directory=/tmp/text-collector}'
       - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
       - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
+      - '--no-collector.ipvs'
+      - '--no-collector.cpufreq'
     pid: host
     network_mode: host  # See all network interfaces
     restart: unless-stopped
     environment:
       - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
     volumes:
-      - /:/host:ro,rslave
-      - /etc/hostname:/etc/nodename:ro
-      - /proc:/host/proc:ro,rslave
+      - /:/rootfs:ro,rslave
       - /sys:/host/sys:ro,rslave
+      - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
     <<: *logging
     labels:
       - metrics.scrape=true

--- a/grafana.yml
+++ b/grafana.yml
@@ -65,27 +65,27 @@ services:
 
   node-exporter:
     image: prom/node-exporter:latest
-    command:
-      - '--path.rootfs=/host'
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
-      - '--no-collector.ipvs'
-      - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}'
-      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
-      - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
     pid: host
     network_mode: host  # See all network interfaces
     restart: unless-stopped
     environment:
       - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
     volumes:
-      - /:/host:ro,rslave
-      - /etc/hostname:/etc/nodename:ro
-      - /proc:/host/proc:ro,rslave
+      - /:/rootfs:ro,rslave
       - /sys:/host/sys:ro,rslave
+      - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
+    command:
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--path.udev.data=/rootfs/run/udev/data'
+      - '--collector.filesystem.mount-points-exclude=${NODE_EXPORTER_IGNORE_MOUNT_REGEX}'
+      - '--collector.textfile.directory=/tmp/text-collector'
+      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
+      - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
+      - '--no-collector.ipvs'
+      - '--no-collector.cpufreq'
     <<: *logging
     labels:
       - metrics.scrape=true


### PR DESCRIPTION
**What I did**

Do not collect cpufreq, file too large

Change `/` mount to `/rootfs` to avoid mount overlap with `/host/sys`

Tell node exporter where to find udev data

Better default behavior of text collector by pointing it to a dummy directory in `/tmp`

Rely on `pid: host` for implicit `/proc`. Confirmed working
