### PR TITLE
`ethd version` change for Eth Docker

### DIFF
--- a/ethd
+++ b/ethd
@@ -6175,7 +6175,7 @@ version() {
   local var
   local w3s_exec=""
 
-  grep "^This is" README.md
+  grep "^This is ${__project_name} v" README.md
   echo
   __value="${COMPOSE_FILE}"
 


### PR DESCRIPTION
**What I did**

Change the match to be more specific, so it does what #2662 does. That way, if the string in `README.md` ever changes, it'll be obvious with `ethd version` that this needs to be adjusted in the code.
