### PR TITLE
Optional provided binary for Grandine source build

### DIFF
--- a/default.env
+++ b/default.env
@@ -313,23 +313,28 @@ RPC_URL=wss://eth-${NETWORK}.g.alchemy.com/v2/<ApiKey>
 ETH_DOCKER_TAG=
 
 # SSV
+# Docker image and repo
 SSV_NODE_TAG=latest
 SSV_NODE_REPO=ssvlabs/ssv-node
 SSV_DKG_TAG=latest
 SSV_DKG_REPO=ssvlabs/ssv-dkg
+
 # SSV Anchor
+# Docker image and repo
 SSV_ANCHOR_TAG=latest
 SSV_ANCHOR_REPO=sigp/anchor
 SSV_ANCHOR_DOCKERFILE=Dockerfile.binary
 
 # Lido Obol
+# Docker image
 CHARON_TAG=latest
 LIDO_DV_EXIT_TAG=latest
 VALIDATOR_EJECTOR_TAG=1.9.0
 
 # EthPandaOps Contributoor
-CONTRIBUTOOR_DOCKER_REPO=ethpandaops/contributoor
+# Docker image and repo
 CONTRIBUTOOR_DOCKER_TAG=latest
+CONTRIBUTOOR_DOCKER_REPO=ethpandaops/contributoor
 
 # Commit-Boost
 CB_PBS_DOCKER_TAG=latest
@@ -338,37 +343,46 @@ CB_PBS_DOCKER_REPO=ghcr.io/commit-boost/pbs
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 MEV_SRC_BUILD_TARGET=stable
 MEV_SRC_REPO=https://github.com/flashbots/mev-boost
+# Docker image and repo
 MEV_DOCKER_TAG=latest
 MEV_DOCKER_REPO=flashbots/mev-boost
+# Whether to use a Docker image or build from source
 MEV_DOCKERFILE=Dockerfile.binary
 
 # Nimbus
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 NIM_SRC_BUILD_TARGET=stable
 NIM_SRC_REPO=https://github.com/status-im/nimbus-eth2
+# Docker image and repo
 NIM_DOCKER_TAG=multiarch-latest
 NIM_DOCKER_VC_TAG=multiarch-latest
 NIM_DOCKER_REPO=statusim/nimbus-eth2
 NIM_DOCKER_VC_REPO=statusim/nimbus-validator-client
+# Whether to use a Docker image or build from source
 NIM_DOCKERFILE=Dockerfile.binary
 
 # Teku
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 TEKU_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 TEKU_SRC_REPO=https://github.com/ConsenSys/teku
+# Docker image and repo
 TEKU_DOCKER_TAG=latest
 TEKU_DOCKER_REPO=consensys/teku
+# Whether to use a Docker image or build from source
 TEKU_DOCKERFILE=Dockerfile.binary
 
 # Lighthouse
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 LH_SRC_BUILD_TARGET=stable
 LH_SRC_REPO=https://github.com/sigp/lighthouse
+# Docker image and repo
 LH_DOCKER_TAG=latest
 LH_DOCKER_REPO=sigp/lighthouse
+# Whether to use a Docker image or build from source
 LH_DOCKERFILE=Dockerfile.binary
 
 # Lighthouse Siren
+# Docker image and repo
 SIREN_DOCKER_TAG=latest
 SIREN_DOCKER_REPO=sigp/siren
 
@@ -376,120 +390,148 @@ SIREN_DOCKER_REPO=sigp/siren
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 PRYSM_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 PRYSM_SRC_REPO=https://github.com/OffchainLabs/prysm
+# Docker image and repo
 PRYSM_DOCKER_TAG=stable
 PRYSM_DOCKER_VC_TAG=stable
 PRYSM_DOCKER_CTL_TAG=stable
 PRYSM_DOCKER_REPO=gcr.io/offchainlabs/prysm/beacon-chain
 PRYSM_DOCKER_VC_REPO=gcr.io/offchainlabs/prysm/validator
 PRYSM_DOCKER_CTL_REPO=gcr.io/offchainlabs/prysm/cmd/prysmctl
