### PR TITLE
Use sudo for chmod only, not for find

### DIFF
--- a/ethd
+++ b/ethd
@@ -688,9 +688,9 @@ __prep_conffiles() {
 # Adjust "other" read permissions for files that are bind-mounted
   for dir in "${!chmod_dirs[@]}"; do
 # shellcheck disable=SC2086
-     ${__chmod_sudo} find "${dir}" -type d \! -perm -o+rx -exec chmod o+rx {} +
+     find "${dir}" -type d \! -perm -o+rx -exec ${__chmod_sudo} chmod o+rx {} +
 # shellcheck disable=SC2086
-     ${__chmod_sudo} find "${dir}" -type f -name "${chmod_dirs[${dir}]}" \! -perm -o+r -exec chmod o+r {} +
+     find "${dir}" -type f -name "${chmod_dirs[${dir}]}" \! -perm -o+r -exec ${__chmod_sudo} chmod o+r {} +
   done
 
 # Make sure directory owner owns .env, or it's owned by directory group and group is writable


### PR DESCRIPTION
**What I did**

If `alice:node-admins` owns the directory and `bob:node-admins` runs `ethd`, then a `sudo` is forced on every run, just for a `find`. Change that to sudo the `chmod` only, and run the `find` as `bob`. This makes running `ethd` commands a whole lot smoother for bob, and works just as well for fixing permissions if needed

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="218" height="148" alt="image" src="https://github.com/user-attachments/assets/41bab944-b57d-45af-b845-6e1f019058b5" />
