### PR TITLE
Support podman

### DIFF
--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -38,7 +38,9 @@ jobs:
         uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48
       - name: Prerequisites on Ubuntu
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
-        run: sudo apt-get install -y expect whiptail
+        run: |
+          sudo apt-get install -y expect whiptail
+          sudo apt-get remove -y podman
       - name: Prerequisites on macOS
         if: ${{ startsWith(matrix.os, 'macos-') }}
         run: brew install bash newt coreutils expect gawk

--- a/anchor.yml
+++ b/anchor.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   anchor:

--- a/besu.yml
+++ b/besu.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/central-metrics.yml
+++ b/central-metrics.yml
@@ -1,11 +1,11 @@
 # For scraping with central-proxy-docker, when all you want is the metrics exporter
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   ethereum-metrics-exporter:

--- a/commit-boost-pbs.yml
+++ b/commit-boost-pbs.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   cb-pbs:

--- a/contributoor.yml
+++ b/contributoor.yml
@@ -2,11 +2,11 @@
 ## Read more: https://github.com/ethpandaops/contributoor
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   contributoor:

--- a/default.env
+++ b/default.env
@@ -289,6 +289,11 @@ ERE_URL=
 
 # If you want debug logs, set this to debug instead of info
 LOG_LEVEL=info
+# Log retention and tagging
+LOG_DRIVER=json-file
+LOG_MAX_SIZE=100m
+LOG_MAX_FILE=3
+LOG_TAG='{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
 
 # JWT secret for CL:EL connection. This is created automatically by default.
 # If specified manually here, this could be used to split CL and EL to different
@@ -572,4 +577,4 @@ DOCKER_SOCK=/var/run/docker.sock
 ALLOY_PROJECT_NAME=
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=62
+ENV_VERSION=63

