### PR TITLE
Better VC options in entrypoint, including Graffiti

### DIFF
--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -188,6 +188,12 @@ else
   __trace=""
 fi
 
+if [[ "${EMBEDDED_VC}" = "true" && "${DEFAULT_GRAFFITI}" != "true" ]]; then
+  __graffiti_args=(--graffiti "${GRAFFITI}")
+else
+  __graffiti_args=()
+fi
+
 __strip_empty_args "$@"
 set -- "${__args[@]}"
 
@@ -208,12 +214,6 @@ while true; do
   fi
 done
 
-if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${__doppel} ${__trace} ${CL_EXTRAS} ${VC_EXTRAS}
-else
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${__doppel} --graffiti "${GRAFFITI}" ${__trace} ${CL_EXTRAS} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} ${__w3s_url} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__ipv6} ${__doppel} ${__trace} ${CL_EXTRAS} ${VC_EXTRAS}

--- a/lighthouse/docker-entrypoint-vc.sh
+++ b/lighthouse/docker-entrypoint-vc.sh
@@ -97,11 +97,11 @@ fi
 # not use a parameter to connect the VC to Web3signer. This is unique to Lighthouse and Vero
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--graffiti-append --graffiti "${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} --graffiti-append --graffiti "${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__att_aggr} ${VC_EXTRAS}

--- a/lodestar/docker-entrypoint-vc.sh
+++ b/lodestar/docker-entrypoint-vc.sh
@@ -104,11 +104,11 @@ else
 fi
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__w3s_url} ${__att_aggr} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--graffiti "${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} "--graffiti" "${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__w3s_url} ${__att_aggr} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} ${__w3s_url} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__beacon_stats} ${__doppel} ${__att_aggr} ${VC_EXTRAS}

--- a/nimbus/docker-entrypoint-vc.sh
+++ b/nimbus/docker-entrypoint-vc.sh
@@ -92,11 +92,11 @@ else
 fi
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--graffiti="${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} "--graffiti=${GRAFFITI}" ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}
-fi
+exec "$@" "${__beacon_nodes[@]}" ${__w3s_url} "${__graffiti_args[@]}" ${__doppel} ${__mev_boost} ${__mev_factor} ${__att_aggr} ${VC_EXTRAS}

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -227,11 +227,15 @@ else
 fi
 
 # Check whether we should enable doppelganger protection
-if [[ "${DOPPELGANGER}" = "true" ]]; then
-  __doppel=""
-  echo "Doppelganger protection enabled, VC will pause for 2 epochs"
+if [[ "${EMBEDDED_VC}" = "true" ]]; then
+  if [[ "${DOPPELGANGER}" = "true" ]]; then
+    __doppel=""
+    echo "Doppelganger protection enabled, VC will pause for 2 epochs"
+  else
+    __doppel="--doppelganger-detection=false"
+  fi
 else
-  __doppel="--doppelganger-detection=false"
+  __doppel=""
 fi
 
 case "${CL_NODE_TYPE}" in
@@ -269,6 +273,12 @@ else
   __w3s_url=""
 fi
 
+if [[ "${EMBEDDED_VC}" = "true" &&  "${DEFAULT_GRAFFITI}" != "true" ]]; then
+  __graffiti_args=(--graffiti="${GRAFFITI}")
+else
+  __graffiti_args=()
+fi
+
 __strip_empty_args "$@"
 set -- "${__args[@]}"
 
@@ -289,12 +299,6 @@ while true; do
   fi
 done
 
-if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${__erc_dir} ${CL_EXTRAS} ${VC_EXTRAS}
-else
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} "--graffiti=${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${__erc_dir} ${CL_EXTRAS} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} ${__w3s_url} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__doppel} ${__prune} ${__erc_dir} ${CL_EXTRAS} ${VC_EXTRAS}

--- a/prysm/docker-entrypoint-vc.sh
+++ b/prysm/docker-entrypoint-vc.sh
@@ -63,11 +63,11 @@ else
 fi
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--graffiti "${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} "--graffiti" "${GRAFFITI}" ${__w3s_url} ${__mev_boost} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} ${__w3s_url} "${__graffiti_args[@]}" ${__mev_boost} ${__doppel} ${__att_aggr} ${VC_EXTRAS}

