### PR TITLE
Do not source build prysmctl

### DIFF
--- a/prysm/Dockerfile.source
+++ b/prysm/Dockerfile.source
@@ -38,7 +38,6 @@ RUN bash -eo pipefail <<'EOF'
   fi
   bazel build --config=release //cmd/beacon-chain:beacon-chain
   bazel build --config=release //cmd/validator:validator
-  bazel build --config=release //cmd/prysmctl:prysmctl
   bazel build --config=release //cmd/client-stats:client-stats
 EOF
 


### PR DESCRIPTION
**What I did**

`prysmctl` is only used for the legacy validator exit path, and always taken from Prysm's docker image. Do not build it in `Dockerfile.source`
