### PR TITLE
Remove `--builder-proposals` from Anchor

### DIFF
--- a/anchor/docker-entrypoint.sh
+++ b/anchor/docker-entrypoint.sh
@@ -21,40 +21,31 @@ else
   __ipv6=""
 fi
 
-if [[ "${MEV_BOOST}" = "true" ]]; then
-  __mev_boost="--builder-proposals"
-  echo "MEV Boost enabled"
-
-  build_factor="$(__normalize_int "${MEV_BUILD_FACTOR}")"
-  case "${build_factor}" in
-    0)
-      __mev_boost=""
-      __mev_factor=""
-      echo "Disabled MEV Boost because MEV_BUILD_FACTOR is 0."
-      echo "WARNING: This conflicts with MEV_BOOST true. Set factor in a range of 1 to 100"
-      ;;
-    [1-9]|[1-9][0-9])
-      __mev_factor="--builder-boost-factor ${build_factor}"
-      echo "Enabled MEV Build Factor of ${build_factor}"
-      ;;
-    100)
-      __mev_factor="--prefer-builder-proposals"
-      echo "Always prefer MEV builder blocks, MEV_BUILD_FACTOR 100"
-      ;;
-    "")
-      __mev_factor=""
-      echo "Use default --builder-boost-factor"
-      ;;
-    *)
-      __mev_factor=""
-      echo "WARNING: MEV_BUILD_FACTOR has an invalid value of \"${build_factor}\""
-      ;;
-  esac
-else
-  __mev_boost=""
-  __mev_factor=""
-fi
+echo "MEV Boost enabled, mandatory Anchor default"
+build_factor="$(__normalize_int "${MEV_BUILD_FACTOR}")"
+case "${build_factor}" in
+  0)
+    __mev_factor="--builder-boost-factor ${build_factor}"
+    echo "MEV_BUILD_FACTOR is 0, which essentially disables remote block building / MEV."
+    ;;
+  [1-9]|[1-9][0-9])
+    __mev_factor="--builder-boost-factor ${build_factor}"
+    echo "Enabled MEV Build Factor of ${build_factor}"
+    ;;
+  100)
+    __mev_factor="--prefer-builder-proposals"
+    echo "Always prefer MEV builder blocks, MEV_BUILD_FACTOR 100"
+    ;;
+  "")
+    __mev_factor=""
+    echo "Use default --builder-boost-factor"
+    ;;
+  *)
+    __mev_factor=""
+    echo "WARNING: MEV_BUILD_FACTOR has an invalid value of \"${build_factor}\""
+    ;;
+esac
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086
-exec "$@" ${__ipv6} ${__mev_boost} ${__mev_factor} ${DVT_EXTRAS}
+exec "$@" ${__ipv6} ${__mev_factor} ${DVT_EXTRAS}


### PR DESCRIPTION
**What I did**

Anchor `1.3.0` deprecates `--builder-proposals`. It will be removed entirely in a future release
