### PR TITLE
Add a test of ethd version to CI

### DIFF
--- a/.github/actions/test_client_stack/action.yml
+++ b/.github/actions/test_client_stack/action.yml
@@ -33,3 +33,6 @@ runs:
       if: ${{ inputs.test_el == 'true' }}
       run: ./.github/check-service.sh execution
       shell: bash
+    - name: Test version
+      run: ./ethd version
+      shell: bash

--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         client:
           - env: |-
-              COMPOSE_FILE=deposit-cli.yml
+              CORE_FILES=deposit-cli.yml
               DEPCLI_DOCKERFILE=Dockerfile.source
             test_cl: false
             test_el: false
@@ -29,143 +29,141 @@ jobs:
             test_el: false
             test_vc: false
           - env: |-
-              COMPOSE_FILE=nimbus-vp.yml
+              CORE_FILES=nimbus-vp.yml
               NIMVP_DOCKERFILE=Dockerfile.source
             test_cl: false
             test_el: false
             test_vc: false
           - env: |-
-              COMPOSE_FILE=prysm.yml:geth.yml:mev-boost.yml
+              CORE_FILES=prysm.yml:geth.yml:mev-boost.yml
               MEV_DOCKERFILE=Dockerfile.source
-              CL_NODE=consensus:4000
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=teku.yml:besu.yml
+              CORE_FILES=teku.yml:besu.yml
               BESU_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=lodestar.yml:erigon.yml
+              CORE_FILES=lodestar.yml:erigon.yml
               ERIGON_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=caplin.yml:erigon.yml:lighthouse-vc-only.yml
+              CORE_FILES=caplin.yml:erigon.yml:lighthouse-vc-only.yml
               ERIGON_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: false
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=lighthouse.yml:ethrex.yml
+              CORE_FILES=lighthouse.yml:ethrex.yml
               ETHREX_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=nimbus.yml:nethermind.yml
+              CORE_FILES=nimbus.yml:nethermind.yml
               NM_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=nimbus.yml:nimbus-el.yml
+              CORE_FILES=nimbus.yml:nimbus-el.yml
               NIMEL_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=prysm.yml:geth.yml
+              CORE_FILES=prysm.yml:geth.yml
               GETH_DOCKERFILE=Dockerfile.source
-              CL_NODE=consensus:4000
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=lighthouse.yml:reth.yml
+              CORE_FILES=lighthouse.yml:reth.yml
               RETH_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=grandine-allin1.yml:reth.yml
+              CORE_FILES=grandine-allin1.yml:reth.yml
               GRANDINE_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: false
           - env: |-
-              COMPOSE_FILE=grandine-cl-only.yml:lighthouse-vc-only.yml:reth.yml
+              CORE_FILES=grandine-cl-only.yml:lighthouse-vc-only.yml:reth.yml
               GRANDINE_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=lighthouse.yml:reth.yml
+              CORE_FILES=lighthouse.yml:reth.yml
               LH_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=lighthouse-cl-only.yml:lighthouse-vc-only.yml:reth.yml
+              CORE_FILES=lighthouse-cl-only.yml:lighthouse-vc-only.yml:reth.yml
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=lodestar.yml:erigon.yml
+              CORE_FILES=lodestar.yml:erigon.yml
               LS_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=lodestar-cl-only.yml:lodestar-vc-only.yml:erigon.yml
+              CORE_FILES=lodestar-cl-only.yml:lodestar-vc-only.yml:erigon.yml
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=nimbus.yml:nethermind.yml
+              CORE_FILES=nimbus.yml:nethermind.yml
               NIM_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
+              CORE_FILES=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=nimbus.yml:nethermind.yml
+              CORE_FILES=nimbus.yml:nethermind.yml
               NIM_DOCKERFILE=Dockerfile.sourcegnosis
               NETWORK=gnosis
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
+              CORE_FILES=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=prysm.yml:geth.yml
+              CORE_FILES=prysm.yml:geth.yml
               PRYSM_DOCKERFILE=Dockerfile.source
