### PR TITLE
Fix "ethd keys import --non-interactive"

### DIFF
--- a/ethd
+++ b/ethd
@@ -3688,7 +3688,7 @@ __prep-keyimport() {
           echo "KEYSTORE_PASSWORD not set or empty, aborting"
           exit 1
         fi
-        __keys_args+="${__keys_args:+ }--interactive"
+        __keys_args+="${__keys_args:+ }--non-interactive"
         shift
         ;;
       --debug)


### PR DESCRIPTION
**What I did**

Fix a bug with ethd keys, it would set `--interactive` instead of `--non-interactive` when using non-interactive key import

**Related issue**
Fixes #2597 
