### PR TITLE
Migrate Tempo to 3.0.0

### DIFF
--- a/ethd
+++ b/ethd
@@ -617,7 +617,6 @@ __prep_conffiles() {
     [./ssv-config/dkg-config.yaml]="./ssv-config/dkg-config.yaml.sample"
     [./commit-boost/cb-config.toml]="./commit-boost/cb-config.toml.sample"
     [./tempo/tempo.yaml]="./tempo/tempo.yaml.sample"
-    [./tempo/overrides.yaml]="./tempo/overrides.yaml.sample"
     [./.motd]="./.motd.sample"
   )
   local -A chmod_dirs=(
@@ -2279,6 +2278,7 @@ update() {
   local dirty
   local branch
   local latest_tag
+  local ts
 
   if [[ "$*" =~ --debug ]]; then
     __debug=1
@@ -2502,6 +2502,16 @@ update() {
   if [[ "${__env_migrated}" -eq 1 ]] && ! cmp -s "${__env_file}" "${__env_file}".source; then  # Create .bak early
     ${__as_owner} cp "${__env_file}".source "${__env_file}".bak
   fi
+
+  # Remove after Glamsterdam
+  if [[ ${__source_ver} -lt 58 ]]; then
+    if [[ -f ./tempo/tempo.yaml ]]; then
+      ts=$(date +%s)
+      mv ./tempo/tempo.yaml "./tempo/tempo.yaml.bak.${ts}"
+      __final_msg+="\nGrafana Tempo has been updated to v3; old tempo/tempo.yaml has been saved as tempo/tempo.yaml.bak.${ts}"
+    fi
+  fi
+
   # Remove after Glamsterdam
   __migrate_alloy_obol
   __pull_and_build

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -75,12 +75,11 @@ services:
       - logs.collect=true
 
   tempo:
-    image: grafana/tempo:2.10.4
+    image: grafana/tempo:3.0.0
     command:
       - '-config.file=/etc/tempo.yaml'
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo.yaml
-      - ./tempo/overrides.yaml:/etc/overrides.yaml
       - tempo-data:/var/tempo
     restart: "unless-stopped"
     <<: *logging

--- a/grafana.yml
+++ b/grafana.yml
@@ -190,12 +190,11 @@ services:
       - logs.collect=true
 
   tempo:
-    image: grafana/tempo:2.10.4
+    image: grafana/tempo:3.0.0
     command:
       - '-config.file=/etc/tempo.yaml'
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo.yaml
-      - ./tempo/overrides.yaml:/etc/overrides.yaml
       - tempo-data:/var/tempo
     restart: "unless-stopped"
     <<: *logging

--- a/tempo/overrides.yaml.sample
+++ b/tempo/overrides.yaml.sample
@@ -1,5 +1,0 @@
-overrides:
-  default:
-    metrics_generator_processors:
-      - local-blocks
-      - span-metrics

--- a/tempo/tempo.yaml.sample
+++ b/tempo/tempo.yaml.sample
@@ -1,6 +1,3 @@
-server:
-  http_listen_port: 3200
-
 distributor:
   receivers:
     otlp:
@@ -9,47 +6,36 @@ distributor:
           endpoint: 0.0.0.0:4317
         http:
           endpoint: 0.0.0.0:4318
-
-ingester:
-  trace_idle_period: 10s
-  max_block_duration: 5m
-
-compactor:
-  compaction:
-    block_retention: 1h
-
 metrics_generator:
   processor:
-    local_blocks:
-      filter_server_spans: false
-      flush_to_storage: true
     span_metrics:
       dimensions:
-        - client
-        - result
-        - non_custody_indices
-        - imported_blocks
-        - missing_column_indexes
-  storage:
-    path: /var/tempo/generator/wal
-    remote_write:
-      - url: http://prometheus:9090/api/v1/write
-        send_exemplars: true
-  traces_storage:
-    path: /var/tempo/generator/traces
+      - client
+      - result
+      - non_custody_indices
+      - imported_blocks
+      - missing_column_indexes
   registry:
     external_labels:
       source: tempo
-
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+    - send_exemplars: true
+      url: http://prometheus:9090/api/v1/write
+server:
+  http_listen_port: 3200
 storage:
   trace:
     backend: local
-    wal:
-      path: /var/tempo/wal
     local:
       path: /var/tempo/traces
-
+    wal:
+      path: /var/tempo/wal
 stream_over_http_enabled: true
 
 overrides:
-  per_tenant_override_config: /etc/overrides.yaml
+  defaults:
+    metrics_generator:
+      processors:
+        - span-metrics

--- a/tests/test-multiuser.sh
+++ b/tests/test-multiuser.sh
@@ -26,7 +26,6 @@ declare -a __config_files=(
   "ssv-config/dkg-config.yaml"
   "commit-boost/cb-config.toml"
   "tempo/tempo.yaml"
-  "tempo/overrides.yaml"
 )
 
 __initial_owner=""


### PR DESCRIPTION
**What I did**

Bump Tempo to 3.0.0 and migrate config. Separate overrides file is no longer required for span metrics
