### PR TITLE
SSV API address default

### DIFF
--- a/ssv-config/config.yaml.sample
+++ b/ssv-config/config.yaml.sample
@@ -18,6 +18,7 @@ eth1:
   ETH1Addr: ws://execution:8546
 MetricsAPIPort: 15000
 SSVAPIPort: 16000
+SSVAPIAddress: 0.0.0.0
 EnableDoppelgangerProtection: false
 Graffiti: ssv.network
 global:


### PR DESCRIPTION
**What I did**

SSV v2.4.3 adds an `SSVAPIAddress` which defaults to `127.0.0.1`. Set `0.0.0.0` in the `config.yaml.sample` so API is reachable from outside the container.