### PR TITLE
Revert "Teku uses same port for IPv4 and IPv6 (#2694)"

### DIFF
--- a/default.env
+++ b/default.env
@@ -164,6 +164,9 @@ CL_P2P_PORT=9000
 PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000
 CL_QUIC_PORT=9001
+# Teku needs separate ports for IPv6
+CL_IPV6_P2P_PORT=9010
+CL_IPV6_QUIC_PORT=9011
 # Local grafana dashboard port. Do not expose to Internet, it is insecure http
 GRAFANA_PORT=3000
 # Local Siren UI port

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -59,12 +59,15 @@ services:
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
       - IPV6=${IPV6:-false}
-      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
-      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -47,12 +47,15 @@ services:
       - WEB3SIGNER=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
-      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku.yml
+++ b/teku.yml
@@ -56,12 +56,15 @@ services:
       - EMBEDDED_VC=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
-      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
+      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
+      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
+      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
+      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -191,7 +191,7 @@ fi
 
 if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Teku to listen on IPv6 ports"
-  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_P2P_PORT:-9000} --p2p-quic-port-ipv6 ${CL_QUIC_PORT:-9001}"
+  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_IPV6_P2P_PORT:-9010} --p2p-quic-port-ipv6 ${CL_IPV6_QUIC_PORT:-9011}"
 else
   __ipv6=""
 fi


### PR DESCRIPTION
This reverts commit 4d27a8b54e70602991156f2a16d9477453c21d75.

**What I did**

Teku same-port breaks with Docker, see https://github.com/rocket-pool/smartnode/pull/1134
