### PR TITLE
Update copyright year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,21 +175,10 @@ Apache License
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2021-2022 the eth-docker team
+   Copyright 2021-2026 the Eth Docker team
 
    Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
+   you may not use this software project except in compliance with the License.
    You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
**What I did**

`LICENSE` year range 2021-2026
`eth-docker` becomes `Eth Docker`
Remove boilerplate instructions
Reference the "software project" being licensed, not an individual file
