### PR TITLE
Reth uses the same port for discv4 and discv5

### DIFF
--- a/reth.yml
+++ b/reth.yml
@@ -31,7 +31,7 @@ services:
       - STATIC_DIR=${ANCIENT_DIR}
       - COMPOSE_FILE=${COMPOSE_FILE}
       - IPV6=${IPV6:-false}
-      - EL_P2P_PORT_2=${EL_P2P_PORT_2:-30304}
+      - EL_P2P_PORT=${EL_P2P_PORT:-30303}
       - RETH_SNAPSHOT=${RETH_SNAPSHOT:-}
       # Make this RUST_LOG=${LOG_LEVEL:-info},engine=trace when requiring deep debug
       # RPC debug can be done with jsonrpsee=trace or jsonrpsee::target=trace for a specific target
@@ -45,7 +45,6 @@ services:
     ports:
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/tcp
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/udp
-      - ${HOST_IP:-}:${EL_P2P_PORT_2:-30304}:${EL_P2P_PORT_2:-30304}/udp
     networks:
       default:
         aliases:
@@ -65,9 +64,8 @@ services:
       - ${EL_P2P_PORT:-30303}
       - --discovery.port
       - ${EL_P2P_PORT:-30303}
-      - --enable-discv5-discovery
       - --discovery.v5.port
-      - ${EL_P2P_PORT_2:-30304}
+      - ${EL_P2P_PORT:-30303}
       - --nat
       - publicip
       - --http

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -208,7 +208,7 @@ fi
 # IPV6
 if [[ "${IPV6:-false}" = "true" ]]; then
   echo "Configuring Reth's discv5 for IPv6 advertisements"
-  __ipv6="--addr :: --discovery.v5.addr 0.0.0.0 --discovery.v5.port.ipv6 ${EL_P2P_PORT_2}"
+  __ipv6="--addr :: --discovery.v5.addr 0.0.0.0 --discovery.v5.port.ipv6 ${EL_P2P_PORT}"
 else
   __ipv6=""
 fi


### PR DESCRIPTION
**What I did**

Discv5 and discv4 are on the same port. Requires Reth 2.2.0

"Support binding Discv5 and Discv4 to the same port (https://github.com/paradigmxyz/reth/pull/23613)"

Rely on discv5 being enabled by default

"Discv5 is now enabled by default (https://github.com/paradigmxyz/reth/pull/23686)"