### PR TITLE
Fix CL node health check

### DIFF
--- a/ethdo/docker-entrypoint.sh
+++ b/ethdo/docker-entrypoint.sh
@@ -85,7 +85,7 @@ if [[ "$*" =~ "--offline" ]]; then
 else
   nodes=$(echo "${CL_NODE}" | tr ',' ' ')
   for node in ${nodes}; do
-    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}/eth/v1/node/health" | grep -q "^[23]"; then
       node_reachable=1
       break
     fi

--- a/lighthouse/validator-exit.sh
+++ b/lighthouse/validator-exit.sh
@@ -11,7 +11,7 @@ fi
 
 nodes=$(echo "${CL_NODE}" | tr ',' ' ')
 for node in ${nodes}; do
-  if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+  if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}/eth/v1/node/health" | grep -q "^[23]"; then
     node_reachable=1
     break
   fi

--- a/nimbus-vp/docker-entrypoint.sh
+++ b/nimbus-vp/docker-entrypoint.sh
@@ -22,7 +22,7 @@ done
 
 while true; do
   for node in ${nodes}; do
-    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}/eth/v1/node/health" | grep -q "^[23]"; then
       echo "Consensus Layer node is up, fetching trusted block root"
       break 2
     fi

--- a/vc-utils/keymanager.sh
+++ b/vc-utils/keymanager.sh
@@ -102,7 +102,7 @@ __call_cl_api() {
 
   nodes=$(echo "${CL_NODE}" | tr ',' ' ')
   for node in ${nodes}; do
-    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}/eth/v1/node/health" | grep -q "^[23]"; then
       node_reachable=1
       break
     fi
@@ -656,7 +656,7 @@ validator-count() {
 
   nodes=$(echo "${CL_NODE}" | tr ',' ' ')
   for node in ${nodes}; do
-    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}" | grep -q "^[23]"; then
+    if curl -s -m 5 -o /dev/null -w "%{http_code}" "${node}/eth/v1/node/health" | grep -q "^[23]"; then
       node_reachable=1
       break
     fi


### PR DESCRIPTION
**What I did**

Bug introduced in `v26.7.0` fixed - the original check would always return `404`