-              CL_NODE=consensus:4000
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=prysm-cl-only.yml:prysm-vc-only.yml:geth.yml
+              CORE_FILES=prysm-cl-only.yml:prysm-vc-only.yml:geth.yml
             test_cl: true
             test_el: true
             test_vc: true
           - env: |-
-              COMPOSE_FILE=teku.yml:besu.yml
+              CORE_FILES=teku.yml:besu.yml
               TEKU_DOCKERFILE=Dockerfile.source
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             vc-env: |-
-              COMPOSE_FILE=teku-cl-only.yml:teku-vc-only.yml:besu.yml
+              CL_NODE=consensus:4000
+              CORE_FILES=teku-cl-only.yml:teku-vc-only.yml:besu.yml
             test_cl: true
             test_el: true
             test_vc: true

--- a/.github/workflows/test-client-combos.yml
+++ b/.github/workflows/test-client-combos.yml
@@ -51,7 +51,7 @@ jobs:
           - label1: test-vero
             label2: na
             env: |-
-              COMPOSE_FILE=nimbus-cl-only.yml:vero-vc-only.yml:nethermind.yml:web3signer.yml
+              CORE_FILES=nimbus-cl-only.yml:vero-vc-only.yml:nethermind.yml:web3signer.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
               WEB3SIGNER=true
             test_cl: true
@@ -60,7 +60,7 @@ jobs:
           - label1: test-caplin
             label2: na
             env: |-
-              COMPOSE_FILE=caplin.yml:erigon.yml:lodestar-vc-only.yml:mev-boost.yml
+              CORE_FILES=caplin.yml:erigon.yml:lodestar-vc-only.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
               CL_NODE=http://execution:5052
               EL_EXTRAS=--torrent.download.rate 1mb
@@ -70,7 +70,7 @@ jobs:
           - label1: test-grandine
             label2: test-nimbus-el
             env: |-
-              COMPOSE_FILE=grandine-allin1.yml:nimbus-el.yml:mev-boost.yml
+              CORE_FILES=grandine-allin1.yml:nimbus-el.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -78,7 +78,7 @@ jobs:
           - label1: test-grandine
             label2: na
             env: |-
-              COMPOSE_FILE=grandine-cl-only.yml:lighthouse-vc-only.yml:nimbus-el.yml:mev-boost.yml
+              CORE_FILES=grandine-cl-only.yml:lighthouse-vc-only.yml:nimbus-el.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -86,7 +86,7 @@ jobs:
           - label1: test-grandine-plugin
             label2: na
             env: |-
-              COMPOSE_FILE=grandine-plugin.yml:lighthouse-vc-only.yml:nethermind.yml:mev-boost.yml
+              CORE_FILES=grandine-plugin.yml:lighthouse-vc-only.yml:nethermind.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
               NM_DOCKER_REPO=sifrai/grandine
               NM_DOCKER_TAG=unstable-nethermind
@@ -96,7 +96,7 @@ jobs:
           - label1: test-grandine-plugin
             label2: na
             env: |-
-              COMPOSE_FILE=grandine-plugin-allin1.yml:nethermind.yml:mev-boost.yml
+              CORE_FILES=grandine-plugin-allin1.yml:nethermind.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
               NM_DOCKER_REPO=sifrai/grandine
               NM_DOCKER_TAG=unstable-nethermind
@@ -106,7 +106,7 @@ jobs:
           - label1: test-ethrex
             label2: na
             env: |-
-              COMPOSE_FILE=lighthouse.yml:ethrex.yml:mev-boost.yml
+              CORE_FILES=lighthouse.yml:ethrex.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -114,7 +114,7 @@ jobs:
           - label1: test-lighthouse
             label2: test-reth
             env: |-
-              COMPOSE_FILE=lighthouse.yml:reth.yml:mev-boost.yml
+              CORE_FILES=lighthouse.yml:reth.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -122,7 +122,7 @@ jobs:
           - label1: test-lighthouse
             label2: na
             env: |-
-              COMPOSE_FILE=lighthouse-cl-only.yml:lighthouse-vc-only.yml:reth.yml:mev-boost.yml
+              CORE_FILES=lighthouse-cl-only.yml:lighthouse-vc-only.yml:reth.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -130,7 +130,7 @@ jobs:
           - label1: test-lodestar
             label2: test-erigon
             env: |-