--- a/teku/docker-entrypoint-vc.sh
+++ b/teku/docker-entrypoint-vc.sh
@@ -120,11 +120,11 @@ else
 fi
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--validators-graffiti="${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} "--validators-graffiti=${GRAFFITI}" ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__att_aggr} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} "${__graffiti_args[@]}" ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__doppel} ${__att_aggr} ${VC_EXTRAS}

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -105,7 +105,10 @@ fi
 if [[ "${MEV_BOOST}" = "true" ]]; then
   __mev_boost="--builder-endpoint=${MEV_NODE:-http://mev-boost:18550}"
   echo "MEV Boost enabled"
-  __mev_boost+=" --validators-builder-registration-default-enabled"
+  if [[ "${EMBEDDED_VC}" = "true" ]]; then
+    __mev_boost+=" --validators-builder-registration-default-enabled"
+  fi
+  # Teku has the build factor on the CL, which is unusual
   build_factor="$(__normalize_int "${MEV_BUILD_FACTOR}")"
   case "${build_factor}" in
     0)
@@ -145,7 +148,7 @@ else
 fi
 
 # Check whether we should enable doppelganger protection
-if [[ "${DOPPELGANGER}" = "true" ]]; then
+if [[ "${EMBEDDED_VC}" = "true" && "${DOPPELGANGER}" = "true" ]]; then
   __doppel="--doppelganger-detection-enabled=true"
   echo "Doppelganger protection enabled, VC will pause for 2 epochs"
 else
@@ -194,6 +197,12 @@ else
   __ipv6=""
 fi
 
+if [[ "${EMBEDDED_VC}" = "true" && "${DEFAULT_GRAFFITI}" != "true" ]]; then
+  __graffiti_args=(--validators-graffiti="${GRAFFITI}")
+else
+  __graffiti_args=()
+fi
+
 __strip_empty_args "$@"
 set -- "${__args[@]}"
 
@@ -214,12 +223,6 @@ while true; do
   fi
 done
 
-if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
-else
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} "--validators-graffiti=${GRAFFITI}" ${__w3s_url} ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} ${__w3s_url} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__checkpoint_sync} ${__prune} ${__beacon_stats} ${__doppel} ${__ipv6} ${CL_EXTRAS} ${VC_EXTRAS}

--- a/vero/docker-entrypoint.sh
+++ b/vero/docker-entrypoint.sh
@@ -111,11 +111,11 @@ if [[ "${COMPOSE_FILE}" =~ (grafana\.yml|grafana-rootless\.yml) ]]; then
 fi
 
 if [[ "${DEFAULT_GRAFFITI}" = "true" ]]; then
-# Word splitting is desired for the command line parameters
-# shellcheck disable=SC2086
-  exec "$@" ${__network} ${__mev_boost} ${__mev_factor} ${__log_level} ${__doppel} ${VC_EXTRAS}
+  __graffiti_args=()
 else
+  __graffiti_args=(--graffiti "${GRAFFITI}")
+fi
+
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-  exec "$@" ${__network} "--graffiti" "${GRAFFITI}" ${__mev_boost} ${__mev_factor} ${__log_level} ${__doppel} ${VC_EXTRAS}
-fi
+exec "$@" ${__network} "${__graffiti_args[@]}" ${__mev_boost} ${__mev_factor} ${__log_level} ${__doppel} ${VC_EXTRAS}


### PR DESCRIPTION
**What I did**

- For "all-in-1" clients, only configure VC options when the embedded VC is in use. This makes it easier for users to understand parameters when they `ps auxww | grep <client-executable>`

- Refactor Graffiti handling. Because spaces in Graffiti have to be preserved, Graffiti was special-cased before, with two separate `exec` lines. Use an array for parameter expansion instead, so `${GRAFFITI}` with spaces remains preserved while also handling spaces between parameters and handling no graffiti parameter when using default graffiti.
