### PR TITLE
Support Reth EraE import

### DIFF
--- a/reth.yml
+++ b/reth.yml
@@ -33,6 +33,7 @@ services:
       - IPV6=${IPV6:-false}
       - EL_P2P_PORT=${EL_P2P_PORT:-30303}
       - RETH_SNAPSHOT=${RETH_SNAPSHOT:-}
+      - ERE_URL=${ERE_URL:-}
       # Make this RUST_LOG=${LOG_LEVEL:-info},engine=trace when requiring deep debug
       # RPC debug can be done with jsonrpsee=trace or jsonrpsee::target=trace for a specific target
       # - RUST_LOG=${LOG_LEVEL:-info},engine=trace

--- a/reth/Dockerfile.source
+++ b/reth/Dockerfile.source
@@ -6,7 +6,14 @@ FROM rust:trixie AS builder
 ARG DOCKER_TAG
 ARG DOCKER_REPO
 
-RUN apt-get update && apt-get install -y --no-install-recommends libclang-dev
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    lsb-release wget gnupg ca-certificates libclang-dev && \
+    wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh && \
+    chmod +x /tmp/llvm.sh && /tmp/llvm.sh 22 all && \
+    for bin in clang llvm-config lld ld.lld FileCheck; do \
+      ln -fs "$(which "$bin-22")" "/usr/bin/$bin"; \
+    done && \
+    rm /tmp/llvm.sh
 
 ARG BUILD_TARGET
 ARG SRC_REPO

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -215,10 +215,25 @@ fi
 
 # Download snapshot if this is a fresh sync
 if [[ -n "${__snap}" && ! -d /var/lib/reth/db ]]; then
+  if [[ -n "${ERE_URL}" ]]; then
+    echo "WARNING: Both EraE URL ${ERE_URL} and Reth snapshot URL found. Preferring snapshot."
+  fi
   echo "Downloading Reth snapshot with parameters: ${__snap}"
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
   exec reth download --chain "${NETWORK}" --datadir /var/lib/reth ${__static} ${__snap}
+fi
+
+# EraE import
+if [[ -n "${ERE_URL}" && ! -f /var/lib/reth/ere-import-complete && ! "${NETWORK}" =~ ^https?:// ]]; then  # Fresh sync and named network
+  if [[ "${NODE_TYPE}" =~ ^(full|archive)$ ]]; then
+    echo "Starting EraE history import from ${ERE_URL}"
+# shellcheck disable=SC2086
+    reth import-era --datadir /var/lib/reth ${__static} ${__network} --url "${ERE_URL}"
+    touch /var/lib/reth/ere-import-complete
+  else
+    echo "Reth is neither a full nor archive node, it uses ${NODE_TYPE}. Skipping EraE import."
+  fi
 fi
 
 __strip_empty_args "$@"


### PR DESCRIPTION
**What I did**

Add support for Reth EraE import. Tested on pandaops sepolia. Requires Reth `main`. Adjusted `Dockerfile.source` to build `main` with a current `llvm`.
