### PR TITLE
Zkproofs becomes an EL node type

### DIFF
--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -93,6 +93,12 @@ case "${NODE_TYPE}" in
     echo "Besu minimal node with aggressive expiry"
     __prune="--snapsync-server-enabled --Xchain-pruning-enabled=ALL --Xchain-pruning-blocks-retained=113056"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"besu.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Besu implementation."
     sleep 30

--- a/default.env
+++ b/default.env
@@ -265,6 +265,7 @@ LODESTAR_HEAP=
 CL_NODE_TYPE=pruned
 # EL_NODE_TYPE can be "archive", "full", "pre-merge-expiry", "pre-prague-expiry",
 # "rolling-expiry" or "aggressive-expiry"
+# "use-cl-zkproofs" can be used with an experimental Lighthouse build, and omits the EL
 # "pre-merge-expiry" is only meaningful for mainnet and sepolia
 # Switching node type typically requires a resync
 # Consider using `./ethd prune-history`, which guides you as to whether to prune in-place

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -97,6 +97,12 @@ case "${NODE_TYPE}" in
     echo "Erigon minimal node with aggressive expiry"
     __prune="--prune.mode=minimal --persist.receipts=false"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"erigon.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Erigon implementation."
     sleep 30

--- a/ethrex/docker-entrypoint.sh
+++ b/ethrex/docker-entrypoint.sh
@@ -89,6 +89,12 @@ case "${NODE_TYPE}" in
     echo "Ethrex minimal node with pre-merge history expiry and snap sync"
     __sync="--syncmode snap"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"ethrex.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Ethrex implementation."
     sleep 30

--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -220,6 +220,12 @@ case "${NODE_TYPE}" in
         ;;
     esac
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"geth.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Geth implementation."
     sleep 30

--- a/lighthouse-cl-only.yml
+++ b/lighthouse-cl-only.yml
@@ -37,6 +37,7 @@ services:
       - BEACON_STATS_MACHINE=${BEACON_STATS_MACHINE}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - EL_NODE_TYPE=${EL_NODE_TYPE}
       - EL_NODE=${EL_NODE}
       - IPV6=${IPV6:-false}
       - CL_P2P_PORT=${CL_P2P_PORT:-9000}

--- a/lighthouse.yml
+++ b/lighthouse.yml
@@ -47,6 +47,7 @@ services:
       - BEACON_STATS_MACHINE=${BEACON_STATS_MACHINE}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - EL_NODE_TYPE=${EL_NODE_TYPE}
       - EL_NODE=${EL_NODE}
       - IPV6=${IPV6:-false}
       - CL_P2P_PORT=${CL_P2P_PORT:-9000}

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -68,33 +68,33 @@ case "${NODE_TYPE}" in
   full|pruned)
     __prune=""
     ;;
-  pruned-with-zkproofs)
-    if [[ ! "${NETWORK}" = "mainnet" ]]; then
-      echo "Lighthouse with zkProof verification only works on mainnet, as far as Eth Docker is aware."
-      echo "Aborting."
-      sleep 30
-      exit 1
-    fi
-    echo "Lighthouse node with zkProof verification. HIGHLY experimental."
-    echo "Please make sure that you have edited \".env\" and changed:"
-    echo "CL_EXTRAS=--boot-nodes enr:-Oy4QJgMz9S1Eb7s13nKIbulKC0nvnt7AEqbmwxnTdwzptxNCGWjc9ipteUaCwqlu2bZDoNz361vGC_IY4fbdkR1K9iCDeuHYXR0bmV0c4gAAAAAAAAABoNjZ2MEhmNsaWVudNGKTGlnaHRob3VzZYU4LjAuMYRldGgykK1TLOsGAAAAAEcGAAAAAACCaWSCdjSCaXCEisV68INuZmSEzCxc24RxdWljgiMpiXNlY3AyNTZrMaEDEIWq41UTcFUgL8LRletpbIwrrpxznIMN_F5jRgatngmIc3luY25ldHMAg3RjcIIjKIR6a3ZtAQ"
-    echo "LH_SRC_BUILD_TARGET=ethproofs/zkattester-demo"
-    echo "LH_SRC_REPO=https://github.com/ethproofs/lighthouse"
-    echo "LH_DOCKERFILE=Dockerfile.source"
-    echo "MEV_BOOST=true"
-    echo "MEV_BUILD_FACTOR=100"
-    echo "And have source-built Lighthouse with \"./ethd update\""
-    echo "A PBS sidecar needs to be in COMPOSE_FILE, and MEV relays need to be configured"
-    echo "Note the bootnodes ENR may have changed, check on the zkEVM attesting Telegram group!"
-    __prune=""
-    __engine="--execution-proofs"
-    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Lighthouse implementation."
     sleep 30
     exit 1
     ;;
 esac
