### PR TITLE
Add CL blob-archive type

### DIFF
--- a/default.env
+++ b/default.env
@@ -256,10 +256,9 @@ W3S_HEAP=
 # If left empty, the default in lodestar.yml will be used
 LODESTAR_HEAP=
 
-# CL_NODE_TYPE can be "archive", "full", "pruned" or "pruned-with-zkproofs"
-# "archive" may also keep all blobs, depending on client
+# CL_NODE_TYPE can be "archive", "blob-archive", "full" or "pruned"
 # Switching node type typically requires a resync
-# "pruned-with-zkproofs" is experimental and will not work with the standard client builds
+# Not all clients support a blob archive, and getting historical blobs is tricky until EraB exports are available
 # Grandine has an additional "aggressive-pruned" mode, which keeps minimal data
 # For a more granular way to handle it, please use CL_EXTRAS in combination with "full"
 CL_NODE_TYPE=pruned
@@ -569,4 +568,4 @@ DOCKER_ROOT=/var/lib/docker
 DOCKER_SOCK=/var/run/docker.sock
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=58
+ENV_VERSION=59

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -119,10 +119,16 @@ else
     __caplin+=" --caplin.mev-relay-url=${MEV_NODE}"
     echo "MEV Boost enabled"
   fi
-  if [[ "${CL_NODE_TYPE}" = "archive" ]]; then
-    echo "Running Caplin archive node"
-    __caplin+=" --caplin.states-archive=true --caplin.blobs-archive=true --caplin.blobs-no-pruning=true --caplin.blocks-archive=true"
-  fi
+  case "${CL_NODE_TYPE}" in
+    archive)
+      echo "Caplin archive node without history pruning"
+      __caplin+=" --caplin.states-archive=true --caplin.blocks-archive=true"
+      ;;
+    blob-archive)
+      echo "Caplin archive node without blob or history pruning"
+      __caplin+=" --caplin.states-archive=true --caplin.blobs-archive=true --caplin.blobs-no-pruning=true --caplin.blocks-archive=true"
+      ;;
+  esac
   if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
     __caplin+=" --caplin.checkpoint-sync-url=${CHECKPOINT_SYNC_URL}/eth/v2/debug/beacon/states/finalized"
     echo "Checkpoint sync enabled"

--- a/ethd
+++ b/ethd
@@ -1980,6 +1980,11 @@ __migrate_env() {
       if [[ "${var}" = "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" && "${__value}" = "/dev/null" ]]; then
         __value=""
       fi
+      # Remove after Glamsterdam
+      if [[ "${__source_ver}" -lt "59" && "${var}" = "CL_NODE_TYPE" && "${__value}" = "archive"
+            && ${COMPOSE_FILE} =~ (prysm\.yml|prysm-cl-only\.yml|lighthouse\.yml|lighthouse-cl-only\.yml|lodestar\.yml|lodestar-cl-only\.yml|caplin\.yml) ]]; then
+        __value="blob-archive"
+      fi
 
       if [[ "${var}" = "CL_QUIC_PORT" ]]; then
         __get_value_from_env "CL_P2P_PORT" "${__env_file}.source" "CL_P2P_PORT"

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -72,7 +72,7 @@ fi
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Grandine archive node without pruning"
+    echo "Grandine archive node without history pruning"
     __prune="--back-sync --archive-storage"
     ;;
   pruned)

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -62,7 +62,11 @@ __engine="--execution-endpoint ${EL_NODE} --execution-jwt /var/lib/lighthouse/be
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Lighthouse archive node without pruning"
+    echo "Lighthouse archive node without history pruning"
+    __prune=""
+    ;;
+  blob-archive)
+    echo "Lighthouse blob archive node without blob or history pruning"
     __prune="--prune-blobs=false"
     ;;
   full|pruned)

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -79,7 +79,11 @@ fi
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Lodestar archive node without pruning"
+    echo "Lodestar archive node without history pruning"
+    __prune="--serveHistoricalState"
+    ;;
+  blob-archive)
+    echo "Lodestar archive node without blob or history pruning"
     __prune="--chain.archiveBlobEpochs Infinity --serveHistoricalState"
     ;;
   full)

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -258,7 +258,7 @@ if [[ "${COMPOSE_FILE}" =~ grandine-plugin(-allin1)?\.yml ]]; then
 
   case "${CL_NODE_TYPE}" in
     archive)
-      echo "Grandine archive node without pruning"
+      echo "Grandine archive node without history pruning"
       __grandine+=" --grandine-back-sync --grandine-archive-storage"
       ;;
     pruned)

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -135,7 +135,7 @@ __log_level="--log-level=${LOG_LEVEL^^}"
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Nimbus archive node without pruning"
+    echo "Nimbus archive node without history pruning"
     __prune="--history=archive"
     ;;
   full)

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -80,7 +80,11 @@ fi
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Prysm archive node without pruning"
+    echo "Prysm archive node without history pruning"
+    __prune="--slots-per-archive-point=32"
+    ;;
+  blob-archive)
+    echo "Prysm blob archive node without blob or history pruning"
     __prune="--slots-per-archive-point=32 --blob-retention-epochs=4294967295"
     ;;
   full)

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -156,7 +156,7 @@ fi
 
 case "${NODE_TYPE}" in
   archive)
-    echo "Teku archive node without pruning"
+    echo "Teku archive node without history pruning"
     __prune="--data-storage-mode=ARCHIVE"
     ;;
   full)


### PR DESCRIPTION
**What I did**

`CL_NODE_TYPE` now has `archive` and `blob-archive` to be more deliberate about whether to keep blobs. Prepares for EraB import.

`./ethd update` will migrate `archive` to `blob-archive` on those clients that support it

**Related issue**
Implements #2652 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/2875ef07-4afd-49d9-b330-795be50c7a6d" />
