### PR TITLE
CI for custom networks

### DIFF
--- a/.github/workflows/test-client-combos-custom.yml
+++ b/.github/workflows/test-client-combos-custom.yml
@@ -1,0 +1,188 @@
+name: Test Custom Network Client Combination
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: customci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint sources
+    if: |
+      (
+        contains(github.event.pull_request.labels.*.name, 'test-custom')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+          cache: 'pip'
+      - name: Lint sources
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure
+
+  test-client-combo:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        combo:
+          - env: |-
+              CORE_FILES=caplin.yml:erigon.yml:lodestar-vc-only.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+              CL_NODE=http://execution:5052
+              EL_EXTRAS=--torrent.download.rate 1mb
+            test_cl: false
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=nimbus-unified.yml:nimbus-vc-only.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: false
+            test_vc: true
+          - env: |-
+              CORE_FILES=grandine-allin1.yml:nimbus-el.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: false
+          - env: |-
+              CORE_FILES=grandine-cl-only.yml:lighthouse-vc-only.yml:nimbus-el.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=grandine-plugin.yml:lighthouse-vc-only.yml:nethermind.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+              NM_DOCKER_REPO=sifrai/grandine
+              NM_DOCKER_TAG=unstable-nethermind
+            test_cl: false
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=grandine-plugin-allin1.yml:nethermind.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+              NM_DOCKER_REPO=sifrai/grandine
+              NM_DOCKER_TAG=unstable-nethermind
+            test_cl: false
+            test_el: true
+            test_vc: false
+          - env: |-
+              CORE_FILES=lighthouse.yml:ethrex.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=lighthouse.yml:reth.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=lighthouse-cl-only.yml:lighthouse-vc-only.yml:reth.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=lodestar.yml:erigon.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=lodestar-cl-only.yml:lodestar-vc-only.yml:erigon.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=nimbus.yml:nethermind.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=nimbus-cl-only.yml:nimbus-vc-only.yml:nethermind.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=prysm.yml:geth.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=prysm-cl-only.yml:prysm-vc-only.yml:geth.yml
+              CL_NODE=consensus:4000
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=teku.yml:besu.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+          - env: |-
+              CORE_FILES=teku-cl-only.yml:teku-vc-only.yml:besu.yml
+              FEE_RECIPIENT=0xDccf8451070a86183eE70D330C4c43b686E9CF86
+            test_cl: true
+            test_el: true
+            test_vc: true
+        env-var:
+          - >-
+            NETWORK=https://github.com/eth-clients/sepolia/tree/main/metadata
+            CHECKPOINT_SYNC_URL=https://checkpoint-sync.sepolia.ethpandaops.io
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Remove podman
+        run: sudo apt-get remove -y podman
+      - name: Create .env file
+        run: cp default.env .env
+      - name: Set env variables
+        run: |
+          source ./.github/helper.sh
+          while IFS= read -r varpair; do
+            IFS='=' read var val <<< "$varpair"
+            export "$var=$val"
+            var=$var
+            set_value_in_env
+          done <<< "${{ matrix.combo.env }}"
+          for varpair in ${{ matrix.env-var }}; do
+            IFS="=" read var val <<< "$varpair"
+            export "$var=$val"
+            var=$var
+            set_value_in_env
+          done
+      - name: Test the stack
+        uses: ./.github/actions/test_client_stack
+        with:
+          test_cl: ${{ matrix.combo.test_cl }}
+          test_el: ${{ matrix.combo.test_el }}
+          test_vc: ${{ matrix.combo.test_vc }}

--- a/.github/workflows/test-client-combos-custom.yml
+++ b/.github/workflows/test-client-combos-custom.yml
@@ -154,8 +154,10 @@ jobs:
             test_vc: true
         env-var:
           - >-
-            NETWORK=https://github.com/eth-clients/sepolia/tree/main/metadata
-            CHECKPOINT_SYNC_URL=https://checkpoint-sync.sepolia.ethpandaops.io
+            NETWORK=https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-7/metadata
+            CHECKPOINT_SYNC_URL=""
+            NIMEL_DOCKER_TAG="master"
+          # Nimbus EL Docker tag until the fixes in master are in a release
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/besu/docker-entrypoint.sh
+++ b/besu/docker-entrypoint.sh
@@ -54,8 +54,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/besu/testnet/${config_dir}/enodes.yaml")"
-  __network="--genesis-file=/var/lib/besu/testnet/${config_dir}/besu.json --bootnodes=${bootnodes}"
+  config_dir_path="/var/lib/besu/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  __network="--genesis-file=${config_dir_path}/besu.json --bootnodes=${bootnodes}"
 else
   __network="--network ${NETWORK}"
 fi

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -54,8 +54,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  el_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/erigon/testnet/${config_dir}/enodes.yaml")"
-  networkid="$(jq -r '.config.chainId' "/var/lib/erigon/testnet/${config_dir}/genesis.json")"
+  config_dir_path="/var/lib/erigon/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    el_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    el_bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  networkid="$(jq -r '.config.chainId' "${config_dir_path}/genesis.json")"
   __network="--bootnodes=${el_bootnodes} --networkid=${networkid}"
   if [[ ! -d /var/lib/erigon/chaindata ]]; then
     erigon init --datadir /var/lib/erigon "/var/lib/erigon/testnet/${config_dir}/genesis.json"
@@ -133,8 +138,13 @@ else
       ;;
   esac
   if [[ "${NETWORK}" =~ ^https?:// ]]; then
-    cl_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/erigon/testnet/${config_dir}/bootstrap_nodes.yaml")"
-    __caplin+=" --caplin.custom-config=/var/lib/erigon/testnet/${config_dir}/config.yaml --caplin.custom-genesis=/var/lib/erigon/testnet/${config_dir}/genesis.ssz --sentinel.bootnodes=${cl_bootnodes}"
+    config_dir_path="/var/lib/erigon/testnet/${config_dir}"
+    if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+      cl_bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+    else
+      cl_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+    fi
+    __caplin+=" --caplin.custom-config=${config_dir_path}/config.yaml --caplin.custom-genesis=${config_dir_path}/genesis.ssz --sentinel.bootnodes=${cl_bootnodes}"
   fi
   if [[ -n "${CHECKPOINT_SYNC_URL}" ]]; then
     __caplin+=" --caplin.checkpoint-sync-url=${CHECKPOINT_SYNC_URL}/eth/v2/debug/beacon/states/finalized"

--- a/ethrex/docker-entrypoint.sh
+++ b/ethrex/docker-entrypoint.sh
@@ -58,8 +58,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/ethrex/testnet/${config_dir}/enodes.yaml")"
-  __network="--network /var/lib/ethrex/testnet/${config_dir}/genesis.json --bootnodes ${bootnodes}"
+  config_dir_path="/var/lib/ethrex/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  __network="--network ${config_dir_path}/genesis.json --bootnodes ${bootnodes}"
 else
   __network="--network ${NETWORK}"
 fi

--- a/geth/docker-entrypoint.sh
+++ b/geth/docker-entrypoint.sh
@@ -138,11 +138,16 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/geth/testnet/${config_dir}/enodes.yaml")"
-  networkid="$(jq -r '.config.chainId' "/var/lib/geth/testnet/${config_dir}/genesis.json")"
+  config_dir_path="/var/lib/geth/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  networkid="$(jq -r '.config.chainId' "${config_dir_path}/genesis.json")"
   __network="--bootnodes=${bootnodes} --networkid=${networkid}"
   if [[ ! -d /var/lib/geth/geth/chaindata/ ]]; then
-    geth init --datadir /var/lib/geth "/var/lib/geth/testnet/${config_dir}/genesis.json"
+    geth init --datadir /var/lib/geth "${config_dir_path}/genesis.json"
   fi
 else
   __network="--${NETWORK}"

--- a/grandine/docker-entrypoint.sh
+++ b/grandine/docker-entrypoint.sh
@@ -61,8 +61,8 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/grandine/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __network="--configuration-directory=/var/lib/grandine/testnet/${config_dir} --boot-nodes=${bootnodes}"
+  config_dir_path="/var/lib/grandine/testnet/${config_dir}"
+  __network="--configuration-directory=${config_dir_path} --network=custom"
 else
   __network="--network=${NETWORK}"
 fi

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -47,8 +47,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/lighthouse/beacon/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __network="--testnet-dir=/var/lib/lighthouse/beacon/testnet/${config_dir} --boot-nodes=${bootnodes}"
+  config_dir_path="/var/lib/lighthouse/beacon/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  __network="--testnet-dir=${config_dir_path} --boot-nodes=${bootnodes}"
 else
   __network="--network=${NETWORK}"
 fi

--- a/lodestar/docker-entrypoint.sh
+++ b/lodestar/docker-entrypoint.sh
@@ -52,9 +52,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/lodestar/consensus/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __network="--paramsFile=/var/lib/lodestar/consensus/testnet/${config_dir}/config.yaml --genesisStateFile=/var/lib/lodestar/consensus/testnet/${config_dir}/genesis.ssz \
---bootnodes=${bootnodes} --network.connectToDiscv5Bootnodes --rest.namespace=*"
+  config_dir_path="/var/lib/lodestar/consensus/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  __network="--paramsFile=${config_dir_path}/config.yaml --genesisStateFile=${config_dir_path}/genesis.ssz --bootnodes=${bootnodes} --network.connectToDiscv5Bootnodes --rest.namespace=*"
 else
   __network="--network ${NETWORK}"
 fi

--- a/nethermind/docker-entrypoint.sh
+++ b/nethermind/docker-entrypoint.sh
@@ -67,8 +67,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nethermind/testnet/${config_dir}/enodes.yaml")"
-  __network="--config none.cfg --Init.ChainSpecPath=/var/lib/nethermind/testnet/${config_dir}/chainspec.json --Discovery.Bootnodes=${bootnodes} --Init.IsMining=false"
+  config_dir_path="/var/lib/nethermind/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  __network="--config none.cfg --Init.ChainSpecPath=${config_dir_path}/chainspec.json --Discovery.Bootnodes=${bootnodes}"
   if [[ ! "${NODE_TYPE}" = "archive" ]]; then
     __prune="--Pruning.Mode=None"
   fi
@@ -250,8 +255,8 @@ if [[ "${COMPOSE_FILE}" =~ grandine-plugin(-allin1)?\.yml ]]; then
       echo "${config_dir}" > .git/info/sparse-checkout
       git pull origin "${branch}"
     fi
-    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/grandine/testnet/${config_dir}/bootstrap_nodes.yaml")"
-    __grandine+=" --grandine-configuration-directory=/var/lib/grandine/testnet/${config_dir} --grandine-boot-nodes=${bootnodes}"
+    config_dir_path="/var/lib/grandine/testnet/${config_dir}"
+    __grandine+=" --grandine-configuration-directory=${config_dir_path} --grandine-network=custom"
   else
     __grandine+=" --grandine-network=${NETWORK}"
   fi
@@ -349,8 +354,8 @@ if [[ "${COMPOSE_FILE}" =~ grandine-plugin(-allin1)?\.yml ]]; then
     done
   fi
 
-  if [[ ! "${DEFAULT_GRAFFITI}" = "true" ]]; then
-      __grandine+=" --grandine-graffiti ${GRAFFITI}"
+  if [[ "${EMBEDDED_VC}" = "true" && "${DEFAULT_GRAFFITI}" != "true" ]]; then
+    __grandine_graffiti_args=(--grandine-graffiti "${GRAFFITI}")
   fi
 
 # Traces
@@ -364,8 +369,10 @@ if [[ "${COMPOSE_FILE}" =~ grandine-plugin(-allin1)?\.yml ]]; then
   fi
 
   __grandine+=" ${CL_EXTRAS} ${VC_EXTRAS}"
+  echo "Grandine plugin will be launched with these parameters: ${__grandine}" "${__grandine_graffiti_args[@]}"
 else
   __grandine=""
+  __grandine_graffiti_args=()
 fi
 
 __strip_empty_args "$@"
@@ -373,4 +380,4 @@ set -- "${__args[@]}"
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__datadir} ${__network} ${__prune} ${__ere} ${__flat} ${__grandine} ${EL_EXTRAS}
+exec "$@" ${__datadir} ${__network} ${__prune} ${__ere} ${__flat} ${__grandine} "${__grandine_graffiti_args[@]}" ${EL_EXTRAS}

--- a/nimbus-el.yml
+++ b/nimbus-el.yml
@@ -52,7 +52,6 @@ services:
       - --ws
       - --data-dir=/var/lib/nimbus
       - --tcp-port=${EL_P2P_PORT:-30303}
-      - --discovery=V5
       - --metrics
       - --metrics-port=6060
       - --metrics-address=0.0.0.0

--- a/nimbus-el/docker-entrypoint-unified.sh
+++ b/nimbus-el/docker-entrypoint-unified.sh
@@ -250,9 +250,18 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  el_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml")"
-  cl_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __network="--bootstrap-node=${cl_bootnodes} --el-bootstrap-node=${el_bootnodes} --network=/var/lib/nimbus/testnet/${config_dir}"
+  config_dir_path="/var/lib/nimbus/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    el_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    el_bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    cl_bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    cl_bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  __network="--bootstrap-node=${cl_bootnodes} --el-bootstrap-node=${el_bootnodes} --network=${config_dir_path}/"
 else
   __network="--network=${NETWORK}"
 fi

--- a/nimbus-el/docker-entrypoint.sh
+++ b/nimbus-el/docker-entrypoint.sh
@@ -169,8 +169,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/enodes.yaml")"
-  __network="--bootstrap-node=${bootnodes} --network=/var/lib/nimbus/testnet/${config_dir}/genesis.json"
+  config_dir_path="/var/lib/nimbus/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  __network="--bootstrap-node=${bootnodes} --network=${config_dir_path}/genesis.json"
 else
   __network="--network=${NETWORK}"
 fi

--- a/nimbus/docker-entrypoint.sh
+++ b/nimbus/docker-entrypoint.sh
@@ -143,8 +143,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/nimbus/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __network="--network=/var/lib/nimbus/testnet/${config_dir} --bootstrap-node=${bootnodes}"
+  config_dir_path="/var/lib/nimbus/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  __network="--network=${config_dir_path} --bootstrap-node=${bootnodes}"
 else
   __network="--network=${NETWORK}"
 fi

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -47,9 +47,14 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/prysm/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  deploy_block=$(cat "/var/lib/prysm/testnet/${config_dir}/deposit_contract_block.txt")
-  __network="--chain-config-file=/var/lib/prysm/testnet/${config_dir}/config.yaml --genesis-state=/var/lib/prysm/testnet/${config_dir}/genesis.ssz \
+  config_dir_path="/var/lib/prysm/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  deploy_block=$(cat "${config_dir_path}/deposit_contract_block.txt")
+  __network="--chain-config-file=${config_dir_path}/config.yaml --genesis-state=${config_dir_path}/genesis.ssz \
 --bootstrap-node=${bootnodes} --contract-deployment-block=${deploy_block}"
 else
   __network="--${NETWORK}"

--- a/prysm/docker-entrypoint.sh
+++ b/prysm/docker-entrypoint.sh
@@ -50,7 +50,7 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
   bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/prysm/testnet/${config_dir}/bootstrap_nodes.yaml")"
   deploy_block=$(cat "/var/lib/prysm/testnet/${config_dir}/deposit_contract_block.txt")
   __network="--chain-config-file=/var/lib/prysm/testnet/${config_dir}/config.yaml --genesis-state=/var/lib/prysm/testnet/${config_dir}/genesis.ssz \
---enable-debug-rpc-endpoints --bootstrap-node=${bootnodes} --contract-deployment-block=${deploy_block}"
+--bootstrap-node=${bootnodes} --contract-deployment-block=${deploy_block}"
 else
   __network="--${NETWORK}"
 fi

--- a/reth/docker-entrypoint.sh
+++ b/reth/docker-entrypoint.sh
@@ -54,8 +54,13 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/reth/testnet/${config_dir}/enodes.yaml")"
-  __network="--chain=/var/lib/reth/testnet/${config_dir}/genesis.json --bootnodes=${bootnodes}"
+  config_dir_path="/var/lib/reth/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/enodes.yaml" ]]; then
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/enodes.yaml")"
+  else
+    bootnodes="$(paste -sd, "${config_dir_path}/enodes.txt")"
+  fi
+  __network="--chain=${config_dir_path}/genesis.json --bootnodes=${bootnodes}"
 else
   __network="--chain ${NETWORK}"
 fi

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -94,9 +94,14 @@ if [[ "${NETWORK}" =~ ^https?:// ]]; then
     echo "${config_dir}" > .git/info/sparse-checkout
     git pull origin "${branch}"
   fi
-  bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "/var/lib/teku/testnet/${config_dir}/bootstrap_nodes.yaml")"
-  __checkpoint_sync="--initial-state=/var/lib/teku/testnet/${config_dir}/genesis.ssz --ignore-weak-subjectivity-period-enabled=true"
-  __network="--network=/var/lib/teku/testnet/${config_dir}/config.yaml --p2p-discovery-bootnodes=${bootnodes}"
+  config_dir_path="/var/lib/teku/testnet/${config_dir}"
+  if [[ -f "${config_dir_path}/bootstrap_nodes.txt" ]]; then
+    bootnodes="$(paste -sd, "${config_dir_path}/bootstrap_nodes.txt")"
+  else
+    bootnodes="$(awk -F'- ' '!/^#/ && NF>1 { split($2, a, /[ \t#]/); if (a[1] != "") printf (first++ ? "," : "") a[1] } END { print "" }' "${config_dir_path}/bootstrap_nodes.yaml")"
+  fi
+  __checkpoint_sync="--initial-state=${config_dir_path}/genesis.ssz --ignore-weak-subjectivity-period-enabled=true"
+  __network="--network=${config_dir_path}/config.yaml --p2p-discovery-bootnodes=${bootnodes}"
 else
   __network="--network=${NETWORK}"
 fi


### PR DESCRIPTION
**What I did**

Add CI for custom networks. In a separate workflow, so mev-boost.yml doesn't run. Do not test Vero, as there is no custom network support for Web3signer implemented.

Requires https://github.com/ethstaker/eth-docker/pull/2703 for Caplin support and #2698 for Sepolia parsing and https://github.com/ethstaker/eth-docker/pull/2682 for Nimbus EL / Nimbus Unified and https://github.com/status-im/nimbus-eth1/pull/4449 for Nimbus Unified

Adjust Prysm parameters, Nethermind parameters, Grandine parameters, Nimbus-EL parameters

Grandine plugin handles Graffiti with spaces

Current devnets use `enodes.txt` and don't have `enodes.yaml`