### PR TITLE
Nimbus archive node improvements

### DIFF
--- a/default.env
+++ b/default.env
@@ -286,6 +286,9 @@ NETHERMIND_FLATDB=
 # If this URL is provided, an EL that supports EraE import will use it when fresh syncing
 # "urls.txt", "checksums.txt" and "checksums_sha256.txt" must exist at the target url
 ERE_URL=
+# EraC URL, see https://ethresear.ch/t/era-archival-files-for-block-and-consensus-data/13526
+# If this URL is provided, a CL that supports EraC import will use it when fresh syncing
+ERC_URL=
 
 # If you want debug logs, set this to debug instead of info
 LOG_LEVEL=info
@@ -579,4 +582,4 @@ DOCKER_SOCK=/var/run/docker.sock
 ALLOY_PROJECT_NAME=
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=63
+ENV_VERSION=64

--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -43,6 +43,7 @@ services:
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
+      - ERC_URL=${ERC_URL:-}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
@@ -51,7 +52,7 @@ services:
       - DOPPELGANGER=${DOPPELGANGER}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=${VC_EXTRAS:-}
-      - NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - CL_NODE_TYPE=${CL_NODE_TYPE:-pruned}
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
       - WEB3SIGNER=${WEB3SIGNER:-false}

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -33,6 +33,7 @@ services:
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
+      - ERC_URL=${ERC_URL:-}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
@@ -41,7 +42,7 @@ services:
       - DOPPELGANGER=false
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=
-      - NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - CL_NODE_TYPE=${CL_NODE_TYPE:-pruned}
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=true
       - WEB3SIGNER=false

--- a/nimbus-el/docker-entrypoint-unified.sh
+++ b/nimbus-el/docker-entrypoint-unified.sh
@@ -46,7 +46,7 @@ __download_ere_files() {
   download_dir="$2"
 
   mkdir -p "${download_dir}"
-  cd "${download_dir}" || { echo "Could not change directory to ${download_dir}. This is a bug."; exit 70; }
+  pushd "${download_dir}" > /dev/null || { echo "Could not change directory to ${download_dir}. This is a bug."; exit 70; }
 
   # 🔧 Normalize base URL (handle trailing slash)
   case "${download_url}" in
@@ -54,7 +54,7 @@ __download_ere_files() {
     *)            base_url="${download_url}" ;;
   esac
 
-  curl -sS -O "${base_url}/urls.txt"
+  curl -fsS -O "${base_url}/urls.txt"
   total_files=$(wc -l < urls.txt)
   aria2c -x 8 -j 5 -c -i urls.txt \
     --dir="." \
@@ -87,9 +87,93 @@ __download_ere_files() {
   echo "✅ All files downloaded to: ${download_dir}"
 
   echo "Verifying checksums"
-  curl -sS -O "${base_url}/checksums_sha256.txt"
+  curl -fsS -O "${base_url}/checksums_sha256.txt"
   sha256sum -c checksums_sha256.txt --ignore-missing
   echo "✅ All checksums verified"
+
+  popd > /dev/null
+}
+
+
+__download_erc_files() {
+# Copyright (c) 2025 Status Research & Development GmbH and 2026 Eth Docker maintainers.
+# Licensed under either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# Usage: __download_erc_files <download_url> <download_path>
+
+  local download_url
+  local download_dir
+  local base_url
+  local completed
+  local percent
+  local total_files
+  local aria_pid
+
+  if [[ $# -ne 2 ]]; then
+    echo "__download_erc_files called without <download_url> <download_path>. This is a bug."
+    exit 70
+  fi
+
+  download_url="$1"
+  download_dir="$2"
+
+  mkdir -p "${download_dir}"
+  pushd "${download_dir}" > /dev/null || { echo "Could not change directory to ${download_dir}. This is a bug."; exit 70; }
+
+  # 🔧 Normalize base URL (handle trailing slash)
+  case "${download_url}" in
+    */)           base_url="${download_url%/}" ;;
+    *)            base_url="${download_url}" ;;
+  esac
+
+  curl -fsS "${base_url}/" | sed -n 's/.*href="\([^"]*\.\(era\|erc\)\)".*/\1/p' > erc_files.txt
+  total_files=$(wc -l < erc_files.txt)
+  sed -i "s|^|${base_url}/|" erc_files.txt
+  aria2c -x 8 -j 5 -c -i erc_files.txt \
+    --dir="." \
+    --console-log-level=warn \
+    --quiet=true \
+    --summary-interval=0 \
+    --continue=true \
+    > /dev/null 2>&1 &
+
+  aria_pid=$!
+
+  echo "Downloading EraC history files"
+  echo "📥 Starting download of ${total_files} files..."
+  while kill -0 "${aria_pid}" 2> /dev/null; do
+    completed=$(find . -type f \( -name '*.era' -o -name '*.erc' \) | wc -l)
+    percent=$(awk "BEGIN { printf \"%.1f\", (${completed}/${total_files})*100 }")
+    echo "📦 Download Progress: ${percent}% complete (${completed} / ${total_files} files)"
+    sleep 10
+  done
+
+  wait "${aria_pid}" && exitstatus=0 || exitstatus=$?
+  if [[ "${exitstatus}" -ne 0 ]]; then
+    echo "EraC download failed with exit code ${exitstatus}"
+    exit "${exitstatus}"
+  fi
+
+  completed=$(find . -type f \( -name '*.era' -o -name '*.erc' \) | wc -l)
+  echo "📦 Download Progress: 100% complete (${completed} / ${total_files} files)"
+
+  echo "✅ All files downloaded to: ${download_dir}"
+
+  rm -f erc_files.txt
+
+  echo "Verifying checksums"
+  if curl -fsS -O "${base_url}/checksums_sha256.txt" 2>/dev/null; then
+    sha256sum -c checksums_sha256.txt --ignore-missing
+    echo "✅ All checksums verified"
+  else
+    echo "No checksums file available, skipping verification"
+  fi
+
+  popd > /dev/null
 }
 
 
@@ -133,7 +217,7 @@ case "${EL_NODE_TYPE}" in
 esac
 
 case "${CL_NODE_TYPE}" in
-  archive)
+  archive|blob-archive)
     echo "Nimbus Unified archive consensus node without history pruning"
     __prune+=" --history=archive --reindex"
     ;;
