### PR TITLE
Support Nimbus EL rolling expiry

### DIFF
--- a/default.env
+++ b/default.env
@@ -270,7 +270,7 @@ CL_NODE_TYPE=pruned
 # Consider using `./ethd prune-history`, which guides you as to whether to prune in-place
 # or resync, depending on client
 # "pre-prague-expiry" is supported with Geth, Reth and Nethermind
-# "rolling-expiry" is supported with Reth, Erigon, Nethermind and Besu
+# "rolling-expiry" is supported with Reth, Erigon, Nethermind, Besu and Nimbus EL
 # "rolling-expiry" is experimental in Nethermind and Besu as of Jan 27th 2026
 # "aggressive-expiry" is supported with Reth, Erigon and Besu
 # "aggressive-expiry" is experimental in Besu as of Jan 27th 2026

--- a/ethd
+++ b/ethd
@@ -3480,7 +3480,7 @@ prune-history() {
       ;;
     *nimbus-el.yml*)
       client="Nimbus"
-      if [[ "${target}" =~ ^(pre-prague|rolling|aggressive)$ ]]; then
+      if [[ "${target}" =~ ^(pre-prague|aggressive)$ ]]; then
         echo "${target} expiry is not supported by ${client}, or ${__project_name} doesn't know how to configure it."
         echo "Aborting."
         exit 1

--- a/nimbus-el/docker-entrypoint.sh
+++ b/nimbus-el/docker-entrypoint.sh
@@ -151,6 +151,10 @@ case "${NODE_TYPE}" in
         ;;
     esac
     ;;
+  rolling-expiry)
+    echo "Nimbus EL minimal node with 33,024 epochs rolling expiry - ~5 months"
+    __prune="--prune"
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Nimbus EL implementation."
     sleep 30


### PR DESCRIPTION
**What I did**

Rolling expiry requires Nimbus EL `0.3.1` and uses `33_024` epochs, to match the CL retention period
