### PR TITLE
Enabled Nethermind log index

### DIFF
--- a/nethermind.yml
+++ b/nethermind.yml
@@ -67,6 +67,8 @@ services:
       - "true"
       - --HealthChecks.UIEnabled
       - "true"
+      - --LogIndex.Enabled
+      - "true"
       - --JsonRpc.Enabled
       - "true"
       - --JsonRpc.Host


### PR DESCRIPTION
**What I did**

Enable log index now that bloom filters are gone, so `eth_getLogs` for RPC, SSV, RocketPool, NodeSet &c remains performant
