### PR TITLE
Give Nethermind its dummy marker service back

### DIFF
--- a/ethd
+++ b/ethd
@@ -3399,7 +3399,7 @@ prune-history() {
   fi
 
   if [[ "${__non_interactive}" -eq 0 ]]; then
-    warning="WARNING - this will stop ${client} and remove pre-merge history. Do you wish to continue? (No/Yes) "
+    warning="WARNING - this will stop ${client} and remove ${target} history. Do you wish to continue? (No/Yes) "
     while true; do
       read -rp "${warning}" yn
       case "${yn}" in

--- a/nethermind.yml
+++ b/nethermind.yml
@@ -97,6 +97,16 @@ services:
       - metrics.network=${NETWORK}
       - logs.collect=true
 
+  set-prune-marker:
+    profiles: ["tools"]
+    image: alpine:3
+    user: "10001:10001"
+    restart: "no"
+    volumes:
+      - nethermind-el-data:/var/lib/nethermind
+    entrypoint: ["/bin/sh", "-c"]
+    command: /bin/sh
+
 volumes:
   nethermind-el-data:
   nm-eth1-data:


### PR DESCRIPTION
**What I did**

The marker isn't used other than by ethd prune-history
