### PR TITLE
VC keymanager traefik via an explicit file

### DIFF
--- a/cl-traefik.yml
+++ b/cl-traefik.yml
@@ -1,6 +1,7 @@
 # To be used in conjunction with lodestar.yml, nimbus.yml, teku.yml, lighthouse.yml or prysm.yml, ditto their
 # -cl-only.yml versions
-# For remote validator setups only. Please be very cautious when exposing your consensus API port
+# For remote validator setups only.
+# Please be extremely cautious when exposing your consensus API port, source-firewall access
 services:
   consensus:
     labels:

--- a/lighthouse-vc-only.yml
+++ b/lighthouse-vc-only.yml
@@ -77,12 +77,6 @@ services:
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.${VC_HOST:-vc}.service=${VC_HOST:-vc}
-      - traefik.http.routers.${VC_HOST:-vc}.entrypoints=websecure
-      - traefik.http.routers.${VC_HOST:-vc}.rule=Host(`${VC_HOST:-vc}.${DOMAIN}`)
-      - traefik.http.routers.${VC_HOST:-vc}.tls.certresolver=letsencrypt
-      - traefik.http.services.${VC_HOST:-vc}.loadbalancer.server.port=${KEY_API_PORT:-7500}
       - metrics.scrape=true
       - metrics.path=/metrics
       - metrics.port=8009

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -156,12 +156,6 @@ services:
       - --suggested-fee-recipient
       - ${FEE_RECIPIENT}
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.${VC_HOST:-vc}.service=${VC_HOST:-vc}
-      - traefik.http.routers.${VC_HOST:-vc}.entrypoints=websecure
-      - traefik.http.routers.${VC_HOST:-vc}.rule=Host(`${VC_HOST:-vc}.${DOMAIN}`)
-      - traefik.http.routers.${VC_HOST:-vc}.tls.certresolver=letsencrypt
-      - traefik.http.services.${VC_HOST:-vc}.loadbalancer.server.port=${KEY_API_PORT:-7500}
       - metrics.scrape=true
       - metrics.path=/metrics
       - metrics.port=8009

--- a/vc-traefik.yml
+++ b/vc-traefik.yml
@@ -1,0 +1,12 @@
+# To be used in conjunction with lighthouse.yml. It's meant for accessing a remote VC
+# with Siren
+# Please be extremely cautious when exposing your validator API port, source-firewall access
+services:
+  validator:
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.${VC_HOST:-vc}.service=${VC_HOST:-vc}
+      - traefik.http.routers.${VC_HOST:-vc}.entrypoints=websecure
+      - traefik.http.routers.${VC_HOST:-vc}.rule=Host(`${VC_HOST:-vc}.${DOMAIN}`)
+      - traefik.http.routers.${VC_HOST:-vc}.tls.certresolver=letsencrypt
+      - traefik.http.services.${VC_HOST:-vc}.loadbalancer.server.port=${KEY_API_PORT:-7500}


### PR DESCRIPTION
**What I did**

For Siren, `lighthouse.yml` was making the keymanager API port accessible via traefik. This would require the `VC_HOST.DOMAIN` to actually exist, and there is a token for access. Still, it's better if this is an explicit action by the user
