### PR TITLE
Make mypy checks --strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,9 @@ repos:
         additional_dependencies:
           - boto3-stubs[route53,sts]
           - types-requests
+          - cloudflare
+          - tenacity
+        args: [--strict]
 
   # Security (lightweight)
   - repo: https://github.com/PyCQA/bandit

--- a/traefik-utils/app/base.py
+++ b/traefik-utils/app/base.py
@@ -1,11 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Literal, Self
 from collections.abc import Mapping
 
 if TYPE_CHECKING:
     from privilege import PrivilegeManager
 
 _provider_registry: dict[str, type[DNSProvider]] = {}
+
+RecordType = Literal["A", "AAAA", "CNAME"]
 
 
 def register_provider(name: str, cls: type[DNSProvider]) -> None:
@@ -42,7 +44,7 @@ class DNSProvider(ABC):
 
     @abstractmethod
     def record_is(
-        self, name: str, rtype: str, value: str, proxied: bool = False
+        self, name: str, rtype: RecordType, value: str, proxied: bool = False
     ) -> bool:
         """Return True if the existing RRSet equals `value`,
         or if it's an alias / a multi-value set (skip with warning).
@@ -51,7 +53,12 @@ class DNSProvider(ABC):
 
     @abstractmethod
     def upsert(
-        self, name: str, rtype: str, value: str, ttl: int, proxied: bool = False
+        self,
+        name: str,
+        rtype: RecordType,
+        value: str,
+        ttl: int,
+        proxied: bool = False,
     ) -> bool:
         """Create or update a single-value record to exactly `value` with `ttl`.
         Return True if an update was performed, False if record was already correct."""

--- a/traefik-utils/app/cf_provider.py
+++ b/traefik-utils/app/cf_provider.py
@@ -2,13 +2,16 @@ __lazy_modules__ = ["cloudflare"]
 
 import logging
 from collections.abc import Mapping
+from typing import Any, cast
 
 from cloudflare import Cloudflare
 from cloudflare.types.dns import RecordResponse
 
-from base import DNSProvider, normalize_fqdn
+from base import DNSProvider, RecordType, normalize_fqdn
 
 logger = logging.getLogger("dns-updater")
+
+_CloudflareRecords = Any
 
 
 class CloudflareProvider(DNSProvider):
@@ -28,20 +31,24 @@ class CloudflareProvider(DNSProvider):
         except Exception as e:
             raise RuntimeError(f"Cloudflare validation failed: {e}") from e
 
-    def _get_record(self, name: str, rtype: str) -> RecordResponse | None:
+    def _get_record(self, name: str, rtype: RecordType) -> RecordResponse | None:
         recs = self._cf.dns.records.list(
             zone_id=self._zone,
             type=rtype,
-            name=normalize_fqdn(name),
+            name=cast(Any, normalize_fqdn(name)),
             per_page=1,
         )
         return recs.result[0] if recs.result else None
 
     def record_is(
-        self, name: str, rtype: str, value: str, proxied: bool = False
+        self, name: str, rtype: RecordType, value: str, proxied: bool = False
     ) -> bool:
         n_name, n_value = normalize_fqdn(name), normalize_fqdn(value)
-        recs = self._cf.dns.records.list(zone_id=self._zone, type=rtype, name=n_name)
+        recs = self._cf.dns.records.list(
+            zone_id=self._zone,
+            type=rtype,
+            name=cast(Any, n_name),
+        )
 
         # No records exist
         if not recs.result:
@@ -60,28 +67,54 @@ class CloudflareProvider(DNSProvider):
         return have == n_value and have_proxied == proxied
 
     def upsert(
-        self, name: str, rtype: str, value: str, ttl: int, proxied: bool = False
+        self,
+        name: str,
+        rtype: RecordType,
+        value: str,
+        ttl: int,
+        proxied: bool = False,
     ) -> bool:
         n_name, n_value = normalize_fqdn(name), normalize_fqdn(value)
         if self.record_is(n_name, rtype, n_value, proxied=proxied):
             return False
         existing = self._get_record(n_name, rtype)
-        payload = {
-            "type": rtype,
-            "name": n_name,
-            "content": n_value,
-            "ttl": ttl,
-            "proxied": proxied,
-        }
-        if existing:
-            self._cf.dns.records.update(
-                dns_record_id=existing.id,
-                zone_id=self._zone,
-                **payload,
-            )
+        records = cast(_CloudflareRecords, self._cf.dns.records)
+        if rtype in ("A", "AAAA"):
+            if existing:
+                records.update(
+                    dns_record_id=existing.id,
+                    zone_id=self._zone,
+                    name=n_name,
+                    type=rtype,
+                    content=n_value,
+                    ttl=ttl,
+                    proxied=proxied,
+                )
+            else:
+                records.create(
+                    zone_id=self._zone,
+                    name=n_name,
+                    type=rtype,
+                    content=n_value,
+                    ttl=ttl,
+                    proxied=proxied,
+                )
         else:
-            self._cf.dns.records.create(
-                zone_id=self._zone,
-                **payload,
-            )
+            if existing:
+                records.update(
+                    dns_record_id=existing.id,
+                    zone_id=self._zone,
+                    name=n_name,
+                    type="CNAME",
+                    content=n_value,
+                    proxied=proxied,
+                )
+            else:
+                records.create(
+                    zone_id=self._zone,
+                    name=n_name,
+                    type="CNAME",
+                    content=n_value,
+                    proxied=proxied,
+                )
         return True

--- a/traefik-utils/app/route53_provider.py
+++ b/traefik-utils/app/route53_provider.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 
 import boto3
 from botocore.exceptions import ClientError
-from base import DNSProvider, normalize_fqdn
+from base import DNSProvider, RecordType, normalize_fqdn
 
 if TYPE_CHECKING:
     from mypy_boto3_route53.client import Route53Client
@@ -25,7 +25,7 @@ else:
 logger = logging.getLogger("dns-updater")
 
 
-def _to_route53_rr_type(rtype: str) -> RRTypeType:
+def _to_route53_rr_type(rtype: RecordType) -> RRTypeType:
     """Cast generic str rtype to boto3's strict RRTypeType for type checking."""
     return cast(RRTypeType, rtype)
 
@@ -92,7 +92,7 @@ class Route53Provider(DNSProvider):
             raise RuntimeError(f"Route53 validation failed: {e}") from e
 
     def record_is(
-        self, name: str, rtype: str, value: str, proxied: bool = False
+        self, name: str, rtype: RecordType, value: str, proxied: bool = False
     ) -> bool:
         n_name = normalize_fqdn(name) + "."
         n_value = normalize_fqdn(value)
@@ -140,7 +140,7 @@ class Route53Provider(DNSProvider):
             return True
 
     def upsert(
-        self, name: str, rtype: str, value: str, ttl: int, proxied: bool = False
+        self, name: str, rtype: RecordType, value: str, ttl: int, proxied: bool = False
     ) -> bool:
         n_name = normalize_fqdn(name) + "."
         n_value = normalize_fqdn(value)


### PR DESCRIPTION
**What I did**

Strict type checking during pre-commit; adjust code to resolve the issues mypy surfaced

Notably CloudFlare doesn't do TTL for CNAME: Instead of common update code for all options, it does an if/else for A/AAAA and CNAME

`RecordType` is now a `Literal` and only allows `A`, `AAAA` and `CNAME`
