### PR TITLE
fix: reset slashing protection flags per key in validator-import loop

### DIFF
--- a/vc-utils/keymanager.sh
+++ b/vc-utils/keymanager.sh
@@ -1008,6 +1008,8 @@ and secrets directories into .eth/validator_keys instead."
         echo
       done
     fi
+    found_one=0
+    do_a_protec=0
     for protect_file in "${keydir}"/slashing_protection*.json; do
       [[ -f "${protect_file}" ]] || continue
       if grep -q "${__pubkey}" "${protect_file}"; then


### PR DESCRIPTION
found_one and do_a_protec were never reset between loop iterations. When importing multiple keys, stale values from a previous key caused the no slashing protection warning to be silently suppressed and
sent slashing_protection: null to the keymanager API.