### PR TITLE
Detect and remove git-tracked eth-docker-version

### DIFF
--- a/ethd
+++ b/ethd
@@ -2639,6 +2639,11 @@ update() {
   fi
 
   if [[ -z "${ETHDSECUNDO:-}" ]]; then
+# Remove after Glamsterdam
+    if git ls-files --error-unmatch ./prometheus/node-exporter-text/eth-docker-version.prom; then
+      rm -f ./prometheus/node-exporter-text/eth-docker-version.prom
+    fi
+
     set +e
     ${__as_owner} git config pull.rebase false
     var="ETH_DOCKER_TAG"


### PR DESCRIPTION
**What I did**

If a user has a git-tracked `./prometheus/node-exporter-text/eth-docker-version.prom`, remove it. That way `git pull` comes in cleanly and removes it from git tracking, then it gets recreated by `__write_eth_docker_version_metric`

This may not help users that already have it since they need a git pull to receive it ... 
