### PR TITLE
Add pyproject.toml for ruff rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,7 @@ updates:
       actions-deps:
         patterns:
           - "*"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 
   # Python formatting & linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/traefik-utils/app/base.py
+++ b/traefik-utils/app/base.py
@@ -1,19 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Mapping, Self
+from typing import TYPE_CHECKING, Self
+from collections.abc import Mapping
 
 if TYPE_CHECKING:
     from privilege import PrivilegeManager
 
-_provider_registry: dict[str, type["DNSProvider"]] = {}
+_provider_registry: dict[str, type[DNSProvider]] = {}
 
 
-def register_provider(name: str, cls: type["DNSProvider"]) -> None:
+def register_provider(name: str, cls: type[DNSProvider]) -> None:
     _provider_registry[name.lower()] = cls
 
 
 def build_provider(
-    priv: "PrivilegeManager", provider_name: str, env: Mapping[str, str]
-) -> "DNSProvider":
+    priv: PrivilegeManager, provider_name: str, env: Mapping[str, str]
+) -> DNSProvider:
     which = provider_name.lower()
     provider_class = _provider_registry.get(which)
     if provider_class is None:

--- a/traefik-utils/app/cf_provider.py
+++ b/traefik-utils/app/cf_provider.py
@@ -1,7 +1,7 @@
 __lazy_modules__ = ["cloudflare"]
 
 import logging
-from typing import Mapping
+from collections.abc import Mapping
 
 from cloudflare import Cloudflare
 from cloudflare.types.dns import RecordResponse
@@ -19,7 +19,7 @@ class CloudflareProvider(DNSProvider):
         self._cf = Cloudflare(api_token=token)
 
     @classmethod
-    def from_env(cls, env: Mapping[str, str]) -> "CloudflareProvider":
+    def from_env(cls, env: Mapping[str, str]) -> CloudflareProvider:
         return cls(env["CF_ZONE_ID"], env["CF_DNS_API_TOKEN"])
 
     def validate(self) -> None:

--- a/traefik-utils/app/privilege.py
+++ b/traefik-utils/app/privilege.py
@@ -2,7 +2,6 @@ import os
 import pwd
 import grp
 import shutil
-import subprocess
 
 
 class PrivilegeManager:
@@ -22,15 +21,16 @@ class PrivilegeManager:
 
         shutil.copytree(src, dst)
 
-        subprocess.check_call(
-            ["chown", "-R", f"{self._pw.pw_uid}:{self._pw.pw_gid}", dst]
-        )
-
         for root, dirs, files in os.walk(dst):
+            os.chown(root, self._pw.pw_uid, self._pw.pw_gid)
             for d in dirs:
-                os.chmod(os.path.join(root, d), 0o700)
+                path = os.path.join(root, d)
+                os.chown(path, self._pw.pw_uid, self._pw.pw_gid)
+                os.chmod(path, 0o700)
             for f in files:
-                os.chmod(os.path.join(root, f), 0o600)
+                path = os.path.join(root, f)
+                os.chown(path, self._pw.pw_uid, self._pw.pw_gid)
+                os.chmod(path, 0o600)
 
     def drop(self) -> None:
         try:

--- a/traefik-utils/app/pyproject.toml
+++ b/traefik-utils/app/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "ddns"
+requires-python = ">=3.14,<4"
+dynamic = ["version"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "UP", "S"]

--- a/traefik-utils/app/route53_provider.py
+++ b/traefik-utils/app/route53_provider.py
@@ -2,7 +2,8 @@ __lazy_modules__ = ["boto3", "botocore.exceptions"]
 
 import os
 import logging
-from typing import cast, TYPE_CHECKING, Mapping
+from typing import cast, TYPE_CHECKING
+from collections.abc import Mapping
 
 import boto3
 from botocore.exceptions import ClientError
@@ -49,7 +50,8 @@ class AwsCredentialResolver:
         elif profile and profile.strip() and os.path.exists(credentials_path):
             logger.info(f"Using AWS profile '{profile}' from {credentials_path}")
             logger.debug(
-                f"Using AWS creds file: {os.environ.get('AWS_SHARED_CREDENTIALS_FILE', 'N/A')}"
+                f"Using AWS creds file: "
+                f"{os.environ.get('AWS_SHARED_CREDENTIALS_FILE', 'N/A')}"
             )
             logger.debug(
                 f"Using AWS config file: {os.environ.get('AWS_CONFIG_FILE', 'N/A')}"
@@ -76,7 +78,7 @@ class Route53Provider(DNSProvider):
         self._r53 = session.client("route53")
 
     @classmethod
-    def from_env(cls, env: Mapping[str, str]) -> "Route53Provider":
+    def from_env(cls, env: Mapping[str, str]) -> Route53Provider:
         hz = env["AWS_HOSTED_ZONE_ID"]
         session = AwsCredentialResolver(env).resolve()
         return cls(hz, session)
@@ -125,7 +127,8 @@ class Route53Provider(DNSProvider):
             ]
             if len(vals) > 1:
                 logger.warning(
-                    f"Record {n_name} {rr_type} has multiple values {vals}; skipping management."
+                    f"Record {n_name} {rr_type} has multiple values {vals}; "
+                    "skipping management."
                 )
                 return True
 

--- a/traefik-utils/app/updater.py
+++ b/traefik-utils/app/updater.py
@@ -130,8 +130,10 @@ def build_cname_fqdn(label: str, domain: str) -> str:
     - 'api.<domain>.' -> 'api.<domain>.'
     Always returns a trailing-dot FQDN.
     Deliberately not handling:
-    - Absolute CNAMEs pointing outside the domain (e.g. 'foo.bar.com' -> 'foo.example.com') - not supported
-    - CNAMEs that are the same as the domain (e.g. 'example.com' -> 'example.com') - extremely provider-specific, too many edge cases
+    - Absolute CNAMEs pointing outside the domain (e.g. 'foo.bar.com' ->
+      'foo.example.com') - not supported
+    - CNAMEs that are the same as the domain (e.g. 'example.com' ->
+      'example.com') - extremely provider-specific, too many edge cases
     """
     n = label.strip().rstrip(".")
     d = domain.strip().rstrip(".")


### PR DESCRIPTION
**What I did**

- Add pre-commit to dependabot
- Add a `pyproject.toml` for minimum Python version and ruff rules
- `chown` isn't a sub-process to satisfy ruff `S`
- Let ruff `W` and `UP` make changes. Notably deferred annotation, `"DNSProvider"` becomes `DNSProvider`, requires Python 3.14 and newer