+# Whether to use a Docker image or build from source
 PRYSM_DOCKERFILE=Dockerfile.binary
 
 # Lodestar
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 LS_SRC_BUILD_TARGET=stable
 LS_SRC_REPO=https://github.com/ChainSafe/lodestar
+# Docker image and repo
 LS_DOCKER_TAG=latest
 LS_DOCKER_REPO=chainsafe/lodestar
+# Whether to use a Docker image or build from source
 LS_DOCKERFILE=Dockerfile.binary
 
 # Grandine
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 GRANDINE_SRC_BUILD_TARGET=master
 GRANDINE_SRC_REPO=https://github.com/grandinetech/grandine
+# Docker image and repo
 GRANDINE_DOCKER_TAG=stable
 GRANDINE_DOCKER_REPO=sifrai/grandine
+# Whether to use a Docker image or build from source
 GRANDINE_DOCKERFILE=Dockerfile.binary
 
 # Vero
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 VERO_SRC_BUILD_TARGET=master
 VERO_SRC_REPO=https://github.com/serenita-org/vero
+# Docker image and repo
 VERO_DOCKER_TAG=latest
 VERO_DOCKER_REPO=ghcr.io/serenita-org/vero
+# Whether to use a Docker image or build from source
 VERO_DOCKERFILE=Dockerfile.binary
 
 # Web3Signer
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 W3S_SRC_BUILD_TARGET=master
 W3S_SRC_REPO=https://github.com/Consensys/web3signer
+# Docker image and repo
 # Use latest-distroless or <vx.y>-distroless for a distroless setup
 W3S_DOCKER_TAG=latest
+W3S_DOCKER_REPO=consensys/web3signer
+PG_DOCKER_TAG=18-trixie
 # Set to "true" for distroless and read-only Docker
 W3S_READ_ONLY=false
-W3S_DOCKER_REPO=consensys/web3signer
+# Whether to use a Docker image or build from source
 W3S_DOCKERFILE=Dockerfile.binary
-PG_DOCKER_TAG=18-trixie
 
 # Besu
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 BESU_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 BESU_SRC_REPO=https://github.com/besu-eth/besu
+# Docker image and repo
 BESU_DOCKER_TAG=latest
 BESU_DOCKER_REPO=hyperledger/besu
+# Whether to use a Docker image or build from source
 BESU_DOCKERFILE=Dockerfile.binary
 
 # Erigon
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 ERIGON_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 ERIGON_SRC_REPO=https://github.com/ledgerwatch/erigon
+# Docker image and repo
 ERIGON_DOCKER_TAG=latest
 ERIGON_DOCKER_REPO=erigontech/erigon
+# Whether to use a Docker image or build from source
 ERIGON_DOCKERFILE=Dockerfile.binary
 
 # Nethermind
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 NM_SRC_BUILD_TARGET='$(git tag --sort=-committerdate | grep -E "^[0-9]+[.][0-9]+[.][0-9]+$" | head -1)'
 NM_SRC_REPO=https://github.com/NethermindEth/nethermind
+# Docker image and repo
 NM_DOCKER_TAG=latest
 NM_DOCKER_REPO=nethermind/nethermind
+# Whether to use a Docker image or build from source
 NM_DOCKERFILE=Dockerfile.binary
 
 # Go-Ethereum aka Geth
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 GETH_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 GETH_SRC_REPO=https://github.com/ethereum/go-ethereum
+# Docker image and repo
 GETH_DOCKER_TAG=stable
 GETH_DOCKER_REPO=ethereum/client-go
+# Whether to use a Docker image or build from source
 GETH_DOCKERFILE=Dockerfile.binary
 
 # Nimbus EL
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 NIMEL_SRC_BUILD_TARGET=master
 NIMEL_SRC_REPO=https://github.com/status-im/nimbus-eth1
+# Docker image and repo
 NIMEL_DOCKER_TAG=master
 NIMEL_DOCKER_REPO=statusim/nimbus-eth1
+# Whether to use a Docker image or build from source
 NIMEL_DOCKERFILE=Dockerfile.binary
 
 # Reth
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 RETH_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 RETH_SRC_REPO=https://github.com/paradigmxyz/reth
+# Docker image and repo
 RETH_DOCKER_TAG=latest
 RETH_DOCKER_REPO=ghcr.io/paradigmxyz/reth
