### PR TITLE
Point Grafana disk-usage panels at the real DOCKER_ROOT mountpoint

### DIFF
--- a/default.env
+++ b/default.env
@@ -573,10 +573,13 @@ NODE_EXPORTER_IGNORE_MOUNT_REGEX='^/(dev|proc|sys|run|var/snap/.+|var/lib/docker
 ALLOY_FILTER_BY_PROJECT_NAME=false
 # And the Docker root so promtail scrapes logs from the right location. This is updated by ethd
 DOCKER_ROOT=/var/lib/docker
+# The real filesystem mountpoint backing DOCKER_ROOT, so Grafana dashboards can show disk usage
+# for that filesystem instead of always "/". This is updated by ethd
+DOCKER_ROOT_MOUNTPOINT=/
 # Docker socket location. Updated by ethd on Ubuntu/Debian; on macOS set to <home-dir>/.colima/default/docker.sock if using Colima
 DOCKER_SOCK=/var/run/docker.sock
 # This install's Compose project name, resolved by ethd when ALLOY_FILTER_BY_PROJECT_NAME is true. Updated by ethd - do not set by hand
 ALLOY_PROJECT_NAME=
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=65
+ENV_VERSION=66

--- a/ethd
+++ b/ethd
@@ -287,6 +287,19 @@ __handle_docker() {
       __update_value_in_env "${var}" "${!var}" "${__env_file}"
     fi
 
+    # Determine the real mountpoint backing DOCKER_ROOT, so Grafana dashboards
+    # can report disk usage for that filesystem instead of always "/"
+    if command -v findmnt >/dev/null; then
+      DOCKER_ROOT_MOUNTPOINT=$(findmnt -T "${DOCKER_ROOT}" -o TARGET -n)
+    else
+      DOCKER_ROOT_MOUNTPOINT=$(df --output=target "${DOCKER_ROOT}" | tail -1)
+    fi
+    var=DOCKER_ROOT_MOUNTPOINT
+    __get_value_from_env "${var}" "${__env_file}" "__value"
+    if [[ "${DOCKER_ROOT_MOUNTPOINT}" != "${__value}" ]]; then
+      __update_value_in_env "${var}" "${!var}" "${__env_file}"
+    fi
+
     # on macOS, user would set this manually to Colima or Docker Desktop value
     if [[ "${__docker_exe}" = "podman" ]]; then
       if [[ "$(__dodocker system info --format '{{.Host.Security.Rootless}}')" = "true" ]]; then

--- a/grafana.yml
+++ b/grafana.yml
@@ -218,6 +218,7 @@ services:
     environment:
       - GF_SERVER_HTTP_PORT=${GRAFANA_PORT}
       - CLIENT=${COMPOSE_FILE}
+      - DOCKER_ROOT_MOUNTPOINT=${DOCKER_ROOT_MOUNTPOINT:-/}
     volumes:
       - grafana-data:/var/lib/grafana
       - grafana-config:/etc/grafana

--- a/grafana/provision.sh
+++ b/grafana/provision.sh
@@ -59,7 +59,7 @@ handle_replacement() {
 # If DOCKER_ROOT lives on its own filesystem (not "/"), rewrite disk-usage
 # panels that hard-code mountpoint="/" to point at the real mountpoint instead.
 # No-op (passthrough) when Docker uses the default root on "/".
-fix_docker_mountpoint() {
+__fix_docker_mountpoint() {
   if [[ -n "${DOCKER_ROOT_MOUNTPOINT:-}" && "${DOCKER_ROOT_MOUNTPOINT}" != "/" ]]; then
     jq --arg mp "${DOCKER_ROOT_MOUNTPOINT}" \
       'walk(if type == "string" then gsub("mountpoint=\"/\""; "mountpoint=\"" + $mp + "\"") else . end)'
@@ -406,7 +406,7 @@ case "${CLIENT}" in
       wget -t 3 -T 10 -qcO - "${url}" | jq '.title = "Host & Docker Monitoring"' \
         | jq '.panels |= map(if .title == "Temp" then .targets[0] |= (.legendFormat = "{{type}}" | .expr = "node_thermal_zone_temp")| .options.orientation = "vertical" elif .title == "Temperature" then .targets[0].expr = "node_thermal_zone_temp" else . end)' \
         | jq 'walk(if . == "${DS_PROMETHEUS}" then "Prometheus" else . end)' \
-        | fix_docker_mountpoint >"${tmp}" || status=1
+        | __fix_docker_mountpoint >"${tmp}" || status=1
     fi
     handle_replacement "${status}" "${tmp}" "${file}"
     ;;

--- a/grafana/provision.sh
+++ b/grafana/provision.sh
@@ -56,6 +56,19 @@ handle_replacement() {
 }
 
 
+# If DOCKER_ROOT lives on its own filesystem (not "/"), rewrite disk-usage
+# panels that hard-code mountpoint="/" to point at the real mountpoint instead.
+# No-op (passthrough) when Docker uses the default root on "/".
+fix_docker_mountpoint() {
+  if [[ -n "${DOCKER_ROOT_MOUNTPOINT:-}" && "${DOCKER_ROOT_MOUNTPOINT}" != "/" ]]; then
+    jq --arg mp "${DOCKER_ROOT_MOUNTPOINT}" \
+      'walk(if type == "string" then gsub("mountpoint=\"/\""; "mountpoint=\"" + $mp + "\"") else . end)'
+  else
+    cat
+  fi
+}
+
+
 cp /tmp/grafana/provisioning/alerting/* /etc/grafana/provisioning/alerting/
 
 shopt -s extglob
@@ -392,7 +405,8 @@ case "${CLIENT}" in
       tmp=$(mktemp)
       wget -t 3 -T 10 -qcO - "${url}" | jq '.title = "Host & Docker Monitoring"' \
         | jq '.panels |= map(if .title == "Temp" then .targets[0] |= (.legendFormat = "{{type}}" | .expr = "node_thermal_zone_temp")| .options.orientation = "vertical" elif .title == "Temperature" then .targets[0].expr = "node_thermal_zone_temp" else . end)' \
-        | jq 'walk(if . == "${DS_PROMETHEUS}" then "Prometheus" else . end)' >"${tmp}" || status=1
+        | jq 'walk(if . == "${DS_PROMETHEUS}" then "Prometheus" else . end)' \
+        | fix_docker_mountpoint >"${tmp}" || status=1
     fi
     handle_replacement "${status}" "${tmp}" "${file}"
     ;;


### PR DESCRIPTION
**What I did**

Grafana's "Host & Docker Monitoring" dashboard (id 15120) hard-codes
`mountpoint="/"` in its Root FS / disk-usage panels ("Root FS Used",
"RootFS Total", "Used Disk Space"). On installs where `DOCKER_ROOT` lives
on its own filesystem (e.g. `/srv/docker`), these panels always reported
the root filesystem's usage instead of the filesystem that actually
holds Docker's data.

- Added a `DOCKER_ROOT_MOUNTPOINT` var to `default.env`, detected by `ethd`
  via `findmnt`/`df` (same pattern already used in `__optimize_host`),
  right after the existing `DOCKER_ROOT` detection in `__handle_docker`.
- Passed it through to the `grafana` container via `grafana.yml`.
- Added a `fix_docker_mountpoint` helper in `grafana/provision.sh` that
  rewrites `mountpoint="/"` to the real mountpoint in dashboard 15120's
  JSON via `jq`.
- Other dashboards with cAdvisor/host metrics (19724) or the home
  staking dashboard (17846) don't hard-code a mountpoint filter, so
  they're left untouched.
- No-op when `DOCKER_ROOT` is on `/` (the default, and by far the most
  common setup) — verified the JSON output is byte-for-byte identical
  in that case.

Manually tested:
- Default setup (`DOCKER_ROOT_MOUNTPOINT=/`): dashboard unchanged.
- Simulated separate mount (`DOCKER_ROOT_MOUNTPOINT=/srv/docker`):
  confirmed via `jq` against the live dashboard 15120 JSON that both
  `mountpoint="/",fstype!="rootfs"` and `fstype!="rootfs",mountpoint="/"`
  orderings get rewritten correctly and output stays valid JSON.
- Verified `ethd update`'s existing `.env` migration path places the new
  var at the same position as in `default.env` (right after
  `DOCKER_ROOT`), not appended at the end — this requires the
  `ENV_VERSION` bump included here.
- `shellcheck ethd grafana/provision.sh` clean (no new findings).

**Related issue**

None filed — found while investigating Grafana disk-usage reporting on
a host with `DOCKER_ROOT` on a separate mount.