### PR TITLE
Introduce a stable option for ETH_DOCKER_TAG

### DIFF
--- a/default.env
+++ b/default.env
@@ -303,8 +303,8 @@ RPC_URL=wss://eth-${NETWORK}.g.alchemy.com/v2/<ApiKey>
 # These settings can be reset to defaults with "./ethd update --refresh-targets"
 # The default source build targets build from the latest github tag
 
-# Eth Docker updates its code to latest by default.
-# Set a Github tag here to pin it to a version. Supported from v2.3.9.
+# Eth Docker updates its code to the latest state of the -dev version by default
+# "stable" follows the latest release, "vx.y.z" pins it to that release
 ETH_DOCKER_TAG=
 
 # SSV

--- a/ethd
+++ b/ethd
@@ -2163,6 +2163,7 @@ update() {
   local no_screen_cmd
   local dirty
   local branch
+  local latest_tag
 
   if [[ "$*" =~ --debug ]]; then
     __debug=1
@@ -2298,6 +2299,30 @@ update() {
       fi
       ${__as_owner} git pull origin main
     else
+      if [[ "${__value}" = "stable" ]]; then
+        if [[ "${__distro}" =~ (debian|ubuntu) ]]; then
+          if ! dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -q "ok installed" || ! dpkg-query -W -f='${Status}' jq 2>/dev/null | grep -q "ok installed"; then
+            if [[ "${__cannot_sudo}" -eq 0 ]]; then
+              echo "Installing curl and jq"
+              ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install -y --no-install-recommends curl jq
+            else
+              echo "Cannot install curl and jq, unable to check for a \"stable\" Eth Docker release"
+              echo "Please install curl and jq manually, and try again"
+              exit 1
+            fi
+          fi
+        fi
+        latest_tag=$(curl -s -m 10 https://api.github.com/repos/ethstaker/eth-docker/releases/latest 2>/dev/null| jq -r '.tag_name // empty' 2>/dev/null) || true
+        if [ -z "${latest_tag}" ]; then
+          echo "ERROR: Cannot fetch the latest release tag for ${__project_name} from Github."
+          if [[ ! "${__distro}" =~ (debian|ubuntu) ]]; then
+            echo "Make sure \"curl\" and \"jq\" are installed, and \"api.github.com\" is reachable."
+          fi
+          echo "Try again later or change to a specific pinned tag for \"ETH_DOCKER_TAG\" in \".env\""
+          exit 1
+        fi
+        __value="${latest_tag}"
+      fi
       export ETHDPINNED="${__value}"
       ${__as_owner} git fetch --tags
       ${__as_owner} git checkout -B "tag-${__value}" "tags/${__value}"


### PR DESCRIPTION
**What I did**

When `ETH_DOCKER_TAG=stable`, query github API for whatever release is tagged `latest`, and switch to it.

This brings with it some risk: Users may either have pinned a client release, in which case breaking changes will break that, or the client release is rolling, in which case changes to `main` that support it, but aren't in a release yet, aren't coming in.

For this reason `stable` is not the default. Users can seek it and need to be aware of potential foot guns.
