### PR TITLE
ethd update sets git pull.rebase=true

### DIFF
--- a/ethd
+++ b/ethd
@@ -2645,7 +2645,7 @@ update() {
     fi
 
     set +e
-    ${__as_owner} git config pull.rebase false
+    ${__as_owner} git config pull.rebase true
     var="ETH_DOCKER_TAG"
     __get_value_from_env "${var}" "${__env_file}" "__value"
     if [[ -z "${__value}" || "${__value}" = "latest" ]]; then


### PR DESCRIPTION
**What I did**

Rebase is better for dev work. Users are unlikely to have local commits; but if they do, a rebase is also cleaner than a new merge commit every time they update
