### PR TITLE
During update, be more careful with logindex

### DIFF
--- a/ethd
+++ b/ethd
@@ -2140,7 +2140,7 @@ __migrate_env() {
       if [[ "${__source_ver}" -lt "65" && "${var}" = "EL_EXTRAS" && "${COMPOSE_FILE}" =~ nethermind\.yml ]]; then
         if [[ -z "${__value}" ]]; then
           __value="--LogIndex.Enabled true"
-        else
+        elif [[ ! "${__value}" =~ Logindex\.Enabled|logindex-enabled ]]; then
           __value+=" --LogIndex.Enabled true"
         fi
       fi


### PR DESCRIPTION
**What I did**

During `ethd update`, only set Nethermind log index if `EL_EXTRAS` is empty or doesn't already contain a LogIndex parameter
