### PR TITLE
Better blob-archive handling

### DIFF
--- a/ethd
+++ b/ethd
@@ -3680,7 +3680,7 @@ prune-lighthouse() {
   # Check for archive node
   var="CL_NODE_TYPE"
   __get_value_from_env "${var}" "${__env_file}" "__value"
-  if [[ "${__value}" = "archive" ]]; then
+  if [[ "${__value}" =~ archive$ ]]; then
     echo "Lighthouse is an archive node: Aborting."
     exit 1
   fi

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -104,8 +104,8 @@ fi
 if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
   __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL}"
   echo "Checkpoint sync enabled"
-  if [[ "${NODE_TYPE}" = "archive" ]]; then
-    __prune+=" --reconstruct-historic-states --genesis-backfill --disable-backfill-rate-limiting"
+  if [[ "${NODE_TYPE}" =~ archive$ ]]; then
+    __prune+=" --archive --genesis-backfill --disable-backfill-rate-limiting"
   fi
 else
   __checkpoint_sync="--allow-insecure-genesis-sync"
@@ -169,7 +169,7 @@ done
 
 if [[ -f /var/lib/lighthouse/beacon/prune-marker ]]; then
   rm -f /var/lib/lighthouse/beacon/prune-marker
-  if [[ "${NODE_TYPE}" = "archive" ]]; then
+  if [[ "${NODE_TYPE}" =~ archive$ ]]; then
     echo "Lighthouse is an archive node. Not attempting to prune state: Aborting."
     exit 1
   fi

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -102,7 +102,7 @@ esac
 
 # Check whether we should rapid sync
 if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
-  if [[ ! "${NODE_TYPE}" = "archive" ]]; then
+  if [[ ! "${NODE_TYPE}" =~ archive$ ]]; then
     __checkpoint_sync="--checkpointSyncUrl=${CHECKPOINT_SYNC_URL}"
     echo "Checkpoint sync enabled"
   else

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -61,7 +61,7 @@ fi
 # Check whether we should rapid sync
 if [[ -n "${CHECKPOINT_SYNC_URL:+x}" ]]; then
   __checkpoint_sync="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --enable-backfill"
-  if [[ "${NODE_TYPE}" = "archive" ]]; then
+  if [[ "${NODE_TYPE}" =~ archive$ ]]; then
     __checkpoint_sync+=" --backfill-oldest-slot 0"
   fi
   echo "Checkpoint sync enabled"


### PR DESCRIPTION
**What I did**

I had introduced `blob-archive` but was still checking for `= "archive"` in multiple places. `blob-archive` would not actually be an archive node or have its constraints, for Lighthouse, Lodestar and Prysm

Also change to `--archive` flag for Lighthouse, introduced with `8.2`

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/f365b9f1-14ce-4ba7-8281-7183bf88b346" />
