### PR TITLE
Add DDNS tests and coverage workflow

### DIFF
--- a/.github/workflows/comment-ddns.yml
+++ b/.github/workflows/comment-ddns.yml
@@ -1,0 +1,105 @@
+name: Comment DDNS Coverage
+
+on:
+  workflow_run:
+    workflows: ["Test DDNS"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: |
+      github.event.workflow_run.name == 'Test DDNS' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: ddns-coverage
+          path: ddns-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update coverage comment
+        uses: actions/github-script@v8
+        env:
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const workflowRun = context.payload.workflow_run;
+            const headRepository = workflowRun.head_repository?.full_name;
+            const headBranch = workflowRun.head_branch;
+
+            if (!headRepository || !headBranch) {
+              throw new Error('Could not determine the workflow run head repository and branch');
+            }
+
+            const [headOwner] = headRepository.split('/');
+            const { owner, repo } = context.repo;
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'all',
+              head: `${headOwner}:${headBranch}`,
+              per_page: 100,
+            });
+
+            const pullRequest = pullRequests.find(pr => pr.head.sha === process.env.HEAD_SHA);
+            if (!pullRequest) {
+              core.info(`No pull request found for ${headRepository}:${headBranch} at ${process.env.HEAD_SHA}`);
+              return;
+            }
+
+            const marker = '<!-- ddns-coverage-report -->';
+            const coveragePath = 'ddns-coverage/coverage.md';
+            const statusPath = 'ddns-coverage/test-status';
+            const coverage = fs.existsSync(coveragePath)
+              ? fs.readFileSync(coveragePath, 'utf8').trim()
+              : 'Coverage report was not generated.';
+            const testStatus = fs.existsSync(statusPath)
+              ? fs.readFileSync(statusPath, 'utf8').trim()
+              : 'unknown';
+            const status = testStatus === '0' ? 'passed' : 'failed';
+            const body = [
+              marker,
+              '## DDNS Coverage',
+              '',
+              `Tests **${status}** for commit \`${process.env.HEAD_SHA.slice(0, 12)}\`.`,
+              '',
+              coverage,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                body,
+              });
+            }

--- a/.github/workflows/test-client-combos.yml
+++ b/.github/workflows/test-client-combos.yml
@@ -24,7 +24,8 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'test-ethd') &&
         !contains(github.event.pull_request.labels.*.name, 'test-grafana') &&
         !contains(github.event.pull_request.labels.*.name, 'test-nimbus-proxy') &&
-        !contains(github.event.pull_request.labels.*.name, 'test-web3signer')
+        !contains(github.event.pull_request.labels.*.name, 'test-web3signer') &&
+        !contains(github.event.pull_request.labels.*.name, 'test-ddns')
       )
       || github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ddns.yml
+++ b/.github/workflows/test-ddns.yml
@@ -1,0 +1,65 @@
+name: Test DDNS
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-ddns:
+    if: contains(github.event.pull_request.labels.*.name, 'test-ddns')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: traefik-utils/app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: traefik-utils/app/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-cov
+
+      - name: Run tests and coverage
+        id: tests
+        run: |
+          set +e
+          pytest --cov=. --cov-report=term-missing --cov-report=markdown:coverage.md
+          status=$?
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+          printf '%s\n' "${status}" > test-status
+          exit 0
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddns-coverage
+          path: |
+            traefik-utils/app/coverage.md
+            traefik-utils/app/test-status
+          if-no-files-found: warn
+
+      - name: Report test result
+        if: always()
+        run: exit "${{ steps.tests.outputs.status }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
           - cloudflare
           - tenacity
         args: [--strict]
+        exclude: ^traefik-utils/app/tests/
 
   # Security (lightweight)
   - repo: https://github.com/PyCQA/bandit

--- a/traefik-utils/app/.gitignore
+++ b/traefik-utils/app/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .venv
+.coverage

--- a/traefik-utils/app/pyproject.toml
+++ b/traefik-utils/app/pyproject.toml
@@ -3,5 +3,26 @@ name = "ddns"
 requires-python = ">=3.14,<4"
 dynamic = ["version"]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--strict-config --strict-markers"
