### PR TITLE
Do not carry ethd prometheus version file in git

### DIFF
--- a/prometheus/node-exporter-text/eth-docker-version.prom
+++ b/prometheus/node-exporter-text/eth-docker-version.prom
@@ -1,3 +1,0 @@
-# HELP eth_docker_version_info Currently checked out Eth Docker version
-# TYPE eth_docker_version_info gauge
-eth_docker_version_info{tag="v26.7.2-dev",commit="6ec90be"} 1


### PR DESCRIPTION
**What I did**

As carrying it causes issues when `ethd update` is being run, `.gitignore` not withstanding
