### PR TITLE
git check errors to /dev/null

### DIFF
--- a/ethd
+++ b/ethd
@@ -2640,7 +2640,7 @@ update() {
 
   if [[ -z "${ETHDSECUNDO:-}" ]]; then
 # Remove after Glamsterdam
-    if git ls-files --error-unmatch ./prometheus/node-exporter-text/eth-docker-version.prom; then
+    if git ls-files --error-unmatch ./prometheus/node-exporter-text/eth-docker-version.prom >/dev/null 2>&1; then
       rm -f ./prometheus/node-exporter-text/eth-docker-version.prom
     fi
 


### PR DESCRIPTION
**What I did**

The check for `eth-docker-version.prom` errors when it's not tracked; redirect that to `/dev/null`
