### PR TITLE
Do not uppercase Nimbus log level

### DIFF
--- a/nimbus-allin1.yml
+++ b/nimbus-allin1.yml
@@ -49,7 +49,6 @@ services:
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
       - MEV_NODE=${MEV_NODE}
       - DOPPELGANGER=${DOPPELGANGER}
-      - LOG_LEVEL=${LOG_LEVEL}
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=${VC_EXTRAS:-}
       - NODE_TYPE=${CL_NODE_TYPE:-pruned}
@@ -93,6 +92,7 @@ services:
       - --keymanager-allow-origin=*
       - --keymanager-token-file=/var/lib/nimbus/api-token.txt
       - --suggested-fee-recipient=${FEE_RECIPIENT}
+      - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/nimbus-cl-only.yml
+++ b/nimbus-cl-only.yml
@@ -38,7 +38,6 @@ services:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}  # Unused, here to avoid runtime errors in case of faulty logic
       - MEV_NODE=${MEV_NODE}
-      - LOG_LEVEL=${LOG_LEVEL}
       - DOPPELGANGER=false
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=
@@ -76,6 +75,7 @@ services:
       - --metrics-port=8008
       - --metrics-address=0.0.0.0
       - --suggested-fee-recipient=${FEE_RECIPIENT}
+      - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/nimbus-vc-only.yml
+++ b/nimbus-vc-only.yml
@@ -35,7 +35,6 @@ services:
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
       - CL_NODE=${CL_NODE}
       - DOPPELGANGER=${DOPPELGANGER}
-      - LOG_LEVEL=${LOG_LEVEL}
       - VC_EXTRAS=${VC_EXTRAS:-}
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
@@ -61,6 +60,7 @@ services:
       - --keymanager-allow-origin=*
       - --keymanager-token-file=/var/lib/nimbus/api-token.txt
       - --suggested-fee-recipient=${FEE_RECIPIENT}
+      - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/nimbus.yml
+++ b/nimbus.yml
@@ -38,7 +38,6 @@ services:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}  # Unused, here to avoid runtime errors in case of faulty logic
       - MEV_NODE=${MEV_NODE}
-      - LOG_LEVEL=${LOG_LEVEL}
       - DOPPELGANGER=false
       - CL_EXTRAS=${CL_EXTRAS:-}
       - VC_EXTRAS=
@@ -76,6 +75,7 @@ services:
       - --metrics-port=8008
       - --metrics-address=0.0.0.0
       - --suggested-fee-recipient=${FEE_RECIPIENT}
+      - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics
@@ -100,7 +100,6 @@ services:
       - MEV_BOOST=${MEV_BOOST}
       - MEV_BUILD_FACTOR=${MEV_BUILD_FACTOR}
       - DOPPELGANGER=${DOPPELGANGER}
-      - LOG_LEVEL=${LOG_LEVEL}
       - VC_EXTRAS=${VC_EXTRAS:-}
       - GRAFFITI=${GRAFFITI:-}
       - DEFAULT_GRAFFITI=${DEFAULT_GRAFFITI:-false}
@@ -127,6 +126,7 @@ services:
       - --keymanager-allow-origin=*
       - --keymanager-token-file=/var/lib/nimbus/api-token.txt
       - --suggested-fee-recipient=${FEE_RECIPIENT}
+      - --log-level=${LOG_LEVEL}
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -68,8 +68,6 @@ for node in ${nodes}; do
   __beacon_nodes+=("--beacon-node=${node}")
 done
 
-__log_level="--log-level=${LOG_LEVEL^^}"
-
 # Web3signer URL
 if [[ "${WEB3SIGNER}" = "true" ]]; then
   __w3s_url="--web3-signer-url=${W3S_NODE}"
@@ -96,9 +94,9 @@ fi
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} ${__log_level} ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} "--graffiti=${GRAFFITI}" ${__log_level} ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
+  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} "--graffiti=${GRAFFITI}" ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
 fi

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -131,8 +131,6 @@ else
   __doppel="--doppelganger-detection=false"
 fi
 
-__log_level="--log-level=${LOG_LEVEL^^}"
-
 case "${NODE_TYPE}" in
   archive)
     echo "Nimbus archive node without history pruning"
@@ -191,9 +189,9 @@ done
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__log_level} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
 else
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__log_level} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
+  exec "$@" ${__network} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${CL_EXTRAS} ${VC_EXTRAS}
 fi


### PR DESCRIPTION
**What I did**

Nimbus no longer requires log levels to be uppercase. Remove the code that handled the conversion.
