### PR TITLE
Upgrade uv version in Vero's Dockerfile

### DIFF
--- a/vero/Dockerfile.source
+++ b/vero/Dockerfile.source
@@ -18,8 +18,7 @@ ARG SRC_REPO=https://github.com/serenita-org/vero
 ARG VENV_LOCATION
 
 ENV PATH="$VENV_LOCATION/bin:$PATH"
-# Pin uv to 0.6 until https://github.com/serenita-org/vero/pull/193 is in a release
-RUN pip install --no-cache-dir uv~=0.6.17 && uv venv ${VENV_LOCATION}
+RUN pip install --no-cache-dir uv~=0.11.8 && uv venv ${VENV_LOCATION}
 
 ARG SRC_DIR=vero
 RUN bash -eo pipefail <<'EOF'


### PR DESCRIPTION
**What I did**

Syncs uv version with upstream Dockerfile to ensure source builds succeed. The uv version was [recently bumped](https://github.com/serenita-org/vero/pull/312).

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/41c0216c-0338-442b-ad2e-092b3a3f7a0a" />
