### PR TITLE
Switch Java source builds to Resolute Raccoon

### DIFF
--- a/besu/Dockerfile.source
+++ b/besu/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Besu in a stock Ubuntu container
-FROM eclipse-temurin:25-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-resolute AS builder
 
 # This is here to avoid build-time complaints
 ARG DOCKER_TAG
@@ -33,7 +33,7 @@ EOF
 
 
 # Pull all binaries into a second stage deploy Ubuntu container
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
   ca-certificates \

--- a/teku/Dockerfile.source
+++ b/teku/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3059,DL4006
 # Build Teku in a stock Ubuntu container
-FROM eclipse-temurin:25-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-resolute AS builder
 
 # This is here to avoid build-time complaints
 ARG DOCKER_TAG
@@ -37,7 +37,7 @@ EOF
 
 
 # Pull all binaries into a second stage deploy Ubuntu container
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
   libjemalloc-dev \

--- a/web3signer/Dockerfile.convert
+++ b/web3signer/Dockerfile.convert
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3008
-FROM eclipse-temurin:25-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-resolute AS builder
 
 #ARG BUILD_TARGET=main
 ARG BUILD_TARGET=d32d6faf156b42985d6287a99e379b91d86fdb44
@@ -21,7 +21,7 @@ RUN bash -eo pipefail <<'EOF'
   ./gradlew installDist
 EOF
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 
 COPY --from=builder /usr/src/converter/converter/build/install/converter/ /opt/converter/
 COPY ./convert-keys.sh /usr/local/bin/

--- a/web3signer/Dockerfile.source
+++ b/web3signer/Dockerfile.source
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3007,DL3008,DL3059
 # Build Web3signer in a stock Ubuntu container
-FROM eclipse-temurin:25-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-resolute AS builder
 
 # This is here to avoid build-time complaints
 ARG DOCKER_TAG
@@ -34,7 +34,7 @@ EOF
 
 
 # Pull all binaries into a second stage deploy Ubuntu container
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
   ca-certificates \


### PR DESCRIPTION
**What I did**

All Java source builds (Teku, Besu, Web3signer) use Ubuntu Resolute Raccoon 26.04

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="195" height="259" alt="image" src="https://github.com/user-attachments/assets/f8b4bb66-390c-4b06-b773-34b275cf483e" />
