### PR TITLE
Use correct syntax for Nimbus EL custom networks

### DIFF
--- a/nimbus-el/Dockerfile-unified.binary
+++ b/nimbus-el/Dockerfile-unified.binary
@@ -17,6 +17,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   gosu \
   adduser \
   bash \
+  git \
+  git-lfs \
   curl \
   aria2 \
   && gosu nobody true \

--- a/nimbus-el/Dockerfile-unified.source
+++ b/nimbus-el/Dockerfile-unified.source
@@ -46,6 +46,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   gosu \
   adduser \
   bash \
+  git \
+  git-lfs \
   curl \
   aria2 \
   && gosu nobody true \

--- a/nimbus-el/Dockerfile.binary
+++ b/nimbus-el/Dockerfile.binary
@@ -17,6 +17,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   gosu \
   adduser \
   bash \
+  git \
+  git-lfs \
   curl \
   aria2 \
   && gosu nobody true \

--- a/nimbus-el/Dockerfile.source
+++ b/nimbus-el/Dockerfile.source
@@ -46,6 +46,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   gosu \
   adduser \
   bash \
+  git \
+  git-lfs \
   curl \
   aria2 \
   && gosu nobody true \

--- a/nimbus-el/docker-entrypoint-unified.sh
+++ b/nimbus-el/docker-entrypoint-unified.sh
@@ -151,7 +151,6 @@ case "${CL_NODE_TYPE}" in
     ;;
 esac
 
-# TODO - adjust for CL and EL bootnodes and network, currently not possible bcs both use the same paraneter names
 if [[ "${NETWORK}" =~ ^https?:// ]]; then
   echo "Custom testnet at ${NETWORK}"
   repo=$(awk -F'/tree/' '{print $1}' <<< "${NETWORK}")
@@ -169,10 +168,12 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 {print $2}' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml" | paste -sd ",")"
-  networkid="$(jq -r '.config.chainId' "/var/lib/nimbus/testnet/${config_dir}/genesis.json")"
+  el_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml")"
+  cl_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/bootstrap_nodes.yaml")"
+  #networkid="$(jq -r '.config.chainId' "/var/lib/nimbus/testnet/${config_dir}/genesis.json")"
   set +e
-  __network="--bootstrap-node=${bootnodes} --network=${networkid} --network=/var/lib/nimbus/testnet/${config_dir}"
+  __network="--bootstrap-node=${cl_bootnodes} --el-bootstrap-node=${el_bootnodes} --network=/var/lib/nimbus/testnet/${config_dir}"
+  # --network=${networkid}
 else
   __network="--network=${NETWORK}"
 fi

--- a/nimbus-el/docker-entrypoint.sh
+++ b/nimbus-el/docker-entrypoint.sh
@@ -169,10 +169,11 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 {print $2}' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml" | paste -sd ",")"
-  networkid="$(jq -r '.config.chainId' "/var/lib/nimbus/testnet/${config_dir}/genesis.json")"
+  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml")"
+  #networkid="$(jq -r '.config.chainId' "/var/lib/nimbus/testnet/${config_dir}/genesis.json")"
   set +e
-  __network="--bootstrap-node=${bootnodes} --network=${networkid} --custom-network /var/lib/nimbus/testnet/${config_dir}/genesis.json"
+  __network="--bootstrap-node=${bootnodes} --network=/var/lib/nimbus/testnet/${config_dir}/genesis.json"
+  # --network=${networkid}
 else
   __network="--network=${NETWORK}"
 fi


### PR DESCRIPTION
**What I did**

Nimbus EL custom path uses `--network`. If `--custom-network` was correct in a previous version, it no longer is

Correct parsing of bootnodes to allow trailing comments, see https://github.com/eth-clients/sepolia/blob/main/metadata/enodes.yaml
