### PR TITLE
Nimbus resync works when not using checkpoint sync

### DIFF
--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -113,7 +113,7 @@ services:
     command:
       - |
         rm -rf /var/lib/nimbus/db/*
-        rm /var/lib/nimbus/setupdone
+        rm -f /var/lib/nimbus/setupdone
 
   validator-exit:
     profiles: ["tools"]


### PR DESCRIPTION
**What I did**

`ethd resync-consensus` with `nimbus-allin1.yml` works when not using checkpoint sync
