### PR TITLE
Remove Prometheus version

### DIFF
--- a/ethd
+++ b/ethd
@@ -6199,8 +6199,6 @@ version() {
   # Grafana version
   case "${__value}" in
     *grafana.yml*)
-      __docompose exec prometheus /bin/prometheus --version
-      echo
       echo -n "Grafana "
       __docompose exec grafana /run.sh -v
       echo


### PR DESCRIPTION
**What I did**

Remove the Prometheus version from `./ethd version`

Having it in there is historically grown. Arguably, if it remains, then Loki, Tempo and Alloy should also be listed.

But all four of those are a bit "deep tracks". Grafana version might matter to the user, they interact with that directly. Version of the storage and collector - considerably less so.
