### PR TITLE
OS EOL nag considers remaining support time

### DIFF
--- a/ethd
+++ b/ethd
@@ -8,11 +8,11 @@ __sample_service="consensus"
 __target_pg=18
 __current_docker=29
 __min_ubuntu=22
-__suggest_ubuntu="24.04 or 22.04."
-__upgrade_ubuntu="24.04: https://gist.github.com/yorickdowne/94f1e5538007f4c9d3da7b22b0dc28a4"
-__min_debian=12
-__suggest_debian="13 or 12."
-__upgrade_debian="13: https://gist.github.com/yorickdowne/3cecc7b424ce241b173510e36754af47"
+__eol_min_ubuntu=2027-05-31
+__upgrade_ubuntu="Guide to upgrading to 24.04: https://gist.github.com/yorickdowne/94f1e5538007f4c9d3da7b22b0dc28a4 , consider an upgrade to 26.04 after that"
+__min_debian=11
+__eol_min_debian=2026-08-31
+__upgrade_debian="Guide to upgrading to 12: https://gist.github.com/yorickdowne/ec9e2c6f4f8a2ee93193469d285cd54c , consider an upgrade to 13 after that"
 __stat_mode_param=()
 __docker_exe="docker"
 __old_docker=0
@@ -2070,25 +2070,71 @@ valid address is set" 12 75
 
 # Both tells the user that their OS is old, and sets __eol_os for code that requires a min version
 __nag_os_version() {
-  if [[ "${__distro}" = "ubuntu" && "${__os_major_version}" -lt "${__min_ubuntu}" ]]; then
-     echo
-     echo "Ubuntu ${__os_major_version} is older than the recommended ${__suggest_ubuntu} version."
-     echo
-     echo "Upgrading is highly recommended, so that up-to-date Docker packages are available."
-     echo
-     echo "Guide to upgrading to ${__upgrade_ubuntu}"
-     __eol_os=1
+  local eol_epoch
+  local now_epoch
+  local days_diff
+
+  now_epoch=$(date +%s)
+
+  if [[ "${__distro}" = "ubuntu" && "${__os_major_version}" -le "${__min_ubuntu}" ]]; then
+    if ! eol_epoch=$(date -d "${__eol_min_ubuntu}" +%s 2>/dev/null); then
+      echo "Invalid EOL date: ${__eol_min_ubuntu}"
+      echo "This is a bug. Exiting so CI fails."
+      exit 70
+    fi
+    days_diff=$(( (eol_epoch - now_epoch) / 86400 ))
+
+    if [[ "${__os_major_version}" -lt "${__min_ubuntu}" || "${days_diff}" -lt 0 ]]; then
+      echo
+      echo "Ubuntu ${__os_major_version} is past the end of its standard support period."
+      echo "Updated Docker packages may no longer be available for this version, and it may not receive security updates."
+      echo "!! Upgrading is highly recommended !!"
+      echo
+      echo "${__upgrade_ubuntu}"
+      __eol_os=1
+    elif [[ "${days_diff}" -lt 30 ]]; then
+      echo
+      echo "Ubuntu ${__os_major_version} is approaching the end of its standard support period in ${days_diff} days."
+      echo "Upgrading before then is highly recommended."
+      echo
+      echo "${__upgrade_ubuntu}"
+    elif [[ "${days_diff}" -lt 90 ]]; then
+      echo
+      echo "Ubuntu ${__os_major_version} is approaching the end of its standard support period in ${days_diff} days."
+      echo "Scheduling an upgrade before then is recommended."
+      echo
+      echo "${__upgrade_ubuntu}"
+    fi
   fi
 
-  if [[ "${__distro}" =~ "debian" ]]; then
-    if [[ "${__os_major_version}" -lt "${__min_debian}" ]]; then
-     echo
-     echo "Debian ${__os_major_version} is older than the recommended ${__suggest_debian} version."
-     echo
-     echo "Upgrading is highly recommended, so that up-to-date Docker packages are available."
-     echo
-     echo "Guide to upgrading to ${__upgrade_debian}"
-     __eol_os=1
+  if [[ "${__distro}" =~ "debian" &&  "${__os_major_version}" -le "${__min_debian}" ]]; then
+    if ! eol_epoch=$(date -d "${__eol_min_debian}" +%s 2>/dev/null); then
+      echo "Invalid EOL date: ${__eol_min_debian}"
+      echo "This is a bug. Exiting so CI fails."
+      exit 70
+    fi
+    days_diff=$(( (eol_epoch - now_epoch) / 86400 ))
+
+    if [[ "${__os_major_version}" -lt "${__min_debian}" || "${days_diff}" -lt 0 ]]; then
+      echo
+      echo "Debian ${__os_major_version} is past the end of its long term support period."
+      echo "Updated Docker packages may no longer be available for this version, and it may not receive security updates."
+      echo "!! Upgrading is highly recommended !!"
+      echo
+      echo "${__upgrade_debian}"
+      __eol_os=1
+    elif [[ "${days_diff}" -lt 30 ]]; then
+      echo
+      echo "Debian ${__os_major_version} is approaching the end of its long term support period in ${days_diff} days."
+      echo "Upgrading before then is highly recommended."
+      echo
+      echo "${__upgrade_debian}"
+    elif [[ "${days_diff}" -lt 90 ]]; then
+      echo
+      echo "Debian ${__os_major_version} is approaching the end of its long term support period in ${days_diff} days."
+      echo "Scheduling an upgrade before then is recommended."
+      echo
+      echo "${__upgrade_debian}"
     fi
   fi
 }


### PR DESCRIPTION
**What I did**

Instead of just nagging about Debian 11, tell the user how much time they have left.

Similar for Ubuntu 22: Start nagging 89 days out, in early 2027

More actionable for users, they know whether they should act now, or schedule something at leisure.

Easier on code maintenance, I only update `__min` and `__eol` at some point past the EOL date of the previous version, instead of making a judgment call on when to cut off support.