### PR TITLE
Change Nimbus EL default tag to latest

### DIFF
--- a/default.env
+++ b/default.env
@@ -514,7 +514,7 @@ GETH_DOCKERFILE=Dockerfile.binary
 NIMEL_SRC_BUILD_TARGET=master
 NIMEL_SRC_REPO=https://github.com/status-im/nimbus-eth1
 # Docker image and repo
-NIMEL_DOCKER_TAG=master
+NIMEL_DOCKER_TAG=latest
 NIMEL_DOCKER_REPO=statusim/nimbus-eth1
 # Whether to use a Docker image or build from source
 NIMEL_DOCKERFILE=Dockerfile.binary


### PR DESCRIPTION
**What I did**

Change default `NIMEL_DOCKER_TAG=latest`, from `master`. This follows releases instead of nightly: Treat it more like a released client, though it is still alpha

Impacts Nimbus EL and Nimbus Unified
