### PR TITLE
Track eth-docker version in metrics

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -12,13 +12,14 @@ discovery.relabel "docker_logs" {
   targets = discovery.docker.docker_containers.targets
 
   // discovery.docker sees every container on the host, not just this
-  // project's - keep only our own so multiple Eth Docker installs on one
-  // host don't ship each other's logs. Falls back to matching every
-  // container on the host if resolving COMPOSE_PROJECT_NAME ever fails,
-  // rather than matching none.
+  // project's. ALLOY_PROJECT_NAME holds this install's Compose project name
+  // when ALLOY_FILTER_BY_PROJECT_NAME=true (ethd resolves and sets it); we
+  // then keep only our own, so multiple Eth Docker installs on one host don't
+  // ship each other's logs. Empty (the default) coalesces to ".*", matching
+  // every container on the host and preserving the scrape-all behavior.
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
-    regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")
+    regex         = coalesce(sys.env("ALLOY_PROJECT_NAME"), ".*")
     action        = "keep"
   }
 
@@ -49,13 +50,14 @@ discovery.relabel "docker_metrics" {
   targets = discovery.docker.docker_containers.targets
 
   // discovery.docker sees every container on the host, not just this
-  // project's - keep only our own so multiple Eth Docker installs on one
-  // host don't scrape/ship each other's metrics. Falls back to matching
-  // every container on the host if resolving COMPOSE_PROJECT_NAME ever
-  // fails, rather than matching none.
+  // project's. ALLOY_PROJECT_NAME holds this install's Compose project name
+  // when ALLOY_FILTER_BY_PROJECT_NAME=true (ethd resolves and sets it); we
+  // then keep only our own, so multiple Eth Docker installs on one host don't
+  // scrape/ship each other's metrics. Empty (the default) coalesces to ".*",
+  // matching every container on the host and preserving the scrape-all behavior.
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
-    regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")
+    regex         = coalesce(sys.env("ALLOY_PROJECT_NAME"), ".*")
     action        = "keep"
   }
 

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -13,9 +13,9 @@ discovery.relabel "docker_logs" {
 
   // discovery.docker sees every container on the host, not just this
   // project's - keep only our own so multiple Eth Docker installs on one
-  // host don't ship each other's logs. Falls back to matching everything
-  // (today's behavior) if resolving COMPOSE_PROJECT_NAME ever fails,
-  // rather than matching nothing.
+  // host don't ship each other's logs. Falls back to matching every
+  // container on the host if resolving COMPOSE_PROJECT_NAME ever fails,
+  // rather than matching none.
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
     regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")
@@ -51,8 +51,8 @@ discovery.relabel "docker_metrics" {
   // discovery.docker sees every container on the host, not just this
   // project's - keep only our own so multiple Eth Docker installs on one
   // host don't scrape/ship each other's metrics. Falls back to matching
-  // everything (today's behavior) if resolving COMPOSE_PROJECT_NAME ever
-  // fails, rather than matching nothing.
+  // every container on the host if resolving COMPOSE_PROJECT_NAME ever
+  // fails, rather than matching none.
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
     regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -11,6 +11,17 @@ discovery.docker "docker_containers" {
 discovery.relabel "docker_logs" {
   targets = discovery.docker.docker_containers.targets
 
+  // discovery.docker sees every container on the host, not just this
+  // project's - keep only our own so multiple Eth Docker installs on one
+  // host don't ship each other's logs. Falls back to matching everything
+  // (today's behavior) if resolving COMPOSE_PROJECT_NAME ever fails,
+  // rather than matching nothing.
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")
+    action        = "keep"
+  }
+
  rule {
     source_labels = ["__meta_docker_container_label_logs_collect"]
     regex         = "true"
@@ -36,6 +47,17 @@ loki.source.docker "docker_logs" {
 // Metrics config
 discovery.relabel "docker_metrics" {
   targets = discovery.docker.docker_containers.targets
+
+  // discovery.docker sees every container on the host, not just this
+  // project's - keep only our own so multiple Eth Docker installs on one
+  // host don't scrape/ship each other's metrics. Falls back to matching
+  // everything (today's behavior) if resolving COMPOSE_PROJECT_NAME ever
+  // fails, rather than matching nothing.
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    regex         = coalesce(sys.env("COMPOSE_PROJECT_NAME"), ".*")
+    action        = "keep"
+  }
 
   rule {
     source_labels = ["__meta_docker_container_label_metrics_scrape"]

--- a/default.env
+++ b/default.env
@@ -562,12 +562,14 @@ DDNS_TAG=v2
 NODE_EXPORTER_COLLECTOR_MOUNT_PATH=
 # For the Node Dashboard, define a regex of mount points to ignore for the diskspace check.
 NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker.+)($|/)'
+# Set true to scope Alloy collection to this install's own containers, needed for a correct Eth Docker version metric when running multiple instances on one host. false scrapes every container
+ALLOY_FILTER_BY_PROJECT_NAME=false
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd
 DOCKER_ROOT=/var/lib/docker
 # Docker socket location. Updated by ethd on Ubuntu/Debian; on macOS set to <home-dir>/.colima/default/docker.sock if using Colima
 DOCKER_SOCK=/var/run/docker.sock
-# Compose project name. Leave empty and ethd pins it to Compose's own name on first start. Set to override; keep unique per install on a host
-COMPOSE_PROJECT_NAME=
+# This install's Compose project name, resolved by ethd when ALLOY_FILTER_BY_PROJECT_NAME is true. Updated by ethd - do not set by hand
+ALLOY_PROJECT_NAME=
 
 # Used by ethd update - please do not adjust
 ENV_VERSION=62

--- a/default.env
+++ b/default.env
@@ -566,6 +566,8 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 DOCKER_ROOT=/var/lib/docker
 # Docker socket location. Updated by ethd on Ubuntu/Debian; on macOS set to <home-dir>/.colima/default/docker.sock if using Colima
 DOCKER_SOCK=/var/run/docker.sock
+# Compose project name. Leave empty and ethd pins it to Compose's own name on first start. Set to override; keep unique per install on a host
+COMPOSE_PROJECT_NAME=
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=61
+ENV_VERSION=62

--- a/ethd
+++ b/ethd
@@ -2698,6 +2698,7 @@ reset to defaults."
     echo "Please make sure to run compatible client versions."
   fi
 
+  __pin_compose_project_name
   __write_eth_docker_version_metric
 
   if [[ ! "$OSTYPE" = "darwin"* ]]; then
@@ -4324,26 +4325,61 @@ __adjust_grandine_permissions() {
 }
 
 
+# Pins COMPOSE_PROJECT_NAME in .env to whatever Compose already resolves it
+# to for this install, if it isn't already set there. This doesn't change
+# which project Compose uses - the value is read back from Compose's own
+# resolution (docker compose config), never computed independently - it just
+# makes that name available for interpolation into the alloy container's
+# environment (see grafana.yml), so config.alloy can scope Docker service
+# discovery to this instance's own containers. Without this, Alloy's
+# discovery.docker sees every container on the host's Docker socket, so
+# running multiple Eth Docker installs on one host causes each instance's
+# Alloy to also scrape/ship the others' metrics and logs.
+__pin_compose_project_name() {
+  local existing
+  local resolved
+
+  __get_value_from_env "COMPOSE_PROJECT_NAME" "${__env_file}" "existing"
+  if [[ -n "${existing}" ]]; then
+    return 0
+  fi
+
+  resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
+  if [[ -z "${resolved}" ]]; then
+    return 0
+  fi
+
+  __update_value_in_env "COMPOSE_PROJECT_NAME" "${resolved}" "${__env_file}"
+}
+
+
 # Writes the currently checked-out Eth Docker version as a node-exporter
 # textfile-collector metric (see grafana.yml), so it can be tracked the same
 # way the EL/CL client versions already are. "tag" is the latest release tag
 # reachable from HEAD rather than an exact-match, so this covers both pinned/
 # stable installs (HEAD is on a tag) and tracking "main" (HEAD is ahead of
-# the latest tag).
+# the latest tag). Writes into the same host directory node-exporter's
+# textfile collector is already mounted from (NODE_EXPORTER_COLLECTOR_MOUNT_PATH,
+# defaulting to ./.eth/node-exporter-text) - that mount is read-only inside
+# the container, so the file has to land there from the host side.
 __write_eth_docker_version_metric() {
   local tag
   local commit
+  local textfile_dir
 
   tag=$(${__as_owner} git describe --tags --abbrev=0 2>/dev/null) || tag=""
   commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
 
-  ${__as_owner} mkdir -p ./.eth
+  __get_value_from_env "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" "${__env_file}" "textfile_dir"
+  textfile_dir="${textfile_dir:-./.eth/node-exporter-text}"
+
+  ${__as_owner} mkdir -p "${textfile_dir}"
   {
     echo "# HELP eth_docker_version_info Currently checked out Eth Docker version"
     echo "# TYPE eth_docker_version_info gauge"
     echo "eth_docker_version_info{tag=\"${tag}\",commit=\"${commit}\"} 1"
-  } | ${__as_owner} tee ./.eth/eth-docker-version.prom.tmp >/dev/null
-  ${__as_owner} mv ./.eth/eth-docker-version.prom.tmp ./.eth/eth-docker-version.prom
+  } | ${__as_owner} tee "${textfile_dir}/eth-docker-version.prom.tmp" >/dev/null
+  ${__as_owner} mv "${textfile_dir}/eth-docker-version.prom.tmp" "${textfile_dir}/eth-docker-version.prom"
 }
 
 
@@ -4353,6 +4389,7 @@ upgrade() {
 
 
 start() {
+  __pin_compose_project_name
   __adjust_grandine_permissions
   __write_eth_docker_version_metric
   __docompose up -d --remove-orphans "$@"

--- a/ethd
+++ b/ethd
@@ -4355,19 +4355,20 @@ __pin_compose_project_name() {
 
 # Writes the currently checked-out Eth Docker version as a node-exporter
 # textfile-collector metric (see grafana.yml), so it can be tracked the same
-# way the EL/CL client versions already are. "tag" is the latest release tag
-# reachable from HEAD rather than an exact-match, so this covers both pinned/
-# stable installs (HEAD is on a tag) and tracking "main" (HEAD is ahead of
-# the latest tag). Writes into the same host directory node-exporter's
-# textfile collector is already mounted from (NODE_EXPORTER_COLLECTOR_MOUNT_PATH,
-# defaulting to ./.eth/node-exporter-text) - that mount is read-only inside
-# the container, so the file has to land there from the host side.
+# way the EL/CL client versions already are. "tag" comes from README.md's
+# "This is Eth Docker vX.Y.Z" line (the same source `version` reads). A
+# release commit bumps that line straight to "vX.Y.Z-dev" for the next
+# version, so this stays accurate on main between releases. Writes into
+# the same host directory node-exporter's textfile collector is already
+# mounted from (NODE_EXPORTER_COLLECTOR_MOUNT_PATH, defaulting to
+# ./.eth/node-exporter-text) - that mount is read-only inside the
+# container, so the file has to land there from the host side.
 __write_eth_docker_version_metric() {
   local tag
   local commit
   local textfile_dir
 
-  tag=$(${__as_owner} git describe --tags --abbrev=0 2>/dev/null) || tag=""
+  tag=$(grep -m1 "^This is Eth Docker v" README.md 2>/dev/null | sed -E 's/^This is Eth Docker //') || tag=""
   commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
 
   __get_value_from_env "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" "${__env_file}" "textfile_dir"

--- a/ethd
+++ b/ethd
@@ -4370,7 +4370,7 @@ __set_alloy_project_name() {
   var=ALLOY_FILTER_BY_PROJECT_NAME
   __get_value_from_env "${var}" "${__env_file}" "__value"
   if [[ "${__value}" = "true" ]]; then
-    resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
+    ALLOY_PROJECT_NAME=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || ALLOY_PROJECT_NAME=""
   else
     ALLOY_PROJECT_NAME=""
   fi

--- a/ethd
+++ b/ethd
@@ -4375,7 +4375,8 @@ __set_alloy_project_name() {
     ALLOY_PROJECT_NAME=""
   fi
 
-  __update_value_in_env "ALLOY_PROJECT_NAME" "${resolved}" "${__env_file}"
+  var=ALLOY_PROJECT_NAME
+  __update_value_in_env "${var}" "${!var}" "${__env_file}"
 }
 
 

--- a/ethd
+++ b/ethd
@@ -4361,7 +4361,7 @@ __pin_compose_project_name() {
 # version, so this stays accurate on main between releases. Writes into
 # the same host directory node-exporter's textfile collector is already
 # mounted from (NODE_EXPORTER_COLLECTOR_MOUNT_PATH, defaulting to
-# ./.eth/node-exporter-text) - that mount is read-only inside the
+# ./prometheus/node-exporter-text) - that mount is read-only inside the
 # container, so the file has to land there from the host side.
 __write_eth_docker_version_metric() {
   local tag
@@ -4372,7 +4372,7 @@ __write_eth_docker_version_metric() {
   commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
 
   __get_value_from_env "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" "${__env_file}" "textfile_dir"
-  textfile_dir="${textfile_dir:-./.eth/node-exporter-text}"
+  textfile_dir="${textfile_dir:-./prometheus/node-exporter-text}"
 
   ${__as_owner} mkdir -p "${textfile_dir}"
   {

--- a/ethd
+++ b/ethd
@@ -4339,7 +4339,7 @@ __write_eth_docker_version_metric() {
   local commit
   local textfile_dir
 
-  tag=$(grep -m1 "^This is Eth Docker v" README.md 2>/dev/null | sed -E 's/^This is Eth Docker //') || tag=""
+  tag=$(grep -m1 "^This is ${__project_name} v" README.md 2>/dev/null | sed -E "s/^This is ${__project_name} //") || tag=""
   commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
 
   __get_value_from_env "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" "${__env_file}" "textfile_dir"
@@ -4347,7 +4347,7 @@ __write_eth_docker_version_metric() {
 
   ${__as_owner} mkdir -p "${textfile_dir}"
   {
-    echo "# HELP eth_docker_version_info Currently checked out Eth Docker version"
+    echo "# HELP eth_docker_version_info Currently checked out ${__project_name} version"
     echo "# TYPE eth_docker_version_info gauge"
     echo "eth_docker_version_info{tag=\"${tag}\",commit=\"${commit}\"} 1"
   } | ${__as_owner} tee "${textfile_dir}/eth-docker-version.prom.tmp" >/dev/null
@@ -4363,11 +4363,12 @@ __write_eth_docker_version_metric() {
 # coalesces the empty value to ".*" - the scrape-all default. Runs on every
 # start so toggling ALLOY_FILTER_BY_PROJECT_NAME takes effect on the next up.
 __set_alloy_project_name() {
-  local enabled
+  local var
   local resolved
 
-  __get_value_from_env "ALLOY_FILTER_BY_PROJECT_NAME" "${__env_file}" "enabled"
-  if [[ "${enabled}" = "true" ]]; then
+  var=ALLOY_FILTER_BY_PROJECT_NAME
+  __get_value_from_env "${var}" "${__env_file}" "__value"
+  if [[ "${__value}" = "true" ]]; then
     resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
   else
     resolved=""

--- a/ethd
+++ b/ethd
@@ -4366,7 +4366,6 @@ __write_eth_docker_version_metric() {
 # start so toggling ALLOY_FILTER_BY_PROJECT_NAME takes effect on the next up.
 __set_alloy_project_name() {
   local var
-  local resolved
 
   var=ALLOY_FILTER_BY_PROJECT_NAME
   __get_value_from_env "${var}" "${__env_file}" "__value"

--- a/ethd
+++ b/ethd
@@ -2698,7 +2698,6 @@ reset to defaults."
     echo "Please make sure to run compatible client versions."
   fi
 
-  __pin_compose_project_name
   __write_eth_docker_version_metric
 
   if [[ ! "$OSTYPE" = "darwin"* ]]; then
@@ -4325,34 +4324,6 @@ __adjust_grandine_permissions() {
 }
 
 
-# Pins COMPOSE_PROJECT_NAME in .env to whatever Compose already resolves it
-# to for this install, if it isn't already set there. This doesn't change
-# which project Compose uses - the value is read back from Compose's own
-# resolution (docker compose config), never computed independently - it just
-# makes that name available for interpolation into the alloy container's
-# environment (see grafana.yml), so config.alloy can scope Docker service
-# discovery to this instance's own containers. Without this, Alloy's
-# discovery.docker sees every container on the host's Docker socket, so
-# running multiple Eth Docker installs on one host causes each instance's
-# Alloy to also scrape/ship the others' metrics and logs.
-__pin_compose_project_name() {
-  local existing
-  local resolved
-
-  __get_value_from_env "COMPOSE_PROJECT_NAME" "${__env_file}" "existing"
-  if [[ -n "${existing}" ]]; then
-    return 0
-  fi
-
-  resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
-  if [[ -z "${resolved}" ]]; then
-    return 0
-  fi
-
-  __update_value_in_env "COMPOSE_PROJECT_NAME" "${resolved}" "${__env_file}"
-}
-
-
 # Writes the currently checked-out Eth Docker version as a node-exporter
 # textfile-collector metric (see grafana.yml), so it can be tracked the same
 # way the EL/CL client versions already are. "tag" comes from README.md's
@@ -4384,15 +4355,36 @@ __write_eth_docker_version_metric() {
 }
 
 
+# Sets ALLOY_PROJECT_NAME in .env so config.alloy can scope Alloy's Docker
+# service discovery to this install's own containers (see grafana.yml). When
+# ALLOY_FILTER_BY_PROJECT_NAME is true, the name is read back from Compose's
+# own resolution (docker compose config), never computed independently and
+# never written to COMPOSE_PROJECT_NAME. Otherwise it is cleared, and Alloy
+# coalesces the empty value to ".*" - the scrape-all default. Runs on every
+# start so toggling ALLOY_FILTER_BY_PROJECT_NAME takes effect on the next up.
+__set_alloy_project_name() {
+  local enabled
+  local resolved
+
+  __get_value_from_env "ALLOY_FILTER_BY_PROJECT_NAME" "${__env_file}" "enabled"
+  if [[ "${enabled}" = "true" ]]; then
+    resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
+  else
+    resolved=""
+  fi
+
+  __update_value_in_env "ALLOY_PROJECT_NAME" "${resolved}" "${__env_file}"
+}
+
+
 upgrade() {
   update
 }
 
 
 start() {
-  __pin_compose_project_name
+  __set_alloy_project_name
   __adjust_grandine_permissions
-  __write_eth_docker_version_metric
   __docompose up -d --remove-orphans "$@"
 }
 

--- a/ethd
+++ b/ethd
@@ -4337,13 +4337,15 @@ __adjust_grandine_permissions() {
 __write_eth_docker_version_metric() {
   local tag
   local commit
+  local var
   local textfile_dir
 
   tag=$(grep -m1 "^This is ${__project_name} v" README.md 2>/dev/null | sed -E "s/^This is ${__project_name} //") || tag=""
   commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
 
-  __get_value_from_env "NODE_EXPORTER_COLLECTOR_MOUNT_PATH" "${__env_file}" "textfile_dir"
-  textfile_dir="${textfile_dir:-./prometheus/node-exporter-text}"
+  var=NODE_EXPORTER_COLLECTOR_MOUNT_PATH
+  __get_value_from_env "${var}" "${__env_file}" "__value"
+  textfile_dir="${__value:-./prometheus/node-exporter-text}"
 
   ${__as_owner} mkdir -p "${textfile_dir}"
   {

--- a/ethd
+++ b/ethd
@@ -2698,6 +2698,8 @@ reset to defaults."
     echo "Please make sure to run compatible client versions."
   fi
 
+  __write_eth_docker_version_metric
+
   if [[ ! "$OSTYPE" = "darwin"* ]]; then
 # Release lock and remove lock file
     exec 200<&-
@@ -4322,6 +4324,29 @@ __adjust_grandine_permissions() {
 }
 
 
+# Writes the currently checked-out Eth Docker version as a node-exporter
+# textfile-collector metric (see grafana.yml), so it can be tracked the same
+# way the EL/CL client versions already are. "tag" is the latest release tag
+# reachable from HEAD rather than an exact-match, so this covers both pinned/
+# stable installs (HEAD is on a tag) and tracking "main" (HEAD is ahead of
+# the latest tag).
+__write_eth_docker_version_metric() {
+  local tag
+  local commit
+
+  tag=$(${__as_owner} git describe --tags --abbrev=0 2>/dev/null) || tag=""
+  commit=$(${__as_owner} git rev-parse --short HEAD 2>/dev/null) || commit=""
+
+  ${__as_owner} mkdir -p ./.eth
+  {
+    echo "# HELP eth_docker_version_info Currently checked out Eth Docker version"
+    echo "# TYPE eth_docker_version_info gauge"
+    echo "eth_docker_version_info{tag=\"${tag}\",commit=\"${commit}\"} 1"
+  } | ${__as_owner} tee ./.eth/eth-docker-version.prom.tmp >/dev/null
+  ${__as_owner} mv ./.eth/eth-docker-version.prom.tmp ./.eth/eth-docker-version.prom
+}
+
+
 upgrade() {
   update
 }
@@ -4329,6 +4354,7 @@ upgrade() {
 
 start() {
   __adjust_grandine_permissions
+  __write_eth_docker_version_metric
   __docompose up -d --remove-orphans "$@"
 }
 

--- a/ethd
+++ b/ethd
@@ -4372,7 +4372,7 @@ __set_alloy_project_name() {
   if [[ "${__value}" = "true" ]]; then
     resolved=$(__docompose config 2>/dev/null | awk -F': ' '/^name:/{print $2; exit}') || resolved=""
   else
-    resolved=""
+    ALLOY_PROJECT_NAME=""
   fi
 
   __update_value_in_env "ALLOY_PROJECT_NAME" "${resolved}" "${__env_file}"

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -121,7 +121,7 @@ services:
     image: grafana/alloy:latest
     restart: unless-stopped
     environment:
-      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
+      - ALLOY_PROJECT_NAME=${ALLOY_PROJECT_NAME:-}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -52,7 +52,7 @@ services:
       - /sys:/host/sys:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./.eth/node-exporter-text}:/tmp/text-collector:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./prometheus/node-exporter-text}:/tmp/text-collector:ro
     <<: *logging
     labels:
       - metrics.scrape=true

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -53,6 +53,7 @@ services:
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
       - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
+      - ./.eth/eth-docker-version.prom:/tmp/text-collector/eth-docker-version.prom:ro
     <<: *logging
     labels:
       - metrics.scrape=true

--- a/grafana-cloud.yml
+++ b/grafana-cloud.yml
@@ -52,8 +52,7 @@ services:
       - /sys:/host/sys:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
-      - ./.eth/eth-docker-version.prom:/tmp/text-collector/eth-docker-version.prom:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./.eth/node-exporter-text}:/tmp/text-collector:ro
     <<: *logging
     labels:
       - metrics.scrape=true
@@ -121,6 +120,8 @@ services:
   alloy:
     image: grafana/alloy:latest
     restart: unless-stopped
+    environment:
+      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -94,6 +94,8 @@ services:
   alloy:
     image: grafana/alloy:latest
     restart: unless-stopped
+    environment:
+      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana-rootless.yml
+++ b/grafana-rootless.yml
@@ -95,7 +95,7 @@ services:
     image: grafana/alloy:latest
     restart: unless-stopped
     environment:
-      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
+      - ALLOY_PROJECT_NAME=${ALLOY_PROJECT_NAME:-}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana.yml
+++ b/grafana.yml
@@ -75,7 +75,7 @@ services:
       - /sys:/host/sys:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./.eth/node-exporter-text}:/tmp/text-collector:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./prometheus/node-exporter-text}:/tmp/text-collector:ro
     command:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'

--- a/grafana.yml
+++ b/grafana.yml
@@ -152,7 +152,7 @@ services:
     image: grafana/alloy:latest
     restart: unless-stopped
     environment:
-      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
+      - ALLOY_PROJECT_NAME=${ALLOY_PROJECT_NAME:-}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana.yml
+++ b/grafana.yml
@@ -75,8 +75,7 @@ services:
       - /sys:/host/sys:ro,rslave
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
-      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
-      - ./.eth/eth-docker-version.prom:/tmp/text-collector/eth-docker-version.prom:ro
+      - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-./.eth/node-exporter-text}:/tmp/text-collector:ro
     command:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
@@ -152,6 +151,8 @@ services:
   alloy:
     image: grafana/alloy:latest
     restart: unless-stopped
+    environment:
+      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
     volumes:
       - alloy-data:/var/lib/alloy
       - ./alloy:/etc/alloy

--- a/grafana.yml
+++ b/grafana.yml
@@ -76,6 +76,7 @@ services:
       - /etc/hostname:/etc/nodename:ro
       - /etc/localtime:/etc/localtime:ro
       - ${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/tmp/dummy-nodeexp-text}:/tmp/text-collector:ro
+      - ./.eth/eth-docker-version.prom:/tmp/text-collector/eth-docker-version.prom:ro
     command:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'

--- a/prometheus/.gitignore
+++ b/prometheus/.gitignore
@@ -2,3 +2,5 @@
 prometheus.yml
 custom-prom.yml
 conf.d
+# node-exporter textfile-collector metrics written by ethd
+node-exporter-text


### PR DESCRIPTION
**What I did**
Scrape eth-docker version so it can be tracked along with EL and CL versions

**Motivation**
When managing a significant number of nodes it can be easy to lose track of what needs to be updated. When creating Grafana dashboards it would be nice to have access to the eth-docker version to spot any instances that are behind others. Releases can require migration steps, and being able to see all your eth-docker versions on a dashboard is useful information.

**Changes**
For the scraping: `ethd` now writes the checked-out tag (via `git describe --tags --abbrev=0`, so it still resolves to the latest release tag even when tracking `main` rather than a pinned release) and commit as an `eth_docker_version_info{tag="...",commit="..."}` gauge, through node-exporter's existing-but-unused textfile collector. `NODE_EXPORTER_COLLECTOR_MOUNT_PATH`'s default now points at a real, eth-docker-managed directory instead of an inert placeholder, so this works with no `.env` changes required.

After implementing scraping, testing with multiple eth-docker instances on one host surfaced an existing issue: Alloy's `discovery.docker` reads the host Docker socket, so it discovers every container on the host, not just its own project's. Most foreign containers are still unreachable (different Docker network) so this was harmless - except node-exporter, which runs with `network_mode: host` and a `metrics.host=host.docker.internal` label specifically so Alloy can reach it cross-network. That same override makes it reachable from *every* instance's Alloy, so each instance's Prometheus ends up storing all instances' node-exporter metrics, correctly labeled but mixed together - which caused two different `eth_docker_version_info` series.

To fix this: `ethd` now pins `COMPOSE_PROJECT_NAME` in `.env` to whatever Compose already resolves it to (read back from `docker compose config`, never computed independently), and `config.alloy` scopes both metrics and logs discovery to containers in this instance's own project - falling back to today's unscoped behavior if that resolution ever fails, rather than discovering nothing. This fixes cross-instance bleed for every metric and log, not just the new one.

