### PR TITLE
Allow UI access to Alloy Obol

### DIFF
--- a/alloy-obol-shared.yml
+++ b/alloy-obol-shared.yml
@@ -1,0 +1,5 @@
+# Expose Alloy Obol port for UI access
+services:
+  alloy-obol:
+    ports:
+      - ${SHARE_IP:-}:${ALLOY_OBOL_PORT:-12346}:12345/tcp

--- a/default.env
+++ b/default.env
@@ -156,6 +156,8 @@ PROMETHEUS_PORT=9090
 PROMETHEUS_RETENTION_TIME=40d
 # Alloy port used when exposing directly on host; used for UI access
 ALLOY_PORT=12345
+# Alloy Obol port used when exposing directly on host; used for UI access
+ALLOY_OBOL_PORT=12346
 # Loki port used when exposing directly on host; used for receiving logs from other servers
 LOKI_PORT=3100
 # Tempo ports used when exposing directly on host; used for receiving traces


### PR DESCRIPTION
**What I did**

Create an `alloy-obol-shared.yml` and `ALLOY_OBOL_PORT`. Deliberately not bumping `.env` version, this can come in with the bump in #2568 
