### PR TITLE
Remove lockfile on fail

### DIFF
--- a/ethd
+++ b/ethd
@@ -49,6 +49,7 @@ __source_ver=1
 __minty_fresh=0
 __network_change=0
 __handler_ran=0
+__lock_file=""
 __deployment=""
 __write_vars=()
 __command=""
@@ -2270,7 +2271,6 @@ update() {
   local targetcli
   local script_dir
   local uniq_id
-  local lock_file
   local screen_session
   local old_sessions
   local session_id
@@ -2292,9 +2292,9 @@ update() {
 # Only one copy of update() should run per Eth Docker stack
     script_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
     uniq_id="${script_dir//\//_}"
-    lock_file="${uniq_id}_lock"
-    ${__as_owner} touch "/tmp/${lock_file}"
-    exec 200<"/tmp/${lock_file}"
+    __lock_file="${uniq_id}_lock"
+    ${__as_owner} touch "/tmp/${__lock_file}"
+    exec 200<"/tmp/${__lock_file}"
     if ! flock -n 200; then
         echo "Another instance of \"${__me} update\" is running. Aborting."
         exit 1
@@ -2564,7 +2564,7 @@ reset to defaults."
   if [[ ! "$OSTYPE" = "darwin"* ]]; then
 # Release lock and remove lock file
     exec 200<&-
-    ${__as_owner} rm -f "/tmp/${lock_file}"
+    ${__as_owner} rm -f "/tmp/${__lock_file}"
   fi
 
   if [[ -n "${STY:-}" || -n "${TMUX:-}" ]]; then
@@ -5541,6 +5541,10 @@ __handle_error() {
   local exitstatus=$1
   local line=$2
   local calling_line=$3
+
+  if [[ -f /tmp/"${__lock_file}" ]]; then
+    ${__as_owner} rm -f "/tmp/${__lock_file}"
+  fi
 
   if [[ ! $- =~ e ]]; then
 # set +e, do nothing


### PR DESCRIPTION
**What I did**

Have the exit handler remove the lock file if present. This prevents failure during `./ethd update` if `alice` aborted it and then `bob` tries to run it
