### PR TITLE
Nimbus VP restarts friendlier

### DIFF
--- a/nimbus-vp/docker-entrypoint.sh
+++ b/nimbus-vp/docker-entrypoint.sh
@@ -65,7 +65,8 @@ while true; do
        sleep 10
        ((secs -= 10)) || true  # To protect against "falsy" evaluation when secs==10, in some version of bash
       done
-      exit 1
+      echo "Restarting"
+      exit 0
     else
       echo "Waiting for Consensus Layer node to have light client bootstrap data..."
       sleep 5


### PR DESCRIPTION
**What I did**

When Nimbus VP needs to restart to get a fresh block root, it prints `Restarting` and does an `exit 0` instead of `exit 1`
