### PR TITLE
Prysm archive node backfills to slot 0

### DIFF
--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -61,6 +61,9 @@ fi
 # Check whether we should rapid sync
 if [[ -n "${CHECKPOINT_SYNC_URL:+x}" ]]; then
   __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --enable-backfill"
+  if [[ "${NODE_TYPE}" = "archive" ]]; then
+    __checkpoint_sync+=" --backfill-oldest-slot 0"
+  fi
   echo "Checkpoint sync enabled"
 else
   __checkpoint_sync=""


### PR DESCRIPTION
**What I did**

A checkpoint-synced Prysm archive node will backfill to genesis