+# Whether to use a Docker image or build from source
 RETH_DOCKERFILE=Dockerfile.binary
 
 # Ethrex
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 ETHREX_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 ETHREX_SRC_REPO=https://github.com/lambdaclass/ethrex
+# Docker image and repo
 ETHREX_DOCKER_TAG=latest
 ETHREX_DOCKER_REPO=ghcr.io/lambdaclass/ethrex
+# Whether to use a Docker image or build from source
 ETHREX_DOCKERFILE=Dockerfile.binary
 
 # Nimbus verified proxy
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 NIMVP_SRC_BUILD_TARGET=master
 NIMVP_SRC_REPO=https://github.com/status-im/nimbus-eth1
+# Docker image and repo
 NIMVP_DOCKER_TAG=proxy-docker-export
 NIMVP_DOCKER_REPO=statusim/nimbus-verified-proxy
+# Whether to use a Docker image or build from source
 NIMVP_DOCKERFILE=Dockerfile.binary
 
 # staking-deposit-cli
 # SRC build target can be a tag, a branch, or a pr as "pr-ID"
 DEPCLI_SRC_BUILD_TARGET='$(git describe --tags $(git rev-list --tags --max-count=1))'
 DEPCLI_SRC_REPO=https://github.com/ethstaker/ethstaker-deposit-cli
+# Docker image and repo
 DEPCLI_DOCKER_TAG=latest
 DEPCLI_DOCKER_REPO=ghcr.io/ethstaker/ethstaker-deposit-cli
+# Whether to use a Docker image or build from source
 DEPCLI_DOCKERFILE=Dockerfile.binary
 
 # traefik and ddns-updater

--- a/grandine/Dockerfile.source
+++ b/grandine/Dockerfile.source
@@ -13,22 +13,28 @@ ARG SRC_REPO
 
 WORKDIR /usr/src
 
+COPY ./src-built-binary /tmp/
 ARG SRC_DIR=grandine
 RUN bash -eo pipefail <<'EOF'
-  git clone "$SRC_REPO" "$SRC_DIR"
-  cd "$SRC_DIR"
-  git config advice.detachedHead false
-  git fetch --all --tags
-  CLEANED=$(echo "$BUILD_TARGET" | sed 's/\$\$(/$(/g')
-  TARGET=$(eval echo "$CLEANED")
-  if [[ "$TARGET" =~ ^pr-[1-9][0-9]*$ ]]; then
-    git fetch origin pull/$(echo "$TARGET" | cut -d '-' -f 2)/head:build-pr
-    git checkout build-pr
+  if [[ -f "/tmp/grandine" ]]; then  # User provided a binary and we'll trust it
+    mkdir -p /usr/src/grandine/target/compact/
+    cp -f "/tmp/grandine" /usr/src/grandine/target/compact/
   else
-    git checkout "$TARGET"
+    git clone "$SRC_REPO" "$SRC_DIR"
+    cd "$SRC_DIR"
+    git config advice.detachedHead false
+    git fetch --all --tags
+    CLEANED=$(echo "$BUILD_TARGET" | sed 's/\$\$(/$(/g')
+    TARGET=$(eval echo "$CLEANED")
+    if [[ "$TARGET" =~ ^pr-[1-9][0-9]*$ ]]; then
+      git fetch origin pull/$(echo "$TARGET" | cut -d '-' -f 2)/head:build-pr
+      git checkout build-pr
+    else
+      git checkout "$TARGET"
+    fi
+    git submodule update --init --jobs $(nproc) dedicated_executor eth2_libp2p
+    make release
   fi
-  git submodule update --init --jobs $(nproc) dedicated_executor eth2_libp2p
-  make release
 EOF
 
 

--- a/grandine/src-built-binary/.gitignore
+++ b/grandine/src-built-binary/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
**What I did**

Grandine can get a `grandine` binary in `grandine/src-built-binary/`, for faster debug iteration. Dockerfile can only copy from the context: An arbitrary location in the file system is not possible

Implements #2593 