--- a/erigon.yml
+++ b/erigon.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/ethd
+++ b/ethd
@@ -143,30 +143,74 @@ __handle_docker() {
   local exitstatus
   local var
   local regex
+  local message
+  local use_podman=0
+  local use_docker=0
 
   if [[ "${__distro}" =~ (debian|ubuntu) ]]; then
     set +e
-    if ! ${__docker_exe} images >/dev/null 2>&1; then
-      if [[ "${__cannot_sudo}" -eq 1 ]]; then
-        echo "Cannot call Docker and cannot use sudo. Please make your user part of the docker group"
-        exit 1
-      fi
-      echo "Will use sudo to access Docker"
-      __docker_sudo="sudo"
+    if dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed" \
+         || dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
+      use_docker=1
+    fi
+    if dpkg-query -W -f='${Status}' podman 2>/dev/null | grep -q "ok installed"; then
+      use_podman=1
     fi
 
-    if __dodocker system info --format '{{json .SecurityOptions}}' | grep -qi rootless; then
-      systemctl --user status docker >/dev/null 2>&1
-      exitstatus=$?
-      message="\"systemctl --user status docker\" and \"journalctl --user -fu docker\" will be helpful."
-    else
-      systemctl status docker >/dev/null 2>&1
-      exitstatus=$?
-      message="\"systemctl status docker\" and \"sudo journalctl -fu docker\" will be helpful."
+    # If both are installed:
+    # If DOCKER_SOCK is set to podman.sock, assume the user prefers podman
+    # If service podman.socket is running, assume the user prefers podman
+    # Otherwise, default to Docker
+    if [[ "${use_docker}" -eq 1 && "${use_podman}" -eq 1 ]]; then
+      echo "Both Docker and Podman are installed"
+      echo "Guessing at user preference by \"DOCKER_SOCK\" in \".env\" and status of service podman.socket"
+      var=DOCKER_SOCK
+      __get_value_from_env "${var}" "${__env_file}" "__value"
+      if [[ "${__value}" =~ podman.sock ]] || systemctl --user status podman.socket >/dev/null 2>&1 || systemctl status podman.socket >/dev/null 2>&1; then
+        echo "Preferring Podman"
+        echo
+        use_docker=0
+      else
+        echo "Preferring Docker"
+        echo
+        use_podman=0
+      fi
     fi
-    if [[ ! "${exitstatus}" -eq 0 ]]; then
-      echo "The Docker daemon is not running. Please check Docker installation."
-      echo "${message}"
+
+    if [[ "${use_docker}" -eq 1 ]]; then
+      if ${__docker_exe} system info --format '{{json .SecurityOptions}}' | grep -qi rootless; then
+        systemctl --user status docker >/dev/null 2>&1
+        exitstatus=$?
+        message="\"systemctl --user status docker\" and \"journalctl --user -fu docker\" will be helpful."
+      else
+        systemctl status docker >/dev/null 2>&1
+        exitstatus=$?
+        message="\"systemctl status docker\" and \"sudo journalctl -fu docker\" will be helpful."
+      fi
+      if [[ ! "${exitstatus}" -eq 0 ]]; then
+        echo "The Docker daemon is not running. Please check Docker installation."
+        echo "${message}"
+        echo "Aborting."
+        exit 1
+      fi
+    elif [[ "${use_podman}" -eq 1 ]]; then
+      __docker_exe=podman
+      __compose_exe="podman compose"
+      if systemctl status podman.socket >/dev/null 2>&1; then  # User has enabled system socket, run podman with sudo.
+        __docker_sudo="sudo"
+      else
+        systemctl --user status podman.socket >/dev/null 2>&1
+        exitstatus=$?
+        if [[ ! "${exitstatus}" -eq 0 ]]; then
+          echo "The Podman socket service is not running. Please check Podman installation."
+          echo "\"systemctl --user status podman.socket\" and \"journalctl --user -fu podman.socket\" will be helpful."
+          echo "Aborting."
+          exit 1
+        fi
+      fi
+    else
+      echo "Neither docker-ce, docker.io nor podman appear to be installed."
+      echo "One of those is required to run ${__project_name}."
       echo "Aborting."
       exit 1
     fi
@@ -177,14 +221,24 @@ __handle_docker() {
       echo "The docker daemon is running. A non-packaged install is highly unusual and hard to maintain."
       echo "Please switch to docker-ce installed via the official Docker repo."
     fi
-  else
-    if ! ${__docker_exe} images >/dev/null 2>&1; then
-      if [[ "${__cannot_sudo}" -eq 1 ]]; then
-        echo "Cannot call Docker and cannot use sudo. Please make your user part of the docker group"
-        exit 1
+    if [[ -f "${__env_file}" ]]; then
+      if [[ "${use_docker}" -eq 1 ]]; then
+        LOG_DRIVER="json-file"
+        LOG_TAG="'{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'"
+      else
+        LOG_DRIVER="journald"
+        LOG_TAG="'{{.ImageName}}|{{.Name}}|{{.ID}}'"
       fi
-      echo "Will use sudo to access Docker"
-      __docker_sudo="sudo"
+      var=LOG_DRIVER
+      __get_value_from_env "${var}" "${__env_file}" "__value"
+      if [[ "${__value}" =~ ^(json-file|journald)$ ]]; then  # Leave user overrides alone
+        __update_value_in_env "${var}" "${!var}" "${__env_file}"
+      fi
+      var=LOG_TAG
+      __get_value_from_env "${var}" "${__env_file}" "__value"
+      if [[ "${__value}" =~ ^('{{\.ImageName}}\|{{\.Name}}\|{{\.ImageFullID}}\|{{\.FullID}}'|'{{\.ImageName}}\|{{\.Name}}\|{{\.ID}}')$ ]]; then  # Leave user overrides alone
+        __update_value_in_env "${var}" "${!var}" "${__env_file}"
+      fi
     fi
   fi
 
@@ -193,7 +247,7 @@ __handle_docker() {
   __docker_minor_version=$(echo "${__docker_version}" | awk '{ split($1, version, "."); print version[2]; }')
   __docker_patch_version=$(echo "${__docker_version}" | awk '{ split($1, version, "."); print version[3]; }')
 
-  if [[ "${__docker_major_version}" -lt 23 ]]; then
+  if [[ "${use_docker}" -eq 1 && "${__docker_major_version}" -lt 23 ]]; then
   # Debian 11 and Debian 12 have docker.io 20.10. From Debian 13, it's >= 26
   # Ubuntu has docker.io>= 27 from 22.04
   # The code to detect old docker.io can be removed when Debian 12 goes EOL in 2028
@@ -208,8 +262,24 @@ __handle_docker() {
     __oldish_docker=1
   fi
 
+  if ! ${__docker_sudo} ${__docker_exe} images >/dev/null 2>&1; then
+    if [[ "${__cannot_sudo}" -eq 1 ]]; then
+      echo "Cannot call ${__docker_exe} and cannot use sudo"
+      if [[ "${__distro}" =~ (debian|ubuntu) && "${__docker_exe}" = "docker" ]]; then
+        echo "Please make your user part of the docker group"
+      fi
+      exit 1
+    fi
+    echo "Will use sudo to access ${__docker_exe}"
+    __docker_sudo="sudo"
+  fi
+
   if [[ -f "${__env_file}" && "${__distro}" =~ (debian|ubuntu) ]]; then
-    DOCKER_ROOT=$(__dodocker system info --format '{{.DockerRootDir}}')
+    if [[ "${__docker_exe}" = "podman" ]]; then
+      DOCKER_ROOT=$(__dodocker system info --format '{{.Store.GraphRoot}}')
+    else
+      DOCKER_ROOT=$(__dodocker system info --format '{{.DockerRootDir}}')
+    fi
     var=DOCKER_ROOT
     __get_value_from_env "${var}" "${__env_file}" "__value"
     if [[ "${DOCKER_ROOT}" != "${__value}" ]]; then
@@ -217,14 +287,22 @@ __handle_docker() {
     fi
 
     # on macOS, user would set this manually to Colima or Docker Desktop value
-    if __dodocker system info --format '{{.SecurityOptions}}' | grep -qi rootless; then
-      DOCKER_SOCK=/run/user/$(id -u)/docker.sock
-      if [[ "${__distro}" =~ (debian|ubuntu) && "${__docker_exe}" = "docker" && ( "${__docker_major_version}" -lt 29 \
-            || ( "${__docker_major_version}" -eq 29 && "${__docker_minor_version}" -lt 5 ) ) ]]; then
-        __old_rootless_docker=1
+    if [[ "${__docker_exe}" = "podman" ]]; then
+      if [[ "$(__dodocker system info --format '{{.Host.Security.Rootless}}')" = "true" ]]; then
+        DOCKER_SOCK=/run/user/$(id -u)/podman/podman.sock
+      else
+        DOCKER_SOCK=/run/podman/podman.sock
       fi
     else
-      DOCKER_SOCK=/var/run/docker.sock
+      if __dodocker system info --format '{{.SecurityOptions}}' | grep -qi rootless; then
+        DOCKER_SOCK=/run/user/$(id -u)/docker.sock
+        if [[ "${__docker_major_version}" -lt 29 \
+              || ( "${__docker_major_version}" -eq 29 && "${__docker_minor_version}" -lt 5 ) ]]; then
+          __old_rootless_docker=1
+        fi
+      else
+        DOCKER_SOCK=/var/run/docker.sock
+      fi
     fi
     var=DOCKER_SOCK
     __get_value_from_env "${var}" "${__env_file}" "__value"
@@ -569,8 +647,8 @@ __check_compose_version() {
 # Compose V1 is in Ubuntu 22.04 and 24.04. The Compose version check can be removed when Ubuntu 24.04 goes EOL in 2029.
 
 # Check for Compose V2+ (docker compose) vs Compose V1 (docker-compose)
-  if __dodocker compose version >/dev/null 2>&1; then
-    __compose_version=$(__dodocker compose version | sed -n -E -e "s/.*version [v]?([0-9.-]*).*/\1/ip")
+  if ${__docker_sudo} ${__docker_exe} compose version >/dev/null 2>&1; then
+    __compose_version=$(${__docker_sudo} ${__docker_exe} compose version | sed -n -E -e "s/.*version [v]?([0-9.-]*).*/\1/ip")
     __compose_major=${__compose_version%%.*}
     __compose_minor=${__compose_version#*.}
     __compose_minor=${__compose_minor%%.*}
@@ -909,7 +987,11 @@ __optimize_host() {
   local memtotal
 
   echo
-  docker_root=$(__dodocker system info --format '{{.DockerRootDir}}')
+  if dpkg-query -W -f='${Status}' podman 2>/dev/null | grep -q "ok installed"; then
+    docker_root=$(__dodocker system info --format '{{.Store.GraphRoot}}')
+  else
+    docker_root=$(__dodocker system info --format '{{.DockerRootDir}}')
+  fi
   if command -v findmnt >/dev/null; then
     docker_mount=$(findmnt -T "${docker_root}" -o TARGET -n)
     docker_mount_opts=$(findmnt -T "${docker_root}" -o OPTIONS -n 2>/dev/null)
@@ -998,6 +1080,11 @@ __install_docker() {
     echo "__install_docker() was called on ${__distro}, which is neither Debian nor Ubuntu."
     echo "This is a bug."
     exit 70
+  fi
+
+  if dpkg-query -W -f='${Status}' podman 2>/dev/null | grep -q "ok installed"; then
+    echo "Found podman. Will not install Docker, as it would conflict."
+    return
   fi
 
   if [[ -z "$(command -v docker)" ]]; then
@@ -1115,8 +1202,12 @@ __get_docker_free_space() {
   if [[ "$OSTYPE" = "darwin"* ]]; then  # macOS doesn't expose docker root dir to the OS
     __free_space=$(__dodocker run --rm -v macos-space-check:/dummy busybox df -P /dummy | awk '/[0-9]%/{print $(NF-2)}')
   else
-    __docker_dir=$(__dodocker system info --format '{{.DockerRootDir}}')
-    __free_space=$(df -P "${__docker_dir}" | awk '/[0-9]%/{print $(NF-2)}')
+    if [[ "${__docker_exe}" = "podman" ]]; then
+      __docker_dir=$(__dodocker system info --format '{{.Store.GraphRoot}}')
+    else
+      __docker_dir=$(__dodocker system info --format '{{.DockerRootDir}}')
+    fi
+    __free_space=$(${__docker_sudo} df -P "${__docker_dir}" | awk '/[0-9]%/{print $(NF-2)}')  # Allow for rootful podman
   fi
 
   regex='^[0-9]+$'
@@ -1125,7 +1216,7 @@ __get_docker_free_space() {
     if [[ "$OSTYPE" = "darwin"* ]]; then
       echo "df reports $(__dodocker run --rm -v macos-space-check:/dummy busybox df -P /dummy) and __free_space is ${__free_space}"
     else
-      echo "df reports $(df -P "${__docker_dir}") and __free_space is ${__free_space}"
+      echo "df reports $(${__docker_sudo} df -P "${__docker_dir}") and __free_space is ${__free_space}"  # Allow for rootful podman
     fi
     exit 70
   fi
@@ -1138,7 +1229,7 @@ __display_docker_dir() {
     __dodocker run --rm -v macos-space-check:/dummy busybox df -h /dummy
   else
     echo "Here's total and used space on ${__docker_dir}"
-    df -h "${__docker_dir}"
+    ${__docker_sudo} df -h "${__docker_dir}"  # Allow for rootful podman
   fi
 }
 
@@ -5016,8 +5107,8 @@ __query_web3signer() {
 
 __query_grafana() {
   if whiptail --title "Grafana" --yesno "Do you want to use Grafana dashboards?" 10 65; then
-      if [[ "$OSTYPE" = "darwin"* ]] || __dodocker system info --format '{{json .SecurityOptions}}' | grep -qi rootless; then
-      # macOS doesn't do well with / bind mount - leave node-exporter and cadvisor off by default. Also detect rootless Docker
+      if [[ "$OSTYPE" = "darwin"* ]] || { [[ "${__docker_exe}" = "podman" ]] && ! systemctl status podman.socket >/dev/null 2>&1 ;} || __dodocker system info --format '{{json .SecurityOptions}}' 2>/dev/null | grep -qi rootless; then
+      # macOS doesn't do well with / bind mount - leave node-exporter and cadvisor off by default. Also detect rootless Docker/Podman
         CORE_FILES+=":grafana-rootless.yml:grafana-shared.yml"
       else
         CORE_FILES+=":grafana.yml:grafana-shared.yml"

--- a/ethrex.yml
+++ b/ethrex.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/geth.yml
+++ b/geth.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -4,15 +4,14 @@
 #
 # This file is called grafana-cloud.yml, as adding a remote write to Grafana Cloud is a
 # common use case. It properly is a Grafana Alloy without local Grafana, or a local metrics/log store
-
-
+#
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   ethereum-metrics-exporter:

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -1,13 +1,14 @@
 # Grafana for use with rootless docker
 # Omits node-exporter and cadvisor. If you want them, run them on the host, then scrape
 # them with custom config in ./alloy/
+#
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   prometheus:

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,14 +1,14 @@
 # Use ./alloy/write-loki.yml and ./alloy/write-prometheus.yml to control
 # where logs and metrics are being sent
 # ./alloy can have additional configuration files such as custom scrape targets
-
+#
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   # Adjust permissions. Can be removed after Glamsterdam

--- a/grafana/provision.sh
+++ b/grafana/provision.sh
@@ -410,6 +410,7 @@ if [[ "${status}" -eq 0 ]]; then
   wget -t 3 -T 10 -qcO - "${url}" | jq 'walk(if . == "${DS_LOKI}" then "Loki" else . end)' >"${tmp}" || status=1
 fi
 handle_replacement "${status}" "${tmp}" "${file}"
+
 # Home staking dashboard
 id=17846
 status=0
@@ -421,6 +422,7 @@ if [[ "${status}" -eq 0 ]]; then
   wget -t 3 -T 10 -qcO - "${url}" | jq 'walk(if . == "${DS_PROMETHEUS}" then "Prometheus" else . end)' >"${tmp}" || status=1
 fi
 handle_replacement "${status}" "${tmp}" "${file}"
+
 # Ethereum Metrics Exporter Dashboard
 id=16277
 status=0

--- a/grandine-allin1.yml
+++ b/grandine-allin1.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 
 x-build: &gr-build

--- a/grandine-cl-only.yml
+++ b/grandine-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 
 x-build: &gr-build

--- a/lido-obol-alloy.yml
+++ b/lido-obol-alloy.yml
@@ -1,3 +1,11 @@
+x-logging: &logging
+  logging:
+    driver: ${LOG_DRIVER}
+    options:
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
+
 services:
   alloy-obol:
     image: grafana/alloy:latest
@@ -11,6 +19,7 @@ services:
       - ./alloy-obol:/etc/alloy
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - alloy-obol-data:/var/lib/alloy
+    <<: *logging
     entrypoint: /etc/alloy/docker-entrypoint.sh
     command:
       - alloy

--- a/lido-obol.yml
+++ b/lido-obol.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   charon:
@@ -12,7 +12,6 @@ services:
     image: obolnetwork/charon:${CHARON_TAG:-latest}
     volumes:
       - .eth:/opt/charon/.charon
-    <<: *logging
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${OBOL_CHARON_CL_ENDPOINTS:-http://consensus:5052}
       - CHARON_LOG_LEVEL=${OBOL_LOG_LEVEL:-debug}
@@ -31,6 +30,7 @@ services:
       - ${OBOL_P2P_PORT:-3610}:${OBOL_P2P_PORT:-3610}/tcp  # P2P TCP libp2p
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
+    <<: *logging
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &lh-build
   context: ./lighthouse

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &lh-build
   context: ./lighthouse

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -1,11 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
-
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &lh-build
   context: ./lighthouse

--- a/lodestar-cl-only.yml
+++ b/lodestar-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &ls-build
   context: ./lodestar

--- a/lodestar-vc-only.yml
+++ b/lodestar-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &ls-build
   context: ./lodestar

--- a/lodestar.yml
+++ b/lodestar.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &ls-build
   context: ./lodestar

--- a/mev-boost.yml
+++ b/mev-boost.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   mev-boost:

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -1,11 +1,11 @@
 # Nimbus consensus also handles validator keys: All In One
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &nimbus-build
   context: ./nimbus

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &nimbus-build
   context: ./nimbus

--- a/nimbus-el.yml
+++ b/nimbus-el.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/nimbus-stats.yml
+++ b/nimbus-stats.yml
@@ -1,10 +1,20 @@
 # Send client stats to beaconcha.in service using client-metrics-exporter
+#
+x-logging: &logging
+  logging:
+    driver: ${LOG_DRIVER}
+    options:
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
+
 services:
   client-stats:
     restart: "unless-stopped"
     image: gobitfly/eth2-client-metrics-exporter:latest
     volumes:
       - /etc/localtime:/etc/localtime:ro
+    <<: *logging
     entrypoint:
       - /bin/eth2-client-metrics-exporter
       - --beaconnode.type

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &nimbus-build
   context: ./nimbus

--- a/nimbus-vp.yml
+++ b/nimbus-vp.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   rpc-proxy:

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &nimbus-build
   context: ./nimbus

--- a/prysm-cl-only.yml
+++ b/prysm-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &prysm-build
   context: ./prysm

--- a/prysm-stats.yml
+++ b/prysm-stats.yml
@@ -1,10 +1,20 @@
 # Send client stats to beaconcha.in service using client-metrics-exporter
+#
+x-logging: &logging
+  logging:
+    driver: ${LOG_DRIVER}
+    options:
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
+
 services:
   client-stats:
     restart: "unless-stopped"
     image: gobitfly/eth2-client-metrics-exporter:latest
     volumes:
       - /etc/localtime:/etc/localtime:ro
+    <<: *logging
     entrypoint:
       - /bin/eth2-client-metrics-exporter
       - --beaconnode.type

--- a/prysm-vc-only.yml
+++ b/prysm-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &prysm-build
   context: ./prysm

--- a/prysm.yml
+++ b/prysm.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &prysm-build
   context: ./prysm

--- a/reth.yml
+++ b/reth.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   execution:

--- a/siren.yml
+++ b/siren.yml
@@ -1,11 +1,11 @@
 # Sigma Prime Siren, for use with Lighthouse
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   siren:

--- a/ssv-dkg.yml
+++ b/ssv-dkg.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   curl-jq:

--- a/ssv-pulse.yml
+++ b/ssv-pulse.yml
@@ -1,16 +1,17 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   ssv-pulse:
     image: ghcr.io/ssvlabs/ssv-pulse:latest
     pull_policy: always
     restart: no
+    <<: *logging
     command:
       - 'benchmark'
       - '--consensus-addr=${CL_NODE}'

--- a/ssv.yml
+++ b/ssv.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   ssv-node:
@@ -18,7 +18,6 @@ services:
     ports:
       - ${HOST_IP:-}:${SSV_P2P_PORT}:${SSV_P2P_PORT}/tcp
       - ${HOST_IP:-}:${SSV_P2P_PORT_UDP}:${SSV_P2P_PORT_UDP}/udp
-    <<: *logging
     environment:
       - CONFIG_PATH=/config/config.yaml
       - HOME=/tmp
@@ -28,6 +27,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
       - OTEL_EXPORTER_OTLP_INSECURE=true
       - OTEL_SERVICE_NAME=ssv-node
+    <<: *logging
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -1,11 +1,11 @@
 # Teku consensus also handles validator keys: All In One
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &teku-build
   context: ./teku

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &teku-build
   context: ./teku

--- a/teku-vc-only.yml
+++ b/teku-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &teku-build
   context: ./teku

--- a/teku.yml
+++ b/teku.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &teku-build
   context: ./teku

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   traefik:

--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   traefik:

--- a/vero-vc-only.yml
+++ b/vero-vc-only.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 x-build: &vero-build
   context: ./vero

--- a/web3signer.yml
+++ b/web3signer.yml
@@ -1,10 +1,10 @@
 x-logging: &logging
   logging:
-    driver: json-file
+    driver: ${LOG_DRIVER}
     options:
-      max-size: 100m
-      max-file: "3"
-      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+      max-size: ${LOG_MAX_SIZE}
+      max-file: ${LOG_MAX_FILE}
+      tag: ${LOG_TAG}
 
 services:
   w3s-init:


### PR DESCRIPTION
**What I did**

Add logic that detects podman and sets `.env` variables accordingly. A user with both docker and podman installed would be using podman, if the podman socket is available, and Docker otherwise.

Logging in compose files uses `.env` vars, so that Podman has a log tag of `'{{.ImageName}}|{{.Name}}|{{.ID}}'` and the `journald` driver, Ubuntu and Debian only. Defaults remain unchanged. `ethd` sets `LOG_DRIVER` and `LOG_TAG` to Docker or Podman values, unless it detects that there are user-defined values in place.

Add logging options to a few files that should have had them.
