### PR TITLE
Fix ethd CI on macOS

### DIFF
--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -58,14 +58,14 @@ jobs:
       - name: Remove .env
         run: rm .env
       - name: Test ethd config defaults
-        run: expect ./.github/test-ethd-config.exp all-defaults
+        run: expect -d ./.github/test-ethd-config.exp all-defaults
         env:
           TERM: xterm
       - name: Test ethd config no mev
-        run: expect ./.github/test-ethd-config.exp no-mev
+        run: expect -d ./.github/test-ethd-config.exp no-mev
         env:
           TERM: xterm
       - name: Test ethd config no grafana
-        run: expect ./.github/test-ethd-config.exp no-grafana
+        run: expect -d ./.github/test-ethd-config.exp no-grafana
         env:
           TERM: xterm


### PR DESCRIPTION
**What I did**

On macOS, `expect` always failed. The recent stricter test exposed this. Run `expect -d` for debug, which is always useful.
