### PR TITLE
Remove GitPOAP badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Eth Docker: Docker automation for Ethereum nodes.
 
-[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/eth-educators/eth-docker/badge)](https://www.gitpoap.io/gh/eth-educators/eth-docker)
-
 Eth Docker, a simple yet configurable way to run [Ethereum](https://ethereum.org/roadmap/) nodes.
 
 ## Getting Started


### PR DESCRIPTION
**What I did**

Remove GitPOAP badge from `README.md`

POAP has been shut down. End of an era. 🥹 