+
+[tool.coverage.run]
+branch = true
+source = ["."]
+
+[tool.coverage.report]
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+
 [tool.ruff.lint]
 select = ["E", "W", "F", "UP", "S"]
+per-file-ignores = { "tests/**/*.py" = ["S101", "S108"] }

--- a/traefik-utils/app/tests/conftest.py
+++ b/traefik-utils/app/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parents[1]))

--- a/traefik-utils/app/tests/test_base.py
+++ b/traefik-utils/app/tests/test_base.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock
+
+import pytest
+
+import base
+import provider_registry
+
+
+def test_normalize_fqdn_canonicalizes_names() -> None:
+    assert base.normalize_fqdn("  WWW.Example.COM... ") == "www.example.com"
+    assert base.normalize_fqdn(".") == "."
+
+
+def test_register_and_build_provider_are_case_insensitive() -> None:
+    provider = Mock()
+    provider.from_env.return_value = provider
+    base._provider_registry.clear()
+    base.register_provider("Example", provider)
+    privilege = Mock()
+
+    result = base.build_provider(privilege, "EXAMPLE", {})
+
+    assert result is provider
+    privilege.setup.assert_called_once_with(need_aws_config=False)
+    provider.from_env.assert_called_once_with({})
+    provider.validate.assert_called_once_with()
+
+
+def test_build_provider_enables_aws_config_for_route53() -> None:
+    provider = Mock()
+    provider.from_env.return_value = provider
+    base._provider_registry.clear()
+    base.register_provider("route53", provider)
+    privilege = Mock()
+
+    base.build_provider(privilege, "Route53", {})
+
+    privilege.setup.assert_called_once_with(need_aws_config=True)
+
+
+def test_build_provider_rejects_unknown_provider() -> None:
+    base._provider_registry.clear()
+
+    with pytest.raises(SystemExit, match="Unknown DNS_PROVIDER=missing"):
+        base.build_provider(Mock(), "missing", {})
+
+
+def test_register_all_registers_supported_providers() -> None:
+    base._provider_registry.clear()
+
+    provider_registry.register_all()
+
+    assert set(base._provider_registry) == {"route53", "cloudflare"}

--- a/traefik-utils/app/tests/test_cf_provider.py
+++ b/traefik-utils/app/tests/test_cf_provider.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cf_provider import CloudflareProvider
+
+
+def response(name="x.example.com", content="192.0.2.1", proxied=False, record_id="id"):
+    return Mock(name=name, content=content, proxied=proxied, id=record_id)
+
+
+def provider_with_records(records):
+    client = Mock()
+    client.dns.records.list.return_value = Mock(result=records)
+    with patch("cf_provider.Cloudflare", return_value=client):
+        provider = CloudflareProvider("zone", "token")
+    return provider, client
+
+
+def test_record_is_compares_content_and_proxy_state() -> None:
+    provider, client = provider_with_records([response()])
+
+    assert provider.record_is("X.Example.COM.", "A", "192.0.2.1.") is True
+    assert provider.record_is("x.example.com", "A", "192.0.2.2") is False
+    assert provider.record_is("x.example.com", "A", "192.0.2.1", proxied=True) is False
+    assert client.dns.records.list.call_args.kwargs["name"] == "x.example.com"
+
+
+def test_record_is_skips_multiple_records() -> None:
+    provider, _ = provider_with_records([response(), response(content="192.0.2.2")])
+
+    assert provider.record_is("x.example.com", "A", "192.0.2.1") is True
+
+
+def test_upsert_creates_a_record_with_ttl() -> None:
+    provider, client = provider_with_records([])
+
+    assert provider.upsert("x.example.com.", "A", "192.0.2.7", 60, proxied=True) is True
+    client.dns.records.create.assert_called_once_with(
+        zone_id="zone",
+        name="x.example.com",
+        type="A",
+        content="192.0.2.7",
+        ttl=60,
+        proxied=True,
+    )
+
+
+def test_upsert_updates_existing_cname_without_ttl() -> None:
+    provider, client = provider_with_records(
+        [response(content="old.example.com", record_id="record")]
+    )
+
+    assert provider.upsert("x.example.com", "CNAME", "new.example.com", 300) is True
+    client.dns.records.update.assert_called_once_with(
+        dns_record_id="record",
+        zone_id="zone",
+        name="x.example.com",
+        type="CNAME",
+        content="new.example.com",
+        proxied=False,
+    )
+
+
+def test_upsert_skips_correct_record() -> None:
+    provider, client = provider_with_records([response()])
+
+    assert provider.upsert("x.example.com", "A", "192.0.2.1", 60) is False
+    client.dns.records.create.assert_not_called()
+    client.dns.records.update.assert_not_called()
+
+
+def test_validate_wraps_api_errors() -> None:
+    provider, client = provider_with_records([])
+    client.dns.records.list.side_effect = RuntimeError("forbidden")
+
+    with pytest.raises(RuntimeError, match="Cloudflare validation failed"):
+        provider.validate()

