### PR TITLE
Add restart parameter to cb-pbs

### DIFF
--- a/commit-boost-pbs.yml
+++ b/commit-boost-pbs.yml
@@ -8,6 +8,7 @@ x-logging: &logging
 
 services:
   cb-pbs:
+    restart: "unless-stopped"
     image: ${CB_PBS_DOCKER_REPO:-ghcr.io/commit-boost/pbs}:${CB_PBS_DOCKER_TAG:-latest}
     environment:
       CB_CONFIG: /cb-config.toml


### PR DESCRIPTION
**What I did**

`cb-pbs` service was missing the restart parameter, and would be down after reboot or update of Docker
