### PR TITLE
Support Teku QUIC port

### DIFF
--- a/default.env
+++ b/default.env
@@ -164,8 +164,9 @@ CL_P2P_PORT=9000
 PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000
 CL_QUIC_PORT=9001
-# Teku needs a separate port for IPv6
+# Teku needs separate ports for IPv6
 CL_IPV6_P2P_PORT=9010
+CL_IPV6_QUIC_PORT=9011
 # Local grafana dashboard port. Do not expose to Internet, it is insecure http
 GRAFANA_PORT=3000
 # Local Siren UI port
@@ -567,4 +568,4 @@ DOCKER_ROOT=/var/lib/docker
 DOCKER_SOCK=/var/run/docker.sock
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=60
+ENV_VERSION=61

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -59,12 +59,15 @@ services:
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9090}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/udp
+      - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:
@@ -82,6 +85,7 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
+      - --p2p-quic-port=${CL_QUIC_PORT:-9001}
       - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
       - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --validator-keys=/var/lib/teku/validator-keys:/var/lib/teku/validator-passwords

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -47,12 +47,15 @@ services:
       - WEB3SIGNER=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9090}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/udp
+      - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:
@@ -70,6 +73,7 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
+      - --p2p-quic-port=${CL_QUIC_PORT:-9001}
       - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
       - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --logging=${LOG_LEVEL}

--- a/teku.yml
+++ b/teku.yml
@@ -56,12 +56,15 @@ services:
       - EMBEDDED_VC=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9090}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9090}:${CL_IPV6_P2P_PORT:-9090}/udp
+      - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:
@@ -79,6 +82,7 @@ services:
       - /var/lib/teku/ee-secret/jwtsecret
       - --eth1-deposit-contract-max-request-size=1000
       - --p2p-port=${CL_P2P_PORT:-9000}
+      - --p2p-quic-port=${CL_QUIC_PORT:-9001}
       - ${CL_MAX_PEER_COUNT:+--p2p-peer-upper-bound=${CL_MAX_PEER_COUNT}}
       - ${CL_MIN_PEER_COUNT:+--p2p-peer-lower-bound=${CL_MIN_PEER_COUNT}}
       - --logging=${LOG_LEVEL}

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -191,7 +191,7 @@ fi
 
 if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Teku to listen on IPv6 ports"
-  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_IPV6_P2P_PORT:-9090}"
+  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_IPV6_P2P_PORT:-9010} --p2p-quic-port-ipv6 ${CL_IPV6_QUIC_PORT:-9011}"
 else
   __ipv6=""
 fi


### PR DESCRIPTION
**What I did**

Teku `v26.7.0` adds support for QUIC protocol. Support that in Eth Docker.