-              COMPOSE_FILE=lodestar.yml:erigon.yml:mev-boost.yml
+              CORE_FILES=lodestar.yml:erigon.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -138,7 +138,7 @@ jobs:
           - label1: test-lodestar
             label2: na
             env: |-
-              COMPOSE_FILE=lodestar-cl-only.yml:lodestar-vc-only.yml:erigon.yml:mev-boost.yml
+              CORE_FILES=lodestar-cl-only.yml:lodestar-vc-only.yml:erigon.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -146,7 +146,7 @@ jobs:
           - label1: test-nimbus
             label2: test-nethermind
             env: |-
-              COMPOSE_FILE=nimbus.yml:nethermind.yml:mev-boost.yml
+              CORE_FILES=nimbus.yml:nethermind.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -154,7 +154,7 @@ jobs:
           - label1: test-nimbus
             label2: na
             env: |-
-              COMPOSE_FILE=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml:mev-boost.yml
+              CORE_FILES=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -162,8 +162,7 @@ jobs:
           - label1: test-prysm
             label2: test-geth
             env: |-
-              COMPOSE_FILE=prysm.yml:geth.yml:mev-boost.yml
-              CL_NODE=consensus:4000
+              CORE_FILES=prysm.yml:geth.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -171,7 +170,7 @@ jobs:
           - label1: test-prysm
             label2: na
             env: |-
-              COMPOSE_FILE=prysm-cl-only.yml:prysm-vc-only.yml:geth.yml:mev-boost.yml
+              CORE_FILES=prysm-cl-only.yml:prysm-vc-only.yml:geth.yml:mev-boost.yml
               CL_NODE=consensus:4000
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
@@ -180,7 +179,7 @@ jobs:
           - label1: test-teku
             label2: test-besu
             env: |-
-              COMPOSE_FILE=teku.yml:besu.yml:mev-boost.yml
+              CORE_FILES=teku.yml:besu.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true
@@ -188,7 +187,7 @@ jobs:
           - label1: test-teku
             label2: na
             env: |-
-              COMPOSE_FILE=teku-cl-only.yml:teku-vc-only.yml:besu.yml:mev-boost.yml
+              CORE_FILES=teku-cl-only.yml:teku-vc-only.yml:besu.yml:mev-boost.yml
               FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
             test_cl: true
             test_el: true

--- a/.github/workflows/test-grafana.yml
+++ b/.github/workflows/test-grafana.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Set Lighthouse/Geth/Grafana
         run: |
           source ./.github/helper.sh
-          COMPOSE_FILE=lighthouse.yml:geth.yml:grafana.yml
-          var=COMPOSE_FILE
+          CORE_FILES=lighthouse.yml:geth.yml:grafana.yml
+          var=CORE_FILES
+          set_value_in_env
+          FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+          var=FEE_RECIPIENT
           set_value_in_env
       - name: Start Lighthouse/Geth/Grafana
         run: ./ethd up
@@ -57,3 +60,5 @@ jobs:
         run: ./.github/check-service.sh loki
       - name: Test Grafana
         run: ./.github/check-service.sh grafana
+      - name: Test version
+        run: ./ethd version

--- a/.github/workflows/test-nimbus-proxy.yml
+++ b/.github/workflows/test-nimbus-proxy.yml
@@ -35,8 +35,8 @@ jobs:
           NETWORK=mainnet
           var=NETWORK
           set_value_in_env
-          COMPOSE_FILE=nimbus-vp.yml
-          var=COMPOSE_FILE
+          CORE_FILES=nimbus-vp.yml
+          var=CORE_FILES
           set_value_in_env
           RPC_URL=wss://ethereum-rpc.publicnode.com
           var=RPC_URL
@@ -50,3 +50,5 @@ jobs:
         run: sleep 30
       - name: Test Nimbus Verified Proxy
         run: ./.github/check-service.sh rpc-proxy
+      - name: Test version
+        run: ./ethd version


### PR DESCRIPTION
**What I did**

Web3signer distroless was not the first time an `./ethd version` broke. Have CI find that, from now on