--- a/traefik-utils/app/tests/test_privilege.py
+++ b/traefik-utils/app/tests/test_privilege.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from privilege import PrivilegeManager
+
+
+def manager() -> PrivilegeManager:
+    pw = SimpleNamespace(pw_dir="/home/dns", pw_uid=1000, pw_gid=1000, pw_name="dns")
+    with patch("privilege.pwd.getpwnam", return_value=pw):
+        return PrivilegeManager("dns")
+
+
+def test_copy_aws_config_does_nothing_when_source_missing() -> None:
+    instance = manager()
+    with (
+        patch("privilege.os.path.exists", return_value=False),
+        patch("privilege.shutil.copytree") as copy,
+    ):
+        instance.copy_aws_config()
+    copy.assert_not_called()
+
+
+def test_copy_aws_config_replaces_destination_and_secures_files() -> None:
+    instance = manager()
+    with (
+        patch("privilege.os.path.exists", side_effect=[True, True]),
+        patch("privilege.shutil.rmtree") as remove,
+        patch("privilege.shutil.copytree") as copy,
+        patch(
+            "privilege.os.walk",
+            return_value=[("/home/dns/.aws", ["sub"], ["credentials"])],
+        ),
+        patch("privilege.os.chown") as chown,
+        patch("privilege.os.chmod") as chmod,
+    ):
+        instance.copy_aws_config()
+
+    remove.assert_called_once_with("/home/dns/.aws")
+    copy.assert_called_once_with("/root/.aws", "/home/dns/.aws")
+    assert chown.call_count == 3
+    chmod.assert_any_call("/home/dns/.aws/sub", 0o700)
+    chmod.assert_any_call("/home/dns/.aws/credentials", 0o600)
+
+
+def test_setup_copies_config_only_when_requested() -> None:
+    instance = manager()
+    instance.copy_aws_config = Mock()
+    instance.drop = Mock()
+
+    instance.setup(need_aws_config=False)
+    instance.copy_aws_config.assert_not_called()
+    instance.drop.assert_called_once_with()
+
+    instance.drop.reset_mock()
+    instance.setup(need_aws_config=True)
+    instance.copy_aws_config.assert_called_once_with()
+    instance.drop.assert_called_once_with()

