### PR TITLE
exit when called with unrecognized command

### DIFF
--- a/ethd
+++ b/ethd
@@ -6484,6 +6484,7 @@ case "${__command}" in
   *)
     echo "Unrecognized command ${__command}"
     help
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
**What I did**

Cleanly exit on unrecognized command, instead of falling through to disk space and failing there because `COMPOSE_FILE` is not set
