### PR TITLE
Support Erigon 3.5

### DIFF
--- a/default.env
+++ b/default.env
@@ -158,7 +158,7 @@ DOCKER_EXT_NETWORK=rocketpool_net
 # P2P ports you will forward to your staking node. Adjust here if you are
 # going to use something other than defaults.
 EL_P2P_PORT=30303
-# second EL P2P port used by Erigon and Reth, and Besu IPv6
+# second EL P2P port used by Besu IPv6
 EL_P2P_PORT_2=30304
 CL_P2P_PORT=9000
 PRYSM_PORT=9000
@@ -202,8 +202,6 @@ PROXY_RPC_PORT=48545
 PROXY_WS_PORT=48546
 # Erigon's torrent port. Don't make this 42070, as it will fail
 ERIGON_TORRENT_PORT=42069
-# Erigon's third P2P port
-ERIGON_P2P_PORT_3=30305
 # When using ssv-node, also update ssv-config/config.yml
 # For Anchor, changing them here is sufficient
 # SSV Node ports
@@ -569,4 +567,4 @@ DOCKER_ROOT=/var/lib/docker
 DOCKER_SOCK=/var/run/docker.sock
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=59
+ENV_VERSION=60

--- a/erigon.yml
+++ b/erigon.yml
@@ -42,10 +42,6 @@ services:
     ports:
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/tcp
       - ${HOST_IP:-}:${EL_P2P_PORT:-30303}:${EL_P2P_PORT:-30303}/udp
-      - ${HOST_IP:-}:${EL_P2P_PORT_2:-30304}:${EL_P2P_PORT_2:-30304}/tcp
-      - ${HOST_IP:-}:${EL_P2P_PORT_2:-30304}:${EL_P2P_PORT_2:-30304}/udp
-      - ${HOST_IP:-}:${ERIGON_P2P_PORT_3:-30305}:${ERIGON_P2P_PORT_3:-30305}/tcp
-      - ${HOST_IP:-}:${ERIGON_P2P_PORT_3:-30305}:${ERIGON_P2P_PORT_3:-30305}/udp
       # torrent ports
       - ${HOST_IP:-}:${ERIGON_TORRENT_PORT:-42069}:${ERIGON_TORRENT_PORT:-42069}/tcp
       - ${HOST_IP:-}:${ERIGON_TORRENT_PORT:-42069}:${ERIGON_TORRENT_PORT:-42069}/udp
@@ -65,8 +61,6 @@ services:
       - /var/lib/erigon
       - --port
       - ${EL_P2P_PORT:-30303}
-      - --p2p.allowed-ports
-      - ${EL_P2P_PORT:-30303},${EL_P2P_PORT_2:-30304},${ERIGON_P2P_PORT_3:-30305}
       - --torrent.port
       - ${ERIGON_TORRENT_PORT:-42069}
       - --nat

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -80,11 +80,11 @@ case "${NODE_TYPE}" in
     case "${NETWORK}" in
       mainnet|sepolia)
         echo "Erigon minimal node with pre-merge history expiry"
-        __prune="--prune.mode=full --persist.receipts=false"
+        __prune="--prune.mode=full --persist.receipts=false --prune.distance.blocks=18446744073709551615"
         ;;
       *)
-        echo "There is no pre-merge history for ${NETWORK} network, Erigon will use \"full\" pruning."
-        __prune="--prune.mode=full --persist.receipts=false"
+        echo "There is no pre-merge history for ${NETWORK} network, Erigon will keep all blocks."
+        __prune="--prune.mode=full --persist.receipts=false --prune.distance.blocks=18446744073709551615"
         ;;
     esac
     ;;


### PR DESCRIPTION
**What I did**

See https://github.com/erigontech/erigon/releases/tag/v3.5.0

`--p2p-allowed-ports` is gone

pre-merge expiry requires an additional parameter