+
+if [[ "${EL_NODE_TYPE}" = "use-cl-zkproofs" ]]; then
+  if [[ ! "${NETWORK}" = "mainnet" ]]; then
+    echo "Lighthouse with zkProof verification only works on mainnet, as far as Eth Docker is aware."
+    echo "Aborting."
+    sleep 30
+    exit 1
+  fi
+  echo "Lighthouse node with zkProof verification. HIGHLY experimental."
+  echo "Please make sure that you have edited \".env\" and changed:"
+  echo "CL_EXTRAS=--boot-nodes enr:-Oy4QJgMz9S1Eb7s13nKIbulKC0nvnt7AEqbmwxnTdwzptxNCGWjc9ipteUaCwqlu2bZDoNz361vGC_IY4fbdkR1K9iCDeuHYXR0bmV0c4gAAAAAAAAABoNjZ2MEhmNsaWVudNGKTGlnaHRob3VzZYU4LjAuMYRldGgykK1TLOsGAAAAAEcGAAAAAACCaWSCdjSCaXCEisV68INuZmSEzCxc24RxdWljgiMpiXNlY3AyNTZrMaEDEIWq41UTcFUgL8LRletpbIwrrpxznIMN_F5jRgatngmIc3luY25ldHMAg3RjcIIjKIR6a3ZtAQ"
+  echo "LH_SRC_BUILD_TARGET=ethproofs/zkattester-demo"
+  echo "LH_SRC_REPO=https://github.com/ethproofs/lighthouse"
+  echo "LH_DOCKERFILE=Dockerfile.source"
+  echo "MEV_BOOST=true"
+  echo "MEV_BUILD_FACTOR=100"
+  echo "And have source-built Lighthouse with \"./ethd update\""
+  echo "A PBS sidecar needs to be in COMPOSE_FILE, and MEV relays need to be configured"
+  echo "Note the bootnodes ENR may have changed, check on the zkEVM attesting Telegram group!"
+  __engine="--execution-proofs"
+fi
 
 # Check whether we should rapid sync
 if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -180,6 +180,12 @@ case "${NODE_TYPE}" in
     echo "\"EL_EXTRAS=--history-retentionepochs <epochs>\" in \".env\" can override, minimum <epochs> are 82125."
     __prune+=" --History.Pruning=Rolling"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"nethermind.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Nethermind implementation."
     sleep 30

--- a/nimbus-el/docker-entrypoint.sh
+++ b/nimbus-el/docker-entrypoint.sh
@@ -139,6 +139,12 @@ case "${NODE_TYPE}" in
     echo "Nimbus EL minimal node with 33,024 epochs rolling expiry - ~5 months"
     __prune="--prune"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"nimbus-el.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Nimbus EL implementation."
     sleep 30

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -152,6 +152,12 @@ case "${NODE_TYPE}" in
     __prune="--minimal"
     __snap="--minimal"
     ;;
+  use-cl-zkproofs)
+    echo "ERROR: The node type ${NODE_TYPE} is designed to not run an execution layer client"
+    echo "Remove \"reth.yml\" from configuration, or change the node type"
+    sleep 30
+    exit 1
+    ;;
   *)
     echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Reth implementation."
     sleep 30


### PR DESCRIPTION
**What I did**

`EL_NODE_TYPE` gains `use-cl-zkproofs`, and `CL_NODE_TYPE` loses `pruned-with-zkproofs`

All execution layer clients log an error if started with `use-cl-zkproofs`

Experimental Lighthouse remains the only client this can be used with, likely until Hegota, when optional proofs become available

**Related issue**
Implements #2653

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="130" height="168" alt="image" src="https://github.com/user-attachments/assets/e6acacb5-1b7f-451d-9c88-23927ed6c77d" />