--- a/traefik-utils/app/tests/test_route53_provider.py
+++ b/traefik-utils/app/tests/test_route53_provider.py
@@ -1,0 +1,142 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from route53_provider import AwsCredentialResolver, Route53Provider
+
+
+def error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code}}, "operation")
+
+
+def provider_with_client() -> tuple[Route53Provider, Mock]:
+    session = Mock()
+    client = Mock()
+    session.client.side_effect = lambda name: client
+    return Route53Provider("Z123", session), client
+
+
+def test_record_is_normalizes_and_matches_single_record() -> None:
+    provider, client = provider_with_client()
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "WWW.Example.COM.",
+                "Type": "A",
+                "ResourceRecords": [{"Value": "192.0.2.1"}],
+            }
+        ]
+    }
+
+    assert provider.record_is("www.example.com", "A", "192.0.2.1.") is True
+    client.list_resource_record_sets.assert_called_once_with(
+        HostedZoneId="Z123",
+        StartRecordName="www.example.com.",
+        StartRecordType="A",
+        MaxItems="1",
+    )
+
+
+def test_record_is_skips_alias_and_multi_value_records() -> None:
+    provider, client = provider_with_client()
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {"Name": "x.example.com.", "Type": "A", "AliasTarget": {}}
+        ]
+    }
+    assert provider.record_is("x.example.com", "A", "192.0.2.1") is True
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "x.example.com.",
+                "Type": "A",
+                "ResourceRecords": [{"Value": "192.0.2.1"}, {"Value": "192.0.2.2"}],
+            }
+        ]
+    }
+    assert provider.record_is("x.example.com", "A", "192.0.2.1") is True
+
+
+def test_record_is_fails_open_on_client_error() -> None:
+    provider, client = provider_with_client()
+    client.list_resource_record_sets.side_effect = error("AccessDenied")
+
+    assert provider.record_is("x.example.com", "A", "192.0.2.1") is True
+
+
+def test_upsert_skips_correct_record() -> None:
+    provider, client = provider_with_client()
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "x.example.com.",
+                "Type": "A",
+                "ResourceRecords": [{"Value": "192.0.2.1"}],
+            }
+        ]
+    }
+
+    assert provider.upsert("x.example.com", "A", "192.0.2.1", 60) is False
+    client.change_resource_record_sets.assert_not_called()
+
+
+def test_upsert_sends_route53_upssert_payload() -> None:
+    provider, client = provider_with_client()
+    client.list_resource_record_sets.return_value = {"ResourceRecordSets": []}
+
+    assert provider.upsert("x.example.com", "CNAME", "target.example.com.", 300) is True
+    client.change_resource_record_sets.assert_called_once_with(
+        HostedZoneId="Z123",
+        ChangeBatch={
+            "Comment": "Auto-updated CNAME record for x.example.com",
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Name": "x.example.com.",
+                        "Type": "CNAME",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "target.example.com"}],
+                    },
+                }
+            ],
+        },
+    )
+
+
+def test_validate_wraps_errors() -> None:
+    provider, client = provider_with_client()
+    client.get_hosted_zone.side_effect = error("NoSuchHostedZone")
+    provider._session.client.return_value.get_caller_identity.return_value = {
+        "Arn": "arn",
+        "Account": "1",
+    }
+
+    with pytest.raises(RuntimeError, match="Route53 validation failed"):
+        provider.validate()
+
+
+def test_credential_resolver_prefers_environment_credentials(monkeypatch) -> None:
+    monkeypatch.setenv("AWS_PROFILE", "profile")
+    env = {"AWS_ACCESS_KEY_ID": "key", "AWS_SECRET_ACCESS_KEY": "secret"}
+    with patch("route53_provider.boto3.session.Session") as session:
+        AwsCredentialResolver(env).resolve()
+    session.assert_called_once_with()
+
+
+def test_credential_resolver_uses_existing_profile_file(monkeypatch) -> None:
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/tmp/credentials")
+    env = {"AWS_PROFILE": " profile "}
+    with (
+        patch("route53_provider.os.path.exists", return_value=True),
+        patch("route53_provider.boto3.session.Session") as session,
+    ):
+        AwsCredentialResolver(env).resolve()
+    session.assert_called_once_with(profile_name="profile")
+
+
+def test_credential_resolver_rejects_incomplete_credentials(monkeypatch) -> None:
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/tmp/missing")
+    with pytest.raises(RuntimeError, match="No valid AWS credentials"):
+        AwsCredentialResolver({"AWS_ACCESS_KEY_ID": "key"}).resolve()

