### PR TITLE
Nimbus VP can parse comma-separated URLs

### DIFF
--- a/.github/workflows/test-nimbus-proxy.yml
+++ b/.github/workflows/test-nimbus-proxy.yml
@@ -38,10 +38,10 @@ jobs:
           CORE_FILES=nimbus-vp.yml
           var=CORE_FILES
           set_value_in_env
-          RPC_URL=wss://ethereum-rpc.publicnode.com
-          var=RPC_URL
+          RPC_URLS=wss://ethereum-rpc.publicnode.com
+          var=RPC_URLS
           set_value_in_env
-          CL_NODE=https://ethereum.operationsolarstorm.org/
+          CL_NODE=https://ethereum-beacon-api.publicnode.com
           var=CL_NODE
           set_value_in_env
       - name: Start Nimbus Verified Proxy

--- a/default.env
+++ b/default.env
@@ -321,8 +321,8 @@ OBOL_CL_NODE=http://${NETWORK}-consensus:${CL_REST_PORT}
 EL_RPC_NODE=http://${NETWORK}-execution:${EL_RPC_PORT}
 # Execution client address (WS) for SSV Anchor
 EL_WS_NODE=ws://${NETWORK}-execution:${EL_WS_PORT}
-# RPC provider when using a verified proxy, use wss:// here
-RPC_URL=wss://eth-${NETWORK}.g.alchemy.com/v2/<ApiKey>
+# RPC provider(s) when using a verified proxy, use wss:// here. Can be multiple, comma-separated
+RPC_URLS=wss://eth-${NETWORK}.g.alchemy.com/v2/<ApiKey>
 
 # You can set specific version targets and choose binary or compiled from source builds below,
 # via "Dockerfile.binary" or "Dockerfile.source"
@@ -569,4 +569,4 @@ DOCKER_ROOT=/var/lib/docker
 DOCKER_SOCK=/var/run/docker.sock
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=59
+ENV_VERSION=60

--- a/ethd
+++ b/ethd
@@ -1884,8 +1884,8 @@ __update_value_in_env() {
 
 
 __migrate_env() {
-  local old_vars=( DDNS_PROXY DDNS_SUBDOMAIN ERA_URL )
-  local new_vars=( CF_PROXY DDNS_HOST ERE_URL )
+  local old_vars=( DDNS_PROXY DDNS_SUBDOMAIN ERA_URL RPC_URL )
+  local new_vars=( CF_PROXY DDNS_HOST ERE_URL RPC_URLS )
   local error
   local line
   local index

--- a/nimbus-vp.yml
+++ b/nimbus-vp.yml
@@ -23,6 +23,7 @@ services:
     user: user
     environment:
       - CL_NODE=${CL_NODE}
+      - RPC_URLS=${RPC_URLS}
       - PROXY_EXTRAS=${PROXY_EXTRAS:-}
     volumes:
       - nimbus-vp-data:/var/lib/nimbus
@@ -38,10 +39,8 @@ services:
       - nimbus_verified_proxy
       - --data-dir=/var/lib/nimbus
       - --network=${NETWORK}
-      - --execution-api-url=${RPC_URL}
       - --listen-url=http://0.0.0.0:${PROXY_RPC_PORT:-48545}
       - --listen-url=ws://0.0.0.0:${PROXY_WS_PORT:-48546}
-      - --beacon-api-url=${CL_NODE}
       - --log-level=${LOG_LEVEL}
 
 volumes:

--- a/nimbus-vp/docker-entrypoint.sh
+++ b/nimbus-vp/docker-entrypoint.sh
@@ -6,25 +6,44 @@ if [[ "$(id -u)" -eq 0 ]]; then
   exec gosu user docker-entrypoint.sh "$@"
 fi
 
-
-while true; do
-  if curl -s -m 5 "${CL_NODE}" &> /dev/null; then
-    echo "Consensus Layer node is up, fetching trusted block root"
-    break
-  else
-    echo "Waiting for Consensus Layer node to be reachable..."
-    sleep 5
-  fi
+# accommodate comma separated list of consensus nodes
+nodes=$(echo "${CL_NODE}" | tr ',' ' ')
+__beacon_urls=()
+for node in ${nodes}; do
+  __beacon_urls+=("--beacon-api-url=${node}")
 done
 
-set +e
-  root=$(curl -s -f -m 30 "${CL_NODE}/eth/v1/beacon/headers/finalized" | jq -r '.data.root')
-  exitstatus=$?
-set -e
+# accommodate comma separated list of RPC URLs
+urls=$(echo "${RPC_URLS}" | tr ',' ' ')
+__rpc_urls=()
+for url in ${urls}; do
+  __rpc_urls+=("--execution-api-url=${url}")
+done
 
-if [[ "${exitstatus}" -ne 0 ]]; then
-  echo "Failed to fetch trusted block root from ${CL_NODE}"
+while true; do
+  for node in ${nodes}; do
+    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+      echo "Consensus Layer node is up, fetching trusted block root"
+      break 2
+    fi
+  done
+  echo "Waiting for Consensus Layer node to be reachable..."
+  sleep 5
+done
+
+if ! response=$(curl -s -f -m 30 "${node}/eth/v1/beacon/headers/finalized"); then
+  echo "Failed to fetch trusted block root from ${node}"
   echo "Please verify it's reachable"
+  sleep 30
+  exit 1
+fi
+
+root=$(echo "${response}" | jq -r '.data.root')
+
+# Guard against empty or "null" results from jq
+if [[ -z "${root}" || "${root}" == "null" ]]; then
+  echo "Error: Received invalid data structure from ${node}"
+  echo "Received ${response}, which does not contain \".data.root\""
   sleep 30
   exit 1
 fi
@@ -33,7 +52,7 @@ __trusted_root="--trusted-block-root=${root}"
 i=0
 # Verified proxy can get "stuck" if light client bootstrap isn't ready. Check for it here
 while true; do
-  if curl -s -f -m 30 "${CL_NODE}/eth/v1/beacon/light_client/bootstrap/${root}" &> /dev/null; then
+  if curl -s -f -m 30 "${node}/eth/v1/beacon/light_client/bootstrap/${root}" &> /dev/null; then
     echo "Consensus Layer node has light client bootstrap available, starting Nimbus Verified Proxy"
     break
   else
@@ -56,4 +75,4 @@ done
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__trusted_root} ${PROXY_EXTRAS}
+exec "$@" "${__beacon_urls[@]}" "${__rpc_urls[@]}" ${__trusted_root} ${PROXY_EXTRAS}


### PR DESCRIPTION
**What I did**

Nimbus Verified Proxy handles comma-separated `CL_NODE` correctly, and accepts comma-separated `RPC_URLS`

**Related issue**
closes #2647 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="266" height="189" alt="image" src="https://github.com/user-attachments/assets/a02539be-506f-4f1a-beb4-49feab72bb1e" />
