### PR TITLE
Do not mount $DOCKER_ROOT/containers into Alloy

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,5 +1,5 @@
 // This file is not meant to be edited
-// Create your own config.d/<something.alloy> file instead for additional config
+// Create your own ./<something.alloy> file instead for additional config
 
 // Discover docker containers to collect logs and metrics from
 discovery.docker "docker_containers" {

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -1,6 +1,6 @@
 # Use ./alloy/write-loki.yml and ./alloy/write-prometheus.yml to control
 # where logs and metrics are being sent
-# ./alloy/config.d can have additional configuration files such as custom scrape targets
+# ./alloy can have additional configuration files such as custom scrape targets
 #
 # This file is called grafana-cloud.yml, as adding a remote write to Grafana Cloud is a
 # common use case. It properly is a Grafana Alloy without local Grafana, or a local metrics/log store
@@ -125,7 +125,6 @@ services:
       - ./alloy:/etc/alloy
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:ro
-      - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
     extra_hosts:  # So we can scrape targets on the host
       - "host.docker.internal:host-gateway"
     entrypoint:

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -1,6 +1,6 @@
 # Grafana for use with rootless docker
 # Omits node-exporter and cadvisor. If you want them, run them on the host, then scrape
-# them with custom config in ./alloy/config.d
+# them with custom config in ./alloy/
 x-logging: &logging
   logging:
     driver: json-file
@@ -100,7 +100,6 @@ services:
       - ./alloy:/etc/alloy
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKER_SOCK:-${XDG_RUNTIME_DIR%/}/docker.sock}:/var/run/docker.sock:ro
-      - ${DOCKER_ROOT:-${HOME}/.local/share/docker}/containers:/var/lib/docker/containers:ro
     extra_hosts:  # So we can scrape targets on the host
       - "host.docker.internal:host-gateway"
     entrypoint:

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,6 +1,6 @@
 # Use ./alloy/write-loki.yml and ./alloy/write-prometheus.yml to control
 # where logs and metrics are being sent
-# ./alloy/config.d can have additional configuration files such as custom scrape targets
+# ./alloy can have additional configuration files such as custom scrape targets
 
 x-logging: &logging
   logging:
@@ -156,7 +156,6 @@ services:
       - ./alloy:/etc/alloy
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:ro
-      - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
     extra_hosts:  # So we can scrape targets on the host
       - "host.docker.internal:host-gateway"
     entrypoint:

--- a/lido-obol-alloy.yml
+++ b/lido-obol-alloy.yml
@@ -10,7 +10,6 @@ services:
     volumes:
       - ./alloy-obol:/etc/alloy
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
       - alloy-obol-data:/var/lib/alloy
     entrypoint: /etc/alloy/docker-entrypoint.sh
     command:


### PR DESCRIPTION
**What I did**

Alloy reads logs directly from the docker socket, there is no need to mount the containers dir in
