### PR TITLE
Remove Grafana datasource deletion

### DIFF
--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -1,16 +1,5 @@
-# config file version
 apiVersion: 1
 
-# list of datasources that should be deleted from the database
-deleteDatasources:
-  - name: Prometheus
-    orgId: 1
-
-  - name: Loki
-    orgId: 1
-
-# list of datasources to insert/update depending
-# what's available in the database
 datasources:
   - name: Prometheus
     type: prometheus


### PR DESCRIPTION
**What I did**

Users have gone through multiple hardforks and updated: No need to delete old Prometheus/Loki data sources any longer
