### PR TITLE
Add EL max peers to Nimbus Unified

### DIFF
--- a/nimbus-unified.yml
+++ b/nimbus-unified.yml
@@ -68,6 +68,7 @@ services:
       - --metrics-port=8008
       - --metrics-address=0.0.0.0
       - ${CL_MAX_PEER_COUNT:+--max-peers=${CL_MAX_PEER_COUNT}}
+      - ${EL_MAX_PEER_COUNT:+--el-max-peers=${EL_MAX_PEER_COUNT}}
       - ${MAX_BLOBS:+--max-blobs=${MAX_BLOBS}}
       - --log-level=${LOG_LEVEL}
       - --suggested-fee-recipient=${FEE_RECIPIENT}


### PR DESCRIPTION
**What I did**

Nimbus Unified uses the `--el-max-peers` alias. If actually using `EL_MAX_PEER_COUNT`, this requires a Nimbus Unified that has https://github.com/status-im/nimbus-eth1/pull/4449 merged.

Given how experimental Nimbus Unified is, and that this change is a NOOP when `EL_MAX_PEER_COUNT` isn't set, I'm comfortable introducing the change now.