--- a/traefik-utils/app/tests/test_updater.py
+++ b/traefik-utils/app/tests/test_updater.py
@@ -1,0 +1,205 @@
+from unittest.mock import Mock
+import logging
+
+import pytest
+import requests
+
+import updater
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("192.0.2.1", True), ("2001:db8::1", False), ("not-an-ip", False)],
+)
+def test_validate_ipv4(value: str, expected: bool) -> None:
+    assert updater.validate_ipv4(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("2001:db8::1", True), ("192.0.2.1", False), ("not-an-ip", False)],
+)
+def test_validate_ipv6(value: str, expected: bool) -> None:
+    assert updater.validate_ipv6(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("label", "domain", "expected"),
+    [
+        ("api", "Example.COM.", "api.Example.COM."),
+        ("api.", "example.com", "api.example.com."),
+        ("api.example.com.", "example.com", "api.example.com."),
+    ],
+)
+def test_build_cname_fqdn(label: str, domain: str, expected: str) -> None:
+    assert updater.build_cname_fqdn(label, domain) == expected
+
+
+def test_build_cname_fqdn_rejects_empty_label() -> None:
+    with pytest.raises(ValueError, match="Empty CNAME entry"):
+        updater.build_cname_fqdn(" . ", "example.com")
+
+
+def test_get_external_ip4_uses_first_valid_service(monkeypatch) -> None:
+    responses = [
+        Mock(ok=True, text="not an address"),
+        Mock(ok=True, text=" 192.0.2.7\n"),
+    ]
+    request = Mock(side_effect=responses)
+    monkeypatch.setattr(updater.requests, "get", request)
+
+    assert (
+        updater.get_external_ip4.retry_with(stop=updater.stop_after_attempt(1))()
+        == "192.0.2.7"
+    )
+    assert request.call_count == 2
+
+
+def test_get_external_ip6_returns_none_when_services_have_no_ipv6(monkeypatch) -> None:
+    monkeypatch.setattr(
+        updater.requests,
+        "get",
+        Mock(return_value=Mock(ok=True, text="192.0.2.1")),
+    )
+
+    assert (
+        updater.get_external_ip6.retry_with(stop=updater.stop_after_attempt(1))()
+        is None
+    )
+
+
+def test_get_external_ip4_retries_request_failures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        updater.requests,
+        "get",
+        Mock(side_effect=requests.RequestException("offline")),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        updater.get_external_ip4.retry_with(stop=updater.stop_after_attempt(1))()
+    assert exc_info.value.__cause__ is not None
+    assert "Unable to fetch" in str(exc_info.value.__cause__)
+
+
+def test_main_runs_one_cycle_and_applies_proxy_overrides(monkeypatch) -> None:
+    provider = Mock(allows_apex_cname=False)
+    privilege = Mock()
+    monkeypatch.setattr(updater, "register_all", Mock())
+    monkeypatch.setattr(updater, "PrivilegeManager", Mock(return_value=privilege))
+    monkeypatch.setattr(updater, "build_provider", Mock(return_value=provider))
+    monkeypatch.setattr(updater, "get_external_ip4", Mock(return_value="192.0.2.7"))
+    monkeypatch.setattr(updater, "get_external_ip6", Mock(return_value="2001:db8::7"))
+    monkeypatch.setattr(updater.signal, "signal", Mock())
+    monkeypatch.setenv("RUN_AS_USER", "dns")
+    monkeypatch.setenv("DNS_PROVIDER", "cloudflare")
+    monkeypatch.setenv("DDNS_HOST", "node")
+    monkeypatch.setenv("DOMAIN", "Example.COM.")
+    monkeypatch.setenv("CNAME_LIST", "grafana:proxy,rpc:noproxy, plain")
+    monkeypatch.setenv("CF_PROXY", "true")
+    monkeypatch.setenv("TTL", "60")
+    monkeypatch.setenv("SLEEP", "1")
+
+    def stop(_):
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(updater.time, "sleep", stop)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        updater.main()
+
+    assert provider.upsert.call_args_list == [
+        (("node.example.com.", "A", "192.0.2.7", 60), {"proxied": True}),
+        (("node.example.com.", "AAAA", "2001:db8::7", 60), {"proxied": True}),
+        (("grafana.Example.COM.", "CNAME", "node.example.com.", 60), {"proxied": True}),
+        (("rpc.Example.COM.", "CNAME", "node.example.com.", 60), {"proxied": False}),
+        (("plain.Example.COM.", "CNAME", "node.example.com.", 60), {"proxied": True}),
+    ]
+
+
+def test_main_skips_aaaa_when_no_external_ipv6(monkeypatch) -> None:
+    provider = Mock(allows_apex_cname=True)
+    monkeypatch.setattr(updater, "register_all", Mock())
+    monkeypatch.setattr(updater, "PrivilegeManager", Mock(return_value=Mock()))
+    monkeypatch.setattr(updater, "build_provider", Mock(return_value=provider))
+    monkeypatch.setattr(updater, "get_external_ip4", Mock(return_value="192.0.2.7"))
+    monkeypatch.setattr(updater, "get_external_ip6", Mock(return_value=None))
+    monkeypatch.setattr(updater.signal, "signal", Mock())
+    monkeypatch.setenv("DDNS_HOST", "node")
+    monkeypatch.setenv("DOMAIN", "example.com")
+    monkeypatch.setenv("CNAME_LIST", "")
+    monkeypatch.setenv("SLEEP", "1")
+
+    monkeypatch.setattr(updater.time, "sleep", Mock(side_effect=RuntimeError("stop")))
+
+    with pytest.raises(RuntimeError, match="stop"):
+        updater.main()
+
+    assert [call.args[1] for call in provider.upsert.call_args_list] == ["A"]
+
+
+def test_main_continues_after_provider_error(monkeypatch) -> None:
+    provider = Mock(allows_apex_cname=True)
+    provider.upsert.side_effect = RuntimeError("provider unavailable")
+    sleeps = Mock(side_effect=[None, RuntimeError("stop")])
+    monkeypatch.setattr(updater, "register_all", Mock())
+    monkeypatch.setattr(updater, "PrivilegeManager", Mock(return_value=Mock()))
+    monkeypatch.setattr(updater, "build_provider", Mock(return_value=provider))
+    monkeypatch.setattr(updater, "get_external_ip4", Mock(return_value="192.0.2.7"))
+    monkeypatch.setattr(updater, "get_external_ip6", Mock(return_value=None))
+    monkeypatch.setattr(updater.signal, "signal", Mock())
+    monkeypatch.setattr(updater.time, "sleep", sleeps)
+    monkeypatch.setenv("DDNS_HOST", "node")
+    monkeypatch.setenv("DOMAIN", "example.com")
+    monkeypatch.setenv("CNAME_LIST", "")
+    monkeypatch.setenv("SLEEP", "1")
+
+    with pytest.raises(RuntimeError, match="stop"):
+        updater.main()
+
+    assert provider.upsert.call_count == 2
+    assert sleeps.call_count == 2
+
+
+def test_main_skips_apex_cname_for_provider_that_disallows_it(monkeypatch) -> None:
+    provider = Mock(allows_apex_cname=False)
+    monkeypatch.setattr(updater, "register_all", Mock())
+    monkeypatch.setattr(updater, "PrivilegeManager", Mock(return_value=Mock()))
+    monkeypatch.setattr(updater, "build_provider", Mock(return_value=provider))
+    monkeypatch.setattr(updater, "get_external_ip4", Mock(return_value="192.0.2.7"))
+    monkeypatch.setattr(updater, "get_external_ip6", Mock(return_value=None))
+    monkeypatch.setattr(updater.signal, "signal", Mock())
+    monkeypatch.setenv("DDNS_HOST", "node")
+    monkeypatch.setenv("DOMAIN", "example.com")
+    monkeypatch.setenv("CNAME_LIST", "example.com")
+    monkeypatch.setenv("SLEEP", "1")
+    monkeypatch.setattr(updater, "build_cname_fqdn", Mock(return_value="example.com."))
+    monkeypatch.setattr(updater.time, "sleep", Mock(side_effect=RuntimeError("stop")))
+
+    with pytest.raises(RuntimeError, match="stop"):
+        updater.main()
+
+    provider.upsert.assert_called_once_with(
+        "node.example.com.", "A", "192.0.2.7", 300, proxied=False
+    )
+
+
+def test_shutdown_exits_successfully() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        updater._shutdown(15, None)
+
+    assert exc_info.value.code == 0
+
+
+def test_setup_logger_configures_handler_and_level(monkeypatch) -> None:
+    logger = logging.getLogger("dns-updater")
+    logger.handlers.clear()
+    monkeypatch.setattr(updater, "logger", logger)
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+    result = updater.setup_logger()
+
+    assert result is logger
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    updater.setup_logger()
+    assert len(logger.handlers) == 1


### PR DESCRIPTION
**What I did**

Add tests for ddns app, run tests with CI when `test-ddns` label is present. This deliberately does not fire on `test-all`
