### PR TITLE
Disable expect CI for ethd on macOS

### DIFF
--- a/.github/workflows/test-ethd.yml
+++ b/.github/workflows/test-ethd.yml
@@ -56,16 +56,20 @@ jobs:
       - name: Test ethd update
         run: ./ethd update --debug --non-interactive
       - name: Remove .env
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: rm .env
       - name: Test ethd config defaults
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: expect -d ./.github/test-ethd-config.exp all-defaults
         env:
           TERM: xterm
       - name: Test ethd config no mev
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: expect -d ./.github/test-ethd-config.exp no-mev
         env:
           TERM: xterm
       - name: Test ethd config no grafana
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: expect -d ./.github/test-ethd-config.exp no-grafana
         env:
           TERM: xterm


### PR DESCRIPTION
**What I did**

Expect test for `./ethd config` rarely completes for macOS. Looks like a buffer flushing / timeout issue. So as to not mask real issues with `ethd`, disable expect testing on macOS.