@@ -197,11 +281,15 @@ if [[ -n "${ERE_URL}" && ! -f /var/lib/nimbus/ere-import-complete && ! "${NETWOR
 fi
 
 if [[ -n "${CHECKPOINT_SYNC_URL}" && ! -f /var/lib/nimbus/setupdone ]]; then
-  if [[ "${CL_NODE_TYPE}" = "archive" ]]; then
-    echo "Starting checkpoint sync with backfill and archive reindex. Nimbus will restart when done."
-# Word splitting is desired for the command line parameters
+  if [[ "${CL_NODE_TYPE}" =~ ^(archive|blob-archive)$ ]]; then
+    if [[ -z "${ERC_URL}" ]]; then
+      echo "Nimbus cannot build an archive node from only a checkpoint sync. Attempting to sync from genesis"
+      echo "It'd be much better to also use \"ERC_URL\" to download EraC files"
+    else
+      echo "Starting Checkpoint sync. EraC files will be downloaded next."
 # shellcheck disable=SC2086
-    nimbus trustedNodeSync --backfill=true --reindex ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
+      nimbus trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
+    fi
     touch /var/lib/nimbus/setupdone
   else
     echo "Starting checkpoint sync. Nimbus will restart when done."
@@ -209,6 +297,27 @@ if [[ -n "${CHECKPOINT_SYNC_URL}" && ! -f /var/lib/nimbus/setupdone ]]; then
 # shellcheck disable=SC2086
     nimbus trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
     touch /var/lib/nimbus/setupdone
+  fi
+fi
+
+__erc_dir=""
+if [[ -n "${ERC_URL}" && ! "${NETWORK}" =~ ^https?:// ]]; then  # Named network
+  if [[ "${CL_NODE_TYPE}" =~ ^(archive|blob-archive)$ ]]; then
+    if [[ ! -f /var/lib/nimbus/erc-download-complete ]]; then
+      if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
+        echo "Starting EraC history file download from ${ERC_URL}"
+        __download_erc_files "${ERC_URL}" /var/lib/nimbus/erc
+        touch /var/lib/nimbus/erc-download-complete
+      else
+        echo "You have EraC files with \"ERC_URL\" but are also genesis syncing. Skipping EraC download."
+        echo "You can specify a \"CHECKPOINT_SYNC_URL\" and resync."
+      fi
+    fi
+    if [[ -f /var/lib/nimbus/erc-download-complete ]]; then
+      __erc_dir="--era-dir=/var/lib/nimbus/erc"
+    fi
+  else
+    echo "Nimbus is not an archive node, it uses ${CL_NODE_TYPE}. Skipping EraC download."
   fi
 fi
 
@@ -225,4 +334,4 @@ set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__prune} ${__mev_boost} ${__network} ${EL_EXTRAS} ${CL_EXTRAS}
+exec "$@" ${__prune} ${__mev_boost} ${__network} ${__erc_dir} ${EL_EXTRAS} ${CL_EXTRAS}

--- a/nimbus-unified.yml
+++ b/nimbus-unified.yml
@@ -32,6 +32,7 @@ services:
       - NETWORK=${NETWORK}
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
       - ERE_URL=${ERE_URL:-}
+      - ERC_URL=${ERC_URL:-}
     volumes:
       - nimbus-unified-data:/var/lib/nimbus
       - /etc/localtime:/etc/localtime:ro

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -33,6 +33,7 @@ services:
       - jwtsecret:/var/lib/nimbus/ee-secret
     environment:
       - CHECKPOINT_SYNC_URL=${CHECKPOINT_SYNC_URL}
+      - ERC_URL=${ERC_URL:-}
       - NETWORK=${NETWORK}
       - JWT_SECRET=${JWT_SECRET}
       - MEV_BOOST=${MEV_BOOST}
@@ -41,7 +42,7 @@ services:
       - DOPPELGANGER=false
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=
-      - NODE_TYPE=${CL_NODE_TYPE:-pruned}
+      - CL_NODE_TYPE=${CL_NODE_TYPE:-pruned}
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=true
       - WEB3SIGNER=false

--- a/nimbus/Dockerfile.binary
+++ b/nimbus/Dockerfile.binary
@@ -24,6 +24,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   git \
   git-lfs \
   curl \
+  aria2 \
   && gosu nobody true \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/nimbus/Dockerfile.source
+++ b/nimbus/Dockerfile.source
@@ -54,6 +54,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   git \
   git-lfs \
   curl \
+  aria2 \
   && gosu nobody true \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/nimbus/Dockerfile.sourcegnosis
+++ b/nimbus/Dockerfile.sourcegnosis
@@ -54,6 +54,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   git \
   git-lfs \
   curl \
+  aria2 \
   && gosu nobody true \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -28,6 +28,88 @@ __normalize_int() {
 }
 
 
+__download_erc_files() {
+# Copyright (c) 2025 Status Research & Development GmbH and 2026 Eth Docker maintainers.
+# Licensed under either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# Usage: __download_erc_files <download_url> <download_path>
+
+  local download_url
+  local download_dir
+  local base_url
+  local completed
+  local percent
+  local total_files
+  local aria_pid
+
+  if [[ $# -ne 2 ]]; then
+    echo "__download_erc_files called without <download_url> <download_path>. This is a bug."
+    exit 70
+  fi
+
+  download_url="$1"
+  download_dir="$2"
+
+  mkdir -p "${download_dir}"
+  pushd "${download_dir}" > /dev/null || { echo "Could not change directory to ${download_dir}. This is a bug."; exit 70; }
+
+  # 🔧 Normalize base URL (handle trailing slash)
+  case "${download_url}" in
+    */)           base_url="${download_url%/}" ;;
+    *)            base_url="${download_url}" ;;
+  esac
+
+  curl -fsS "${base_url}/" | sed -n 's/.*href="\([^"]*\.\(era\|erc\)\)".*/\1/p' > erc_files.txt
+  total_files=$(wc -l < erc_files.txt)
+  sed -i "s|^|${base_url}/|" erc_files.txt
+  aria2c -x 8 -j 5 -c -i erc_files.txt \
+    --dir="." \
+    --console-log-level=warn \
+    --quiet=true \
+    --summary-interval=0 \
+    --continue=true \
+    > /dev/null 2>&1 &
+
+  aria_pid=$!
+
+  echo "Downloading EraC history files"
+  echo "📥 Starting download of ${total_files} files..."
+  while kill -0 "${aria_pid}" 2> /dev/null; do
+    completed=$(find . -type f \( -name '*.era' -o -name '*.erc' \) | wc -l)
+    percent=$(awk "BEGIN { printf \"%.1f\", (${completed}/${total_files})*100 }")
+    echo "📦 Download Progress: ${percent}% complete (${completed} / ${total_files} files)"
+    sleep 10
+  done
+
+  wait "${aria_pid}" && exitstatus=0 || exitstatus=$?
+  if [[ "${exitstatus}" -ne 0 ]]; then
+    echo "EraC download failed with exit code ${exitstatus}"
+    exit "${exitstatus}"
+  fi
+
+  completed=$(find . -type f \( -name '*.era' -o -name '*.erc' \) | wc -l)
+  echo "📦 Download Progress: 100% complete (${completed} / ${total_files} files)"
+
+  echo "✅ All files downloaded to: ${download_dir}"
+
+  rm -f erc_files.txt
+
+  echo "Verifying checksums"
+  if curl -fsS -O "${base_url}/checksums_sha256.txt" 2>/dev/null; then
+    sha256sum -c checksums_sha256.txt --ignore-missing
+    echo "✅ All checksums verified"
+  else
+    echo "No checksums file available, skipping verification"
+  fi
+
+  popd > /dev/null
+}
+
+
 if [[ ! -f /var/lib/nimbus/api-token.txt ]]; then
   token=api-token-0x$(head -c 8 /dev/urandom | od -A n -t u8 | tr -d '[:space:]' | sha256sum | head -c 32)$(head -c 8 /dev/urandom | od -A n -t u8 | tr -d '[:space:]' | sha256sum | head -c 32)
   echo "${token}" > /var/lib/nimbus/api-token.txt
@@ -67,19 +149,44 @@ else
   __network="--network=${NETWORK}"
 fi
 
-if [[ -n "${CHECKPOINT_SYNC_URL:+x}" && ! -f /var/lib/nimbus/setupdone ]]; then
-  if [[ "${NODE_TYPE}" = "archive" ]]; then
-    echo "Starting checkpoint sync with backfill and archive reindex. Nimbus will restart when done."
-# Word splitting is desired for the command line parameters
+if [[ -n "${CHECKPOINT_SYNC_URL}" && ! -f /var/lib/nimbus/setupdone ]]; then
+  if [[ "${CL_NODE_TYPE}" =~ ^(archive|blob-archive)$ ]]; then
+    if [[ -z "${ERC_URL}" ]]; then
+      echo "Nimbus cannot build an archive node from only a checkpoint sync. Attempting to sync from genesis"
+      echo "It'd be much better to also use \"ERC_URL\" to download EraC files"
+    else
+      echo "Starting Checkpoint sync. EraC files will be downloaded next."
 # shellcheck disable=SC2086
-    /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=true --reindex ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
+      nimbus_beacon_node trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
+    fi
     touch /var/lib/nimbus/setupdone
   else
     echo "Starting checkpoint sync. Nimbus will restart when done."
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-    /usr/local/bin/nimbus_beacon_node trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
+    nimbus_beacon_node trustedNodeSync --backfill=false ${__network} --data-dir=/var/lib/nimbus --trusted-node-url="${CHECKPOINT_SYNC_URL}"
     touch /var/lib/nimbus/setupdone
+  fi
+fi
+
+__erc_dir=""
+if [[ -n "${ERC_URL}" && ! "${NETWORK}" =~ ^https?:// ]]; then  # Named network
+  if [[ "${CL_NODE_TYPE}" =~ ^(archive|blob-archive)$ ]]; then
+    if [[ ! -f /var/lib/nimbus/erc-download-complete ]]; then
+       if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
+        echo "Starting EraC history file download from ${ERC_URL}"
+        __download_erc_files "${ERC_URL}" /var/lib/nimbus/erc
+        touch /var/lib/nimbus/erc-download-complete
+      else
+        echo "You have EraC files with \"ERC_URL\" but are also genesis syncing. Skipping EraC download."
+        echo "You can specify a \"CHECKPOINT_SYNC_URL\" and resync."
+      fi
+    fi
+    if [[ -f /var/lib/nimbus/erc-download-complete ]]; then
+      __erc_dir="--era-dir=/var/lib/nimbus/erc"
+    fi
+  else
+    echo "Nimbus is not an archive node, it uses ${CL_NODE_TYPE}. Skipping EraC download."
   fi
 fi
 
@@ -127,10 +234,10 @@ else
   __doppel="--doppelganger-detection=false"
 fi
 
-case "${NODE_TYPE}" in
-  archive)
-    echo "Nimbus archive node without history pruning"
-    __prune="--history=archive"
+case "${CL_NODE_TYPE}" in
+  archive|blob-archive)
+    echo "Nimbus archive node without history or blob pruning."
+    __prune="--history=archive --reindex"
     ;;
   full)
     __prune=""
@@ -140,7 +247,7 @@ case "${NODE_TYPE}" in
     __prune="--history=prune"
     ;;
   *)
-    echo "ERROR: The node type ${NODE_TYPE} is not known to Eth Docker's Nimbus implementation."
+    echo "ERROR: The node type ${CL_NODE_TYPE} is not known to Eth Docker's Nimbus implementation."
     sleep 30
     exit 1
     ;;
@@ -185,9 +292,9 @@ done
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${__erc_dir} ${CL_EXTRAS} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${__erc_dir} ${CL_EXTRAS} ${VC_EXTRAS}
 fi


### PR DESCRIPTION
**What I did**

Do not checkpoint sync when `archive`  and no `ERC_URL`, genesis sync and warn user

`history=archive` also keeps blobs, Nimbus is not granular about state history and blob history

Support Era(C) files with `ERC_URL`

curl and pushd/popd improvements to the downloader, also for ere on Unified. Broader improvement across all entrypoints will be a separate PR
