### PR TITLE
Change default traefik tag to 3.7

### DIFF
--- a/default.env
+++ b/default.env
@@ -535,7 +535,7 @@ DEPCLI_DOCKER_REPO=ghcr.io/ethstaker/ethstaker-deposit-cli
 DEPCLI_DOCKERFILE=Dockerfile.binary
 
 # traefik and ddns-updater
-TRAEFIK_TAG=v3.6
+TRAEFIK_TAG=v3.7
 DDNS_TAG=v2
 
 # Path to mount to node-exporter if needed for --collector.textfile.directory


### PR DESCRIPTION
**What I did**

Default traefik to `3.7`. No need to change existing installations.
