### PR TITLE
Reapply "Teku uses same port for IPv4 and IPv6 (#2694)" (#2710)

### DIFF
--- a/default.env
+++ b/default.env
@@ -164,9 +164,6 @@ CL_P2P_PORT=9000
 PRYSM_PORT=9000
 PRYSM_UDP_PORT=9000
 CL_QUIC_PORT=9001
-# Teku needs separate ports for IPv6
-CL_IPV6_P2P_PORT=9010
-CL_IPV6_QUIC_PORT=9011
 # Local grafana dashboard port. Do not expose to Internet, it is insecure http
 GRAFANA_PORT=3000
 # Local Siren UI port

--- a/teku-allin1.yml
+++ b/teku-allin1.yml
@@ -59,15 +59,12 @@ services:
       - NETWORK=${NETWORK}
       - ENABLE_DIST_ATTESTATION_AGGR=${ENABLE_DIST_ATTESTATION_AGGR:-false}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
-      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
+      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
+      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
-      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku-cl-only.yml
+++ b/teku-cl-only.yml
@@ -47,15 +47,12 @@ services:
       - WEB3SIGNER=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
-      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
+      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
+      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
-      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku.yml
+++ b/teku.yml
@@ -56,15 +56,12 @@ services:
       - EMBEDDED_VC=false
       - NETWORK=${NETWORK}
       - IPV6=${IPV6:-false}
-      - CL_IPV6_P2P_PORT=${CL_IPV6_P2P_PORT:-9010}
-      - CL_IPV6_QUIC_PORT=${CL_IPV6_QUIC_PORT:-9011}
+      - CL_P2P_PORT=${CL_P2P_PORT:-9000}
+      - CL_QUIC_PORT=${CL_QUIC_PORT:-9001}
     ports:
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/tcp
       - ${HOST_IP:-}:${CL_P2P_PORT:-9000}:${CL_P2P_PORT:-9000}/udp
       - ${HOST_IP:-}:${CL_QUIC_PORT:-9001}:${CL_QUIC_PORT:-9001}/udp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/tcp
-      - ${HOST_IP:-}:${CL_IPV6_P2P_PORT:-9010}:${CL_IPV6_P2P_PORT:-9010}/udp
-      - ${HOST_IP:-}:${CL_IPV6_QUIC_PORT:-9011}:${CL_IPV6_QUIC_PORT:-9011}/udp
     networks:
       default:
         aliases:

--- a/teku/docker-entrypoint.sh
+++ b/teku/docker-entrypoint.sh
@@ -197,7 +197,7 @@ fi
 
 if [[ "${IPV6}" = "true" ]]; then
   echo "Configuring Teku to listen on IPv6 ports"
-  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_IPV6_P2P_PORT:-9010} --p2p-quic-port-ipv6 ${CL_IPV6_QUIC_PORT:-9011}"
+  __ipv6="--p2p-interface 0.0.0.0,:: --p2p-port-ipv6 ${CL_P2P_PORT:-9000} --p2p-quic-port-ipv6 ${CL_QUIC_PORT:-9001}"
 else
   __ipv6=""
 fi


### PR DESCRIPTION
This reverts commit 17f039d1655a2ff55f501a53aeb8eb491459bde9.

**What I did**

Re-enable same port for dual-stack Teku. This works in my testing

```
yorick@test-node:~/dev/eth-docker$ telnet 192.168.3.25 9000
Trying 192.168.3.25...
Connected to 192.168.3.25.
Escape character is '^]'.
/multistream/1.0.0
^]
telnet> quit
Connection closed.
yorick@test-node:~/dev/eth-docker$ telnet <v6-address> 9000
Trying <v6-address>...
Connected to <v6-address>.
Escape character is '^]'.
/multistream/1.0.0
^]
telnet> quit
Connection closed.
yorick@test-node:~/dev/eth-docker$ docker ps
CONTAINER ID   IMAGE        COMMAND                  CREATED         STATUS                   PORTS                                                                                                                                                                            NAMES
6e1d0c3429ae   teku:local   "docker-entrypoint.s…"   3 minutes ago   Up 3 minutes             5051/tcp, 8008/tcp, 0.0.0.0:9000->9000/tcp, 0.0.0.0:9000-9001->9000-9001/udp, [::]:9000->9000/tcp, [::]:9000-9001->9000-9001/udp                                                 eth-docker-consensus-1
